### PR TITLE
v1.2.1 — UX improvements, global hotkeys, new sources, bug fixes

### DIFF
--- a/src/Wallnetic/App/AppDelegate.swift
+++ b/src/Wallnetic/App/AppDelegate.swift
@@ -35,6 +35,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             object: nil
         )
 
+        // Setup global hotkeys
+        setupGlobalHotkeys()
+
         logger.info("Wallnetic started successfully")
     }
 
@@ -141,7 +144,82 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
+    // MARK: - Global Hotkeys
+
+    private var globalMonitor: Any?
+    private var localMonitor: Any?
+
+    private func setupGlobalHotkeys() {
+        guard UserDefaults.standard.bool(forKey: "globalHotkeysEnabled") else { return }
+
+        // Global monitor (when app is not focused)
+        globalMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            self?.handleHotkey(event)
+        }
+
+        // Local monitor (when app is focused)
+        localMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            if self?.handleHotkey(event) == true { return nil }
+            return event
+        }
+    }
+
+    @discardableResult
+    private func handleHotkey(_ event: NSEvent) -> Bool {
+        let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+
+        // ⌘⇧→ Next wallpaper
+        if flags == [.command, .shift] && event.keyCode == 124 {
+            WallpaperManager.shared.cycleToNextWallpaper()
+            return true
+        }
+
+        // ⌘⇧← Previous wallpaper
+        if flags == [.command, .shift] && event.keyCode == 123 {
+            cycleToPreviousWallpaper()
+            return true
+        }
+
+        // ⌘⇧P Toggle play/pause
+        if flags == [.command, .shift] && event.charactersIgnoringModifiers == "p" {
+            WallpaperManager.shared.togglePlayback()
+            return true
+        }
+
+        // ⌘⇧R Random wallpaper
+        if flags == [.command, .shift] && event.charactersIgnoringModifiers == "r" {
+            setRandomWallpaper()
+            return true
+        }
+
+        return false
+    }
+
+    private func cycleToPreviousWallpaper() {
+        let wallpapers = WallpaperManager.shared.wallpapers
+        guard !wallpapers.isEmpty else { return }
+        if let current = WallpaperManager.shared.currentWallpaper,
+           let idx = wallpapers.firstIndex(where: { $0.id == current.id }) {
+            let prevIdx = (idx - 1 + wallpapers.count) % wallpapers.count
+            WallpaperManager.shared.setWallpaper(wallpapers[prevIdx])
+        } else if let last = wallpapers.last {
+            WallpaperManager.shared.setWallpaper(last)
+        }
+    }
+
+    private func setRandomWallpaper() {
+        let candidates = WallpaperManager.shared.wallpapers.filter {
+            $0.id != WallpaperManager.shared.currentWallpaper?.id
+        }
+        guard let random = candidates.randomElement() else { return }
+        WallpaperManager.shared.setWallpaper(random)
+    }
+
     func applicationWillTerminate(_ notification: Notification) {
+        // Remove hotkey monitors
+        if let m = globalMonitor { NSEvent.removeMonitor(m) }
+        if let m = localMonitor { NSEvent.removeMonitor(m) }
+
         // Remove all notification observers
         NotificationCenter.default.removeObserver(self)
 

--- a/src/Wallnetic/Engine/DesktopWindowController.swift
+++ b/src/Wallnetic/Engine/DesktopWindowController.swift
@@ -147,49 +147,24 @@ class DesktopWindowController {
                 continue
             }
 
-            // Create snapshot of current frame
-            let snapshotLayer = CALayer()
-            snapshotLayer.frame = renderer.rendererView.bounds
-            snapshotLayer.autoresizingMask = [.layerWidthSizable, .layerHeightSizable]
-            snapshotLayer.zPosition = 50
-            snapshotLayer.backgroundColor = NSColor.black.cgColor
+            // Use CATransition on the renderer layer for reliable animation
+            let transition = CATransition()
+            transition.duration = duration
+            transition.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
 
-            if let layer = renderer.rendererView.layer {
-                snapshotLayer.contents = layer.contents
+            switch style {
+            case "zoom":
+                transition.type = .reveal
+                transition.subtype = .fromBottom
+            case "slide":
+                transition.type = .push
+                transition.subtype = .fromRight
+            default:
+                transition.type = .fade
             }
 
-            renderer.rendererView.layer?.addSublayer(snapshotLayer)
-
-            // Load new video underneath
+            renderer.rendererView.layer?.add(transition, forKey: "wallpaperTransition")
             renderer.loadVideo(url: url)
-
-            // Apply transition after short buffer delay
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                CATransaction.begin()
-                CATransaction.setAnimationDuration(duration)
-                CATransaction.setAnimationTimingFunction(CAMediaTimingFunction(name: .easeInEaseOut))
-
-                switch style {
-                case "zoom":
-                    // Genie/zoom — snapshot scales down to center and fades
-                    snapshotLayer.opacity = 0
-                    snapshotLayer.transform = CATransform3DMakeScale(0.3, 0.3, 1.0)
-
-                case "slide":
-                    // Slide left — snapshot slides out to the left
-                    snapshotLayer.opacity = 0
-                    snapshotLayer.transform = CATransform3DMakeTranslation(-snapshotLayer.bounds.width, 0, 0)
-
-                default:
-                    // Crossfade (default)
-                    snapshotLayer.opacity = 0
-                }
-
-                CATransaction.setCompletionBlock {
-                    snapshotLayer.removeFromSuperlayer()
-                }
-                CATransaction.commit()
-            }
         }
     }
 

--- a/src/Wallnetic/Engine/DesktopWindowController.swift
+++ b/src/Wallnetic/Engine/DesktopWindowController.swift
@@ -128,25 +128,32 @@ class DesktopWindowController {
 
     // MARK: - Playback Control
 
-    /// Sets the wallpaper video with smooth crossfade transition
+    /// Sets the wallpaper video with animated transition
     func setWallpaper(url: URL, for screen: NSScreen? = nil) {
         guard url != currentWallpaperURL else { return }
         currentWallpaperURL = url
 
+        let style = WallpaperManager.shared.transitionStyle
+        let duration = WallpaperManager.shared.transitionDuration
         let screens = screen.map { [$0] } ?? Array(desktopWindows.keys)
 
         for s in screens {
             guard let window = desktopWindows[s],
                   let renderer = renderers[s] else { continue }
 
-            // Create a snapshot of current frame as transition layer
+            // No transition — instant switch
+            if style == "none" {
+                renderer.loadVideo(url: url)
+                continue
+            }
+
+            // Create snapshot of current frame
             let snapshotLayer = CALayer()
             snapshotLayer.frame = renderer.rendererView.bounds
             snapshotLayer.autoresizingMask = [.layerWidthSizable, .layerHeightSizable]
             snapshotLayer.zPosition = 50
             snapshotLayer.backgroundColor = NSColor.black.cgColor
 
-            // Capture current frame if possible
             if let layer = renderer.rendererView.layer {
                 snapshotLayer.contents = layer.contents
             }
@@ -156,11 +163,28 @@ class DesktopWindowController {
             // Load new video underneath
             renderer.loadVideo(url: url)
 
-            // Fade out snapshot after short delay (let new video buffer)
+            // Apply transition after short buffer delay
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
                 CATransaction.begin()
-                CATransaction.setAnimationDuration(0.5)
-                snapshotLayer.opacity = 0
+                CATransaction.setAnimationDuration(duration)
+                CATransaction.setAnimationTimingFunction(CAMediaTimingFunction(name: .easeInEaseOut))
+
+                switch style {
+                case "zoom":
+                    // Genie/zoom — snapshot scales down to center and fades
+                    snapshotLayer.opacity = 0
+                    snapshotLayer.transform = CATransform3DMakeScale(0.3, 0.3, 1.0)
+
+                case "slide":
+                    // Slide left — snapshot slides out to the left
+                    snapshotLayer.opacity = 0
+                    snapshotLayer.transform = CATransform3DMakeTranslation(-snapshotLayer.bounds.width, 0, 0)
+
+                default:
+                    // Crossfade (default)
+                    snapshotLayer.opacity = 0
+                }
+
                 CATransaction.setCompletionBlock {
                     snapshotLayer.removeFromSuperlayer()
                 }

--- a/src/Wallnetic/Engine/DynamicIslandController.swift
+++ b/src/Wallnetic/Engine/DynamicIslandController.swift
@@ -1,6 +1,7 @@
 import Cocoa
 import SwiftUI
 import Combine
+import UniformTypeIdentifiers
 
 /// Dynamic Island — wraps around the notch on MacBooks, or floats at top-center on other Macs
 class DynamicIslandController: ObservableObject {
@@ -17,6 +18,8 @@ class DynamicIslandController: ObservableObject {
     @Published var isVisible = false
     @Published var isRenameActive = false
     @Published var hasNotch = false
+    @Published var isDragOver = false
+    @Published var isImporting = false
 
     private var islandWindow: NSPanel?
     private var cancellables = Set<AnyCancellable>()
@@ -221,6 +224,8 @@ struct DynamicIslandView: View {
     @State private var isRenaming = false
     @State private var renameText = ""
 
+    private let supportedTypes: [UTType] = [.movie, .video, .mpeg4Movie, .quickTimeMovie, .gif]
+
     private var bottomRadius: CGFloat {
         island.state == .compact ? 16 : 20
     }
@@ -239,6 +244,43 @@ struct DynamicIslandView: View {
                 .shadow(color: .black.opacity(0.6), radius: 8, y: 4)
         )
         .clipShape(IslandShape(bottomRadius: bottomRadius))
+        .overlay {
+            // Drop zone indicator
+            if island.isDragOver {
+                IslandShape(bottomRadius: bottomRadius)
+                    .stroke(.white.opacity(0.6), lineWidth: 2)
+                    .overlay {
+                        VStack(spacing: 4) {
+                            Image(systemName: "plus.circle.fill")
+                                .font(.system(size: 20))
+                                .foregroundColor(.white.opacity(0.9))
+                            if island.state == .expanded {
+                                Text("Drop to import")
+                                    .font(.system(size: 11, weight: .medium))
+                                    .foregroundColor(.white.opacity(0.7))
+                            }
+                        }
+                    }
+            }
+            // Importing indicator
+            if island.isImporting {
+                IslandShape(bottomRadius: bottomRadius)
+                    .fill(.black.opacity(0.5))
+                    .overlay {
+                        ProgressView()
+                            .progressViewStyle(.circular)
+                            .scaleEffect(0.8)
+                            .tint(.white)
+                    }
+            }
+        }
+        .onDrop(of: supportedTypes, isTargeted: $island.isDragOver) { providers in
+            handleDrop(providers: providers)
+            return true
+        }
+        .onChange(of: island.isDragOver) { dragging in
+            if dragging { island.expand() }
+        }
         .onHover { hovering in
             withAnimation(.easeOut(duration: 0.15)) { isHovering = hovering }
             if hovering { island.expand() }
@@ -436,6 +478,45 @@ struct DynamicIslandView: View {
         let candidates = wallpaperManager.wallpapers.filter { $0.id != wallpaperManager.currentWallpaper?.id }
         guard let random = candidates.randomElement() else { return }
         wallpaperManager.setWallpaper(random)
+    }
+
+    // MARK: - Drag & Drop Import
+
+    private func handleDrop(providers: [NSItemProvider]) {
+        island.isImporting = true
+
+        for provider in providers {
+            provider.loadItem(forTypeIdentifier: UTType.fileURL.identifier, options: nil) { item, error in
+                guard let data = item as? Data,
+                      let url = URL(dataRepresentation: data, relativeTo: nil) else {
+                    DispatchQueue.main.async { island.isImporting = false }
+                    return
+                }
+
+                let ext = url.pathExtension.lowercased()
+                let supported = WallpaperManager.supportedImportExtensions
+                guard supported.contains(ext) else {
+                    DispatchQueue.main.async { island.isImporting = false }
+                    return
+                }
+
+                Task {
+                    do {
+                        let wallpaper = try await wallpaperManager.importVideo(from: url)
+                        await MainActor.run {
+                            wallpaperManager.setWallpaper(wallpaper)
+                            island.isImporting = false
+                            island.expand()
+                        }
+                    } catch {
+                        await MainActor.run {
+                            island.isImporting = false
+                        }
+                        print("[DynamicIsland] Drop import failed: \(error)")
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/src/Wallnetic/Engine/DynamicIslandController.swift
+++ b/src/Wallnetic/Engine/DynamicIslandController.swift
@@ -486,35 +486,56 @@ struct DynamicIslandView: View {
         island.isImporting = true
 
         for provider in providers {
-            provider.loadItem(forTypeIdentifier: UTType.fileURL.identifier, options: nil) { item, error in
-                guard let data = item as? Data,
-                      let url = URL(dataRepresentation: data, relativeTo: nil) else {
-                    DispatchQueue.main.async { island.isImporting = false }
-                    return
+            // Try to load as file URL first
+            if provider.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier) {
+                _ = provider.loadObject(ofClass: URL.self) { url, error in
+                    guard let url = url else {
+                        DispatchQueue.main.async { island.isImporting = false }
+                        return
+                    }
+                    self.importDroppedFile(url: url)
                 }
-
-                let ext = url.pathExtension.lowercased()
-                let supported = WallpaperManager.supportedImportExtensions
-                guard supported.contains(ext) else {
-                    DispatchQueue.main.async { island.isImporting = false }
-                    return
-                }
-
-                Task {
-                    do {
-                        let wallpaper = try await wallpaperManager.importVideo(from: url)
-                        await MainActor.run {
-                            wallpaperManager.setWallpaper(wallpaper)
-                            island.isImporting = false
-                            island.expand()
+            } else {
+                // Fallback: load as file representation
+                for type in supportedTypes {
+                    if provider.hasItemConformingToTypeIdentifier(type.identifier) {
+                        provider.loadFileRepresentation(forTypeIdentifier: type.identifier) { tempURL, error in
+                            guard let tempURL = tempURL else {
+                                DispatchQueue.main.async { island.isImporting = false }
+                                return
+                            }
+                            // Copy to temp location (file will be deleted after this block)
+                            let copyURL = FileManager.default.temporaryDirectory.appendingPathComponent(tempURL.lastPathComponent)
+                            try? FileManager.default.removeItem(at: copyURL)
+                            try? FileManager.default.copyItem(at: tempURL, to: copyURL)
+                            self.importDroppedFile(url: copyURL)
                         }
-                    } catch {
-                        await MainActor.run {
-                            island.isImporting = false
-                        }
-                        print("[DynamicIsland] Drop import failed: \(error)")
+                        break
                     }
                 }
+            }
+        }
+    }
+
+    private func importDroppedFile(url: URL) {
+        let ext = url.pathExtension.lowercased()
+        let supported = WallpaperManager.supportedImportExtensions
+        guard supported.contains(ext) else {
+            DispatchQueue.main.async { island.isImporting = false }
+            return
+        }
+
+        Task {
+            do {
+                let wallpaper = try await wallpaperManager.importVideo(from: url)
+                await MainActor.run {
+                    wallpaperManager.setWallpaper(wallpaper)
+                    island.isImporting = false
+                    island.expand()
+                }
+            } catch {
+                await MainActor.run { island.isImporting = false }
+                print("[DynamicIsland] Drop import failed: \(error)")
             }
         }
     }

--- a/src/Wallnetic/Models/Wallpaper.swift
+++ b/src/Wallnetic/Models/Wallpaper.swift
@@ -1,6 +1,8 @@
 import Foundation
 import AVFoundation
 import AppKit
+import CoreImage
+import SwiftUI
 
 /// Represents a wallpaper in the library
 struct Wallpaper: Identifiable, Equatable, Hashable, Codable {
@@ -13,6 +15,8 @@ struct Wallpaper: Identifiable, Equatable, Hashable, Codable {
     let resolution: CGSize?
     let dateAdded: Date
     var isFavorite: Bool
+    var dominantColorHex: String?
+    var tags: [String]
 
     /// Display name: customTitle if set, otherwise filename
     var displayName: String {
@@ -24,6 +28,7 @@ struct Wallpaper: Identifiable, Equatable, Hashable, Codable {
         self.url = url
         self.name = url.deletingPathExtension().lastPathComponent
         self.customTitle = nil
+        self.tags = []
         self.dateAdded = Date()
         self.isFavorite = isFavorite
 
@@ -62,11 +67,41 @@ struct Wallpaper: Identifiable, Equatable, Hashable, Codable {
         return "\(Int(resolution.width))×\(Int(resolution.height))"
     }
 
+    /// Dominant color as NSColor (from hex)
+    var dominantColor: NSColor? {
+        guard let hex = dominantColorHex else { return nil }
+        return NSColor(hex: hex)
+    }
+
+    /// Color category for filtering
+    var colorCategory: ColorCategory? {
+        guard let color = dominantColor else { return nil }
+        return ColorCategory.from(color: color)
+    }
+
     // MARK: - Thumbnail Generation
 
     /// Generates or retrieves cached thumbnail
     func generateThumbnail(size: CGSize = CGSize(width: 320, height: 180)) async -> NSImage? {
         return await ThumbnailCache.shared.thumbnail(for: url, size: size)
+    }
+
+    /// Extract dominant color from thumbnail
+    func extractDominantColor() async -> String? {
+        guard let thumbnail = await generateThumbnail(size: CGSize(width: 64, height: 36)) else { return nil }
+        guard let tiffData = thumbnail.tiffRepresentation,
+              let ciImage = CIImage(data: tiffData) else { return nil }
+
+        let extent = ciImage.extent
+        guard let filter = CIFilter(name: "CIAreaAverage", parameters: [
+            kCIInputImageKey: ciImage,
+            kCIInputExtentKey: CIVector(cgRect: extent)
+        ]), let output = filter.outputImage else { return nil }
+
+        var pixel = [UInt8](repeating: 0, count: 4)
+        CIContext().render(output, toBitmap: &pixel, rowBytes: 4, bounds: CGRect(x: 0, y: 0, width: 1, height: 1), format: .RGBA8, colorSpace: CGColorSpaceCreateDeviceRGB())
+
+        return String(format: "#%02X%02X%02X", pixel[0], pixel[1], pixel[2])
     }
 
     // MARK: - Equatable & Hashable
@@ -81,3 +116,58 @@ struct Wallpaper: Identifiable, Equatable, Hashable, Codable {
         hasher.combine(isFavorite)
     }
 }
+
+// MARK: - Color Category
+
+enum ColorCategory: String, CaseIterable, Identifiable {
+    case red, orange, yellow, green, blue, purple, pink, brown, gray, black, white
+
+    var id: String { rawValue }
+
+    var color: Color {
+        switch self {
+        case .red: return .red
+        case .orange: return .orange
+        case .yellow: return .yellow
+        case .green: return .green
+        case .blue: return .blue
+        case .purple: return .purple
+        case .pink: return .pink
+        case .brown: return .brown
+        case .gray: return .gray
+        case .black: return Color(white: 0.15)
+        case .white: return Color(white: 0.9)
+        }
+    }
+
+    static func from(color: NSColor) -> ColorCategory {
+        let rgb = color.usingColorSpace(.sRGB) ?? color
+        let r = rgb.redComponent
+        let g = rgb.greenComponent
+        let b = rgb.blueComponent
+        let brightness = (r + g + b) / 3.0
+        let saturation = max(r, g, b) - min(r, g, b)
+
+        if brightness < 0.15 { return .black }
+        if brightness > 0.85 && saturation < 0.15 { return .white }
+        if saturation < 0.12 { return .gray }
+
+        // Determine hue
+        var hue: CGFloat = 0
+        var sat: CGFloat = 0
+        var bri: CGFloat = 0
+        rgb.getHue(&hue, saturation: &sat, brightness: &bri, alpha: nil)
+        let h = hue * 360
+
+        if h < 15 || h >= 345 { return .red }
+        if h < 45 { return .orange }
+        if h < 70 { return .yellow }
+        if h < 160 { return .green }
+        if h < 250 { return .blue }
+        if h < 290 { return .purple }
+        if h < 345 { return .pink }
+        return .red
+    }
+}
+
+// NSColor.init(hex:) is defined in WallpaperEffectsManager.swift

--- a/src/Wallnetic/Services/ThemeManager.swift
+++ b/src/Wallnetic/Services/ThemeManager.swift
@@ -26,8 +26,13 @@ class ThemeManager: ObservableObject {
         }
     }
 
+    /// Dynamic accent color derived from current wallpaper
+    @Published var accentColor: Color = .accentColor
+    @AppStorage("dynamicThemeEnabled") var dynamicThemeEnabled: Bool = false
+
     private let defaults = UserDefaults.standard
     private let appearanceKey = "appearanceMode"
+    private var wallpaperObserver: Any?
 
     private init() {
         // Load saved appearance
@@ -39,6 +44,46 @@ class ThemeManager: ObservableObject {
         }
 
         applyAppearance()
+        observeWallpaperChanges()
+    }
+
+    // MARK: - Dynamic Theme
+
+    private func observeWallpaperChanges() {
+        wallpaperObserver = NotificationCenter.default.addObserver(
+            forName: .wallpaperDidChange,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            guard let self, self.dynamicThemeEnabled else { return }
+            if let wallpaper = notification.object as? Wallpaper,
+               let hex = wallpaper.dominantColorHex,
+               let nsColor = NSColor(hex: hex) {
+                self.accentColor = Color(nsColor: nsColor)
+            }
+        }
+    }
+
+    /// Update accent color from current wallpaper
+    func updateAccentFromWallpaper(_ wallpaper: Wallpaper?) {
+        guard dynamicThemeEnabled, let wp = wallpaper else {
+            accentColor = .accentColor
+            return
+        }
+        if let hex = wp.dominantColorHex, let nsColor = NSColor(hex: hex) {
+            accentColor = Color(nsColor: nsColor)
+        }
+
+        // Extract if not available yet
+        if wp.dominantColorHex == nil {
+            Task {
+                if let hex = await wp.extractDominantColor() {
+                    await MainActor.run {
+                        self.accentColor = Color(nsColor: NSColor(hex: hex) ?? .controlAccentColor)
+                    }
+                }
+            }
+        }
     }
 
     // MARK: - Persistence

--- a/src/Wallnetic/Services/ThumbnailCache.swift
+++ b/src/Wallnetic/Services/ThumbnailCache.swift
@@ -1,17 +1,17 @@
 import AppKit
 import AVFoundation
 
-/// Memory-efficient thumbnail cache with automatic cleanup
+/// Memory-efficient dual-size thumbnail cache with automatic cleanup
 final class ThumbnailCache {
     static let shared = ThumbnailCache()
 
-    private let cache = NSCache<NSURL, NSImage>()
+    private let cache = NSCache<NSString, NSImage>()
     private let queue = DispatchQueue(label: "com.wallnetic.thumbnailcache", qos: .utility)
 
     private init() {
-        // Configure cache limits
-        cache.countLimit = 50  // Max 50 thumbnails
-        cache.totalCostLimit = 50 * 1024 * 1024  // ~50MB max
+        // Configure cache limits — dual size means more entries
+        cache.countLimit = 120  // ~60 wallpapers × 2 sizes
+        cache.totalCostLimit = 80 * 1024 * 1024  // ~80MB max
 
         // Clear cache on memory pressure
         NotificationCenter.default.addObserver(
@@ -28,12 +28,17 @@ final class ThumbnailCache {
 
     // MARK: - Public API
 
+    /// Cache key includes URL + size for dual-size support
+    private func cacheKey(for url: URL, size: CGSize) -> NSString {
+        "\(url.path)_\(Int(size.width))x\(Int(size.height))" as NSString
+    }
+
     /// Gets a cached thumbnail or generates a new one
     func thumbnail(for url: URL, size: CGSize = CGSize(width: 320, height: 180)) async -> NSImage? {
-        let cacheKey = url as NSURL
+        let key = cacheKey(for: url, size: size)
 
         // Check cache first
-        if let cached = cache.object(forKey: cacheKey) {
+        if let cached = cache.object(forKey: key) {
             return cached
         }
 
@@ -44,14 +49,20 @@ final class ThumbnailCache {
 
         // Cache the result with estimated cost
         let cost = Int(thumbnail.size.width * thumbnail.size.height * 4)  // RGBA
-        cache.setObject(thumbnail, forKey: cacheKey, cost: cost)
+        cache.setObject(thumbnail, forKey: key, cost: cost)
 
         return thumbnail
     }
 
-    /// Removes a specific thumbnail from cache
+    /// Removes all cached thumbnails for a URL (all sizes)
     func removeThumbnail(for url: URL) {
-        cache.removeObject(forKey: url as NSURL)
+        // Remove common sizes
+        for size in [CGSize(width: 320, height: 180), CGSize(width: 160, height: 90),
+                     CGSize(width: 64, height: 36), CGSize(width: 44, height: 44),
+                     CGSize(width: 48, height: 48), CGSize(width: 112, height: 112),
+                     CGSize(width: 128, height: 72), CGSize(width: 200, height: 112)] {
+            cache.removeObject(forKey: cacheKey(for: url, size: size))
+        }
     }
 
     /// Clears all cached thumbnails

--- a/src/Wallnetic/Services/WallpaperManager.swift
+++ b/src/Wallnetic/Services/WallpaperManager.swift
@@ -80,10 +80,13 @@ class WallpaperManager: ObservableObject {
 
     // MARK: - Initialization
 
+    private var fileWatcher: DispatchSourceFileSystemObject?
+
     private init() {
         loadWallpapers()
         loadSettings()
         syncToWidget()
+        startFileWatching()
     }
 
     /// Load persisted settings
@@ -221,6 +224,7 @@ class WallpaperManager: ObservableObject {
                 wallpapers.append(wallpaper)
                 print("[WallpaperManager] Wallpaper added to library. Total count: \(wallpapers.count)")
             }
+            postImportProcess(wallpaper)
             return wallpaper
         } else {
             try fileManager.copyItem(at: importURL, to: destURL)
@@ -231,7 +235,29 @@ class WallpaperManager: ObservableObject {
                 wallpapers.append(wallpaper)
                 print("[WallpaperManager] Wallpaper added to library. Total count: \(wallpapers.count)")
             }
+            postImportProcess(wallpaper)
             return wallpaper
+        }
+    }
+
+    /// Pre-generate thumbnails and extract color after import
+    private func postImportProcess(_ wallpaper: Wallpaper) {
+        Task {
+            // Pre-generate both common thumbnail sizes
+            _ = await wallpaper.generateThumbnail(size: CGSize(width: 320, height: 180))
+            _ = await wallpaper.generateThumbnail(size: CGSize(width: 160, height: 90))
+
+            // Extract dominant color
+            if let hex = await wallpaper.extractDominantColor() {
+                await MainActor.run {
+                    if let idx = wallpapers.firstIndex(where: { $0.id == wallpaper.id }) {
+                        wallpapers[idx].dominantColorHex = hex
+                        var colors = savedColors
+                        colors[wallpaper.url.path] = hex
+                        savedColors = colors
+                    }
+                }
+            }
         }
     }
 
@@ -479,6 +505,31 @@ class WallpaperManager: ObservableObject {
 
         // All chars matched in order → score based on match ratio
         return qi == query.endIndex ? max(10, matched * 30 / query.count) : 0
+    }
+
+    // MARK: - File Watching
+
+    private func startFileWatching() {
+        let fd = open(libraryURL.path, O_EVTONLY)
+        guard fd >= 0 else { return }
+
+        let source = DispatchSource.makeFileSystemObjectSource(
+            fileDescriptor: fd,
+            eventMask: [.write, .rename, .delete],
+            queue: .main
+        )
+
+        source.setEventHandler { [weak self] in
+            NSLog("[WallpaperManager] Library folder changed — reloading")
+            self?.loadWallpapers()
+        }
+
+        source.setCancelHandler {
+            close(fd)
+        }
+
+        source.resume()
+        fileWatcher = source
     }
 
     // MARK: - Playback

--- a/src/Wallnetic/Services/WallpaperManager.swift
+++ b/src/Wallnetic/Services/WallpaperManager.swift
@@ -59,6 +59,8 @@ class WallpaperManager: ObservableObject {
     @AppStorage("lastWallpaperURL") private var lastWallpaperURL: String = ""
     @AppStorage("favoriteWallpaperPaths") private var favoriteWallpaperPaths: String = ""
     @AppStorage("customWallpaperTitles") private var customWallpaperTitlesData: String = ""
+    @AppStorage("wallpaperColors") private var wallpaperColorsData: String = ""
+    @AppStorage("wallpaperTags") private var wallpaperTagsData: String = ""
 
     // MARK: - Properties
 
@@ -166,10 +168,15 @@ class WallpaperManager: ObservableObject {
             }
         }
 
-        // Apply saved custom titles
+        // Apply saved custom titles, colors, and tags
         applyCustomTitles()
+        applySavedColors()
+        applySavedTags()
 
         print("Loaded \(wallpapers.count) wallpapers from library (\(savedFavorites.count) favorites)")
+
+        // Extract colors in background for new wallpapers
+        extractMissingColors()
     }
 
     /// Checks if a file is a duplicate of an existing library item (by file size + name)
@@ -327,6 +334,151 @@ class WallpaperManager: ObservableObject {
                 wallpapers[i].customTitle = title
             }
         }
+    }
+
+    // MARK: - Dominant Color Persistence
+
+    private var savedColors: [String: String] {
+        get {
+            guard !wallpaperColorsData.isEmpty,
+                  let data = wallpaperColorsData.data(using: .utf8),
+                  let dict = try? JSONDecoder().decode([String: String].self, from: data)
+            else { return [:] }
+            return dict
+        }
+        set {
+            if let data = try? JSONEncoder().encode(newValue),
+               let str = String(data: data, encoding: .utf8) {
+                wallpaperColorsData = str
+            }
+        }
+    }
+
+    private func applySavedColors() {
+        let colors = savedColors
+        guard !colors.isEmpty else { return }
+        for i in wallpapers.indices {
+            if let hex = colors[wallpapers[i].url.path] {
+                wallpapers[i].dominantColorHex = hex
+            }
+        }
+    }
+
+    /// Extract colors for wallpapers that don't have one yet
+    func extractMissingColors() {
+        Task {
+            var updatedColors = savedColors
+            for i in wallpapers.indices where wallpapers[i].dominantColorHex == nil {
+                if let hex = await wallpapers[i].extractDominantColor() {
+                    await MainActor.run {
+                        wallpapers[i].dominantColorHex = hex
+                    }
+                    updatedColors[wallpapers[i].url.path] = hex
+                }
+            }
+            await MainActor.run {
+                savedColors = updatedColors
+            }
+        }
+    }
+
+    // MARK: - Tags
+
+    private var savedTags: [String: [String]] {
+        get {
+            guard !wallpaperTagsData.isEmpty,
+                  let data = wallpaperTagsData.data(using: .utf8),
+                  let dict = try? JSONDecoder().decode([String: [String]].self, from: data)
+            else { return [:] }
+            return dict
+        }
+        set {
+            if let data = try? JSONEncoder().encode(newValue),
+               let str = String(data: data, encoding: .utf8) {
+                wallpaperTagsData = str
+            }
+        }
+    }
+
+    private func applySavedTags() {
+        let tags = savedTags
+        guard !tags.isEmpty else { return }
+        for i in wallpapers.indices {
+            if let t = tags[wallpapers[i].url.path] {
+                wallpapers[i].tags = t
+            }
+        }
+    }
+
+    /// Add a tag to a wallpaper
+    func addTag(_ tag: String, to wallpaper: Wallpaper) {
+        guard let index = wallpapers.firstIndex(where: { $0.id == wallpaper.id }) else { return }
+        let trimmed = tag.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !trimmed.isEmpty, !wallpapers[index].tags.contains(trimmed) else { return }
+        wallpapers[index].tags.append(trimmed)
+        var all = savedTags
+        all[wallpapers[index].url.path] = wallpapers[index].tags
+        savedTags = all
+    }
+
+    /// Remove a tag from a wallpaper
+    func removeTag(_ tag: String, from wallpaper: Wallpaper) {
+        guard let index = wallpapers.firstIndex(where: { $0.id == wallpaper.id }) else { return }
+        wallpapers[index].tags.removeAll { $0 == tag }
+        var all = savedTags
+        all[wallpapers[index].url.path] = wallpapers[index].tags
+        savedTags = all
+    }
+
+    /// All unique tags across library
+    var allTags: [String] {
+        Array(Set(wallpapers.flatMap { $0.tags })).sorted()
+    }
+
+    // MARK: - Fuzzy Search
+
+    /// Search wallpapers by name, tags, and fuzzy matching
+    func searchWallpapers(query: String) -> [Wallpaper] {
+        let q = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !q.isEmpty else { return wallpapers }
+
+        return wallpapers
+            .map { wp -> (Wallpaper, Int) in
+                var score = 0
+                let name = wp.displayName.lowercased()
+
+                // Exact match
+                if name == q { score += 100 }
+                // Contains
+                else if name.contains(q) { score += 70 }
+                // Tag match
+                if wp.tags.contains(q) { score += 80 }
+                if wp.tags.contains(where: { $0.contains(q) }) { score += 50 }
+                // Fuzzy: characters appear in order
+                if score == 0 { score = fuzzyScore(query: q, in: name) }
+
+                return (wp, score)
+            }
+            .filter { $0.1 > 0 }
+            .sorted { $0.1 > $1.1 }
+            .map { $0.0 }
+    }
+
+    private func fuzzyScore(query: String, in text: String) -> Int {
+        var qi = query.startIndex
+        var ti = text.startIndex
+        var matched = 0
+
+        while qi < query.endIndex && ti < text.endIndex {
+            if query[qi] == text[ti] {
+                matched += 1
+                qi = query.index(after: qi)
+            }
+            ti = text.index(after: ti)
+        }
+
+        // All chars matched in order → score based on match ratio
+        return qi == query.endIndex ? max(10, matched * 30 / query.count) : 0
     }
 
     // MARK: - Playback

--- a/src/Wallnetic/Services/WallpaperManager.swift
+++ b/src/Wallnetic/Services/WallpaperManager.swift
@@ -54,6 +54,8 @@ class WallpaperManager: ObservableObject {
     @AppStorage("wallpaperModeRaw") private var wallpaperModeRaw: String = "same"
     @AppStorage("screenWallpapersData") private var screenWallpapersData: Data = Data()
     @AppStorage("useMetalRenderer") var useMetalRenderer: Bool = false
+    @AppStorage("transitionStyle") var transitionStyle: String = "crossfade"
+    @AppStorage("transitionDuration") var transitionDuration: Double = 0.5
     @AppStorage("lastWallpaperURL") private var lastWallpaperURL: String = ""
     @AppStorage("favoriteWallpaperPaths") private var favoriteWallpaperPaths: String = ""
     @AppStorage("customWallpaperTitles") private var customWallpaperTitlesData: String = ""

--- a/src/Wallnetic/Views/Components/StrikingEffects.swift
+++ b/src/Wallnetic/Views/Components/StrikingEffects.swift
@@ -3,6 +3,7 @@ import SwiftUI
 // MARK: - Animation Timing
 
 enum Anim {
+    // Durations
     static let micro: Double = 0.1
     static let fast: Double = 0.15
     static let normal: Double = 0.2
@@ -11,6 +12,17 @@ enum Anim {
     static let expand: Double = 0.35
     static let slow: Double = 0.4
     static let hero: Double = 0.8
+
+    // Spring presets
+    static let snappy = Animation.spring(response: 0.3, dampingFraction: 0.7)
+    static let gentle = Animation.spring(response: 0.5, dampingFraction: 0.8)
+    static let bouncy = Animation.spring(response: 0.4, dampingFraction: 0.6)
+    static let stiff = Animation.spring(response: 0.2, dampingFraction: 0.9)
+
+    // Interactive
+    static let hover = Animation.easeOut(duration: normal)
+    static let press = Animation.easeIn(duration: micro)
+    static let transition = Animation.easeInOut(duration: medium)
 }
 
 // MARK: - Glow Card Modifier
@@ -171,6 +183,52 @@ struct AnimatedGradientBackground: View {
     }
 }
 
+// MARK: - Card Flip
+
+struct CardFlip<Back: View>: ViewModifier {
+    @Binding var isFlipped: Bool
+    let back: Back
+
+    init(isFlipped: Binding<Bool>, @ViewBuilder back: () -> Back) {
+        self._isFlipped = isFlipped
+        self.back = back()
+    }
+
+    func body(content: Content) -> some View {
+        ZStack {
+            content
+                .opacity(isFlipped ? 0 : 1)
+                .rotation3DEffect(.degrees(isFlipped ? 180 : 0), axis: (x: 0, y: 1, z: 0))
+
+            back
+                .opacity(isFlipped ? 1 : 0)
+                .rotation3DEffect(.degrees(isFlipped ? 0 : -180), axis: (x: 0, y: 1, z: 0))
+        }
+        .animation(Anim.gentle, value: isFlipped)
+    }
+}
+
+extension View {
+    func cardFlip<Back: View>(isFlipped: Binding<Bool>, @ViewBuilder back: () -> Back) -> some View {
+        modifier(CardFlip(isFlipped: isFlipped, back: back))
+    }
+}
+
+// MARK: - Press Effect (scale down on click)
+
+struct PressEffect: ViewModifier {
+    @State private var isPressed = false
+
+    func body(content: Content) -> some View {
+        content
+            .scaleEffect(isPressed ? 0.96 : 1.0)
+            .animation(Anim.press, value: isPressed)
+            .onLongPressGesture(minimumDuration: .infinity, pressing: { pressing in
+                isPressed = pressing
+            }, perform: {})
+    }
+}
+
 // MARK: - View Extensions
 
 extension View {
@@ -196,5 +254,17 @@ extension View {
 
     func parallaxHover(isHovering: Bool) -> some View {
         modifier(ParallaxHover(isHovering: isHovering))
+    }
+
+    func pressEffect() -> some View {
+        modifier(PressEffect())
+    }
+}
+
+// MARK: - Safe Array Subscript
+
+extension Array {
+    subscript(safe index: Int) -> Element? {
+        indices.contains(index) ? self[index] : nil
     }
 }

--- a/src/Wallnetic/Views/Main/ContentView.swift
+++ b/src/Wallnetic/Views/Main/ContentView.swift
@@ -3,6 +3,7 @@ import UniformTypeIdentifiers
 
 struct ContentView: View {
     @EnvironmentObject var wallpaperManager: WallpaperManager
+    @ObservedObject private var downloadManager = DownloadManager.shared
     @State private var selectedTab: NavigationTab = .home
     @State private var isImporting = false
     @State private var searchText = ""
@@ -23,6 +24,12 @@ struct ContentView: View {
                     isScrolled: scrollOffset > 50
                 )
                 .zIndex(10)
+
+                // Download progress bar
+                if !downloadManager.downloads.isEmpty {
+                    DownloadProgressBar(downloads: downloadManager.downloads)
+                        .transition(.move(edge: .top).combined(with: .opacity))
+                }
 
                 switch selectedTab {
                 case .discover:
@@ -91,6 +98,8 @@ struct ContentView: View {
             print("File picker error: \(error)")
         }
     }
+
+    // MARK: - Drop
 
     private func handleDrop(_ providers: [NSItemProvider]) {
         for provider in providers {
@@ -194,6 +203,65 @@ struct EmptyLibraryView: View {
             Spacer()
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+// MARK: - Download Progress Bar
+
+struct DownloadProgressBar: View {
+    let downloads: [DownloadManager.Download]
+
+    private var activeDownloads: [DownloadManager.Download] {
+        downloads.filter { $0.status == .downloading || $0.status == .waiting }
+    }
+
+    private var totalProgress: Double {
+        let active = activeDownloads
+        guard !active.isEmpty else { return 1.0 }
+        return active.reduce(0) { $0 + $1.progress } / Double(active.count)
+    }
+
+    var body: some View {
+        if !activeDownloads.isEmpty {
+            HStack(spacing: 10) {
+                ProgressView()
+                    .scaleEffect(0.6)
+                    .frame(width: 16, height: 16)
+
+                if let current = activeDownloads.first {
+                    Text(current.name)
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundColor(.white.opacity(0.8))
+                        .lineLimit(1)
+                }
+
+                Spacer()
+
+                // Progress percentage
+                Text("\(Int(totalProgress * 100))%")
+                    .font(.system(size: 11, weight: .bold, design: .monospaced))
+                    .foregroundColor(.accentColor)
+
+                if activeDownloads.count > 1 {
+                    Text("\(activeDownloads.count) files")
+                        .font(.system(size: 10))
+                        .foregroundColor(.white.opacity(0.4))
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 6)
+            .background(
+                GeometryReader { geo in
+                    ZStack(alignment: .leading) {
+                        Rectangle().fill(Color.white.opacity(0.03))
+                        Rectangle()
+                            .fill(Color.accentColor.opacity(0.15))
+                            .frame(width: geo.size.width * totalProgress)
+                            .animation(.easeInOut(duration: 0.3), value: totalProgress)
+                    }
+                }
+            )
+        }
     }
 }
 

--- a/src/Wallnetic/Views/Main/DiscoverView.swift
+++ b/src/Wallnetic/Views/Main/DiscoverView.swift
@@ -37,6 +37,12 @@ struct WallpaperSource: Identifiable {
         WallpaperSource(id: "motionbgs", name: "MotionBGs", description: "4K animated backgrounds",
                         icon: "film.stack", color: .orange, url: "https://motionbgs.com",
                         type: .browser, estimatedCount: "8,790+"),
+        WallpaperSource(id: "wallhaven", name: "Wallhaven", description: "Community-curated wallpapers, 4K+",
+                        icon: "globe.americas.fill", color: .cyan, url: "https://wallhaven.cc/search?categories=010&purity=100&sorting=toplist&order=desc&topRange=1M",
+                        type: .browser, estimatedCount: "1M+"),
+        WallpaperSource(id: "steamworkshop", name: "Steam Workshop", description: "Wallpaper Engine community content",
+                        icon: "gamecontroller.fill", color: .indigo, url: "https://steamcommunity.com/workshop/browse/?appid=431960&browsesort=trend&section=readytouseitems",
+                        type: .browser, estimatedCount: "2M+"),
     ]
 }
 

--- a/src/Wallnetic/Views/Main/ExploreView.swift
+++ b/src/Wallnetic/Views/Main/ExploreView.swift
@@ -7,6 +7,11 @@ struct ExploreView: View {
 
     @State private var selectedCategory: String = "All"
     @State private var hoveredCategory: String?
+    @State private var viewMode: ViewMode = .grid
+
+    enum ViewMode: String {
+        case grid, list
+    }
 
     private let categories = ["All", "Favorites", "Recent", "Long", "Short", "HD", "4K"]
 
@@ -65,7 +70,7 @@ struct ExploreView: View {
                 )
                 .frame(height: 0.5)
 
-            // Results count
+            // Results count + view mode toggle
             HStack {
                 Text("\(filteredWallpapers.count)")
                     .font(.system(size: 12, weight: .bold, design: .monospaced))
@@ -74,24 +79,71 @@ struct ExploreView: View {
                 Text(" wallpapers")
                     .font(.system(size: 12))
                     .foregroundColor(.white.opacity(0.4))
+
                 Spacer()
+
+                // View mode toggle
+                HStack(spacing: 4) {
+                    viewModeButton(icon: "square.grid.2x2", mode: .grid)
+                    viewModeButton(icon: "list.bullet", mode: .list)
+                }
             }
             .padding(.horizontal, 20)
             .padding(.vertical, 8)
 
-            // Grid with staggered entrance
+            // Content — grid or list
             ScrollView {
-                LazyVGrid(columns: columns, spacing: 14) {
-                    ForEach(Array(filteredWallpapers.enumerated()), id: \.element.id) { index, wallpaper in
-                        ExploreCard(wallpaper: wallpaper, index: index)
+                if viewMode == .grid {
+                    LazyVGrid(columns: columns, spacing: 14) {
+                        ForEach(Array(filteredWallpapers.enumerated()), id: \.element.id) { index, wallpaper in
+                            ExploreCard(wallpaper: wallpaper, index: index)
+                        }
                     }
+                    .padding(.horizontal, 20)
+                    .padding(.top, 4)
+                    .padding(.bottom, 20)
+                } else {
+                    LazyVStack(spacing: 8) {
+                        ForEach(Array(filteredWallpapers.enumerated()), id: \.element.id) { index, wallpaper in
+                            ExploreListRow(wallpaper: wallpaper)
+                                .staggered(index: index)
+                        }
+                    }
+                    .padding(.horizontal, 20)
+                    .padding(.top, 4)
+                    .padding(.bottom, 20)
                 }
-                .padding(.horizontal, 20)
-                .padding(.top, 4)
-                .padding(.bottom, 20)
             }
         }
         .background(Color.clear)
+        .modifier(KeyPressModifier(
+            onLeft: {
+                let wallpapers = filteredWallpapers
+                guard !wallpapers.isEmpty else { return }
+                wallpaperManager.cycleToNextWallpaper()
+            },
+            onRight: {
+                wallpaperManager.cycleToNextWallpaper()
+            }
+        ))
+    }
+
+    // MARK: - View Mode Button
+
+    private func viewModeButton(icon: String, mode: ViewMode) -> some View {
+        Button {
+            withAnimation(Anim.snappy) { viewMode = mode }
+        } label: {
+            Image(systemName: icon)
+                .font(.system(size: 11))
+                .foregroundColor(viewMode == mode ? .white : .white.opacity(0.3))
+                .frame(width: 24, height: 24)
+                .background(
+                    RoundedRectangle(cornerRadius: 5)
+                        .fill(viewMode == mode ? Color.white.opacity(0.1) : .clear)
+                )
+        }
+        .buttonStyle(.plain)
     }
 
     // MARK: - Filter Chip
@@ -253,5 +305,89 @@ struct ExploreCard: View {
             }, onCancel: { renamingWallpaper = nil })
         }
         .task { thumbnail = await wallpaper.generateThumbnail() }
+    }
+}
+
+// MARK: - Explore List Row
+
+struct ExploreListRow: View {
+    let wallpaper: Wallpaper
+    @EnvironmentObject var wallpaperManager: WallpaperManager
+    @State private var thumbnail: NSImage?
+    @State private var isHovering = false
+
+    var body: some View {
+        HStack(spacing: 12) {
+            // Thumbnail
+            if let thumb = thumbnail {
+                Image(nsImage: thumb)
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .frame(width: 80, height: 45)
+                    .clipShape(RoundedRectangle(cornerRadius: 6))
+            } else {
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(Color.white.opacity(0.05))
+                    .frame(width: 80, height: 45)
+                    .overlay { ProgressView().scaleEffect(0.5) }
+            }
+
+            // Info
+            VStack(alignment: .leading, spacing: 2) {
+                Text(wallpaper.displayName)
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundColor(.white.opacity(0.9))
+                    .lineLimit(1)
+
+                HStack(spacing: 8) {
+                    Text(wallpaper.formattedResolution)
+                    Text(wallpaper.formattedDuration)
+                    Text(wallpaper.formattedFileSize)
+                }
+                .font(.system(size: 11, design: .monospaced))
+                .foregroundColor(.white.opacity(0.4))
+            }
+
+            Spacer()
+
+            // Favorite
+            if wallpaper.isFavorite {
+                Image(systemName: "heart.fill")
+                    .font(.system(size: 11))
+                    .foregroundColor(.pink)
+            }
+
+            // Apply button on hover
+            if isHovering {
+                Button {
+                    wallpaperManager.setWallpaper(wallpaper)
+                } label: {
+                    Image(systemName: "play.fill")
+                        .font(.system(size: 11))
+                        .foregroundColor(.white.opacity(0.8))
+                        .frame(width: 28, height: 28)
+                        .background(Circle().fill(.white.opacity(0.1)))
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(isHovering ? Color.white.opacity(0.04) : .clear)
+        )
+        .onHover { h in withAnimation(Anim.hover) { isHovering = h } }
+        .onTapGesture(count: 2) { wallpaperManager.setWallpaper(wallpaper) }
+        .contextMenu {
+            Button { wallpaperManager.setWallpaper(wallpaper) } label: {
+                Label("Set as Wallpaper", systemImage: "photo.on.rectangle")
+            }
+            Button { wallpaperManager.toggleFavorite(wallpaper) } label: {
+                Label(wallpaper.isFavorite ? "Remove Favorite" : "Add Favorite",
+                      systemImage: wallpaper.isFavorite ? "heart.fill" : "heart")
+            }
+        }
+        .task { thumbnail = await wallpaper.generateThumbnail(size: CGSize(width: 160, height: 90)) }
     }
 }

--- a/src/Wallnetic/Views/Main/ExploreView.swift
+++ b/src/Wallnetic/Views/Main/ExploreView.swift
@@ -8,6 +8,7 @@ struct ExploreView: View {
     @State private var selectedCategory: String = "All"
     @State private var hoveredCategory: String?
     @State private var viewMode: ViewMode = .grid
+    @State private var selectedColor: ColorCategory?
 
     enum ViewMode: String {
         case grid, list
@@ -40,8 +41,15 @@ struct ExploreView: View {
             break
         }
 
+        // Color filter
+        if let colorFilter = selectedColor {
+            result = result.filter { $0.colorCategory == colorFilter }
+        }
+
         if !searchText.isEmpty {
-            result = result.filter { $0.name.localizedCaseInsensitiveContains(searchText) }
+            let fuzzyResults = wallpaperManager.searchWallpapers(query: searchText)
+            let fuzzyIDs = Set(fuzzyResults.map { $0.id })
+            result = result.filter { fuzzyIDs.contains($0.id) }
         }
 
         return result
@@ -58,6 +66,45 @@ struct ExploreView: View {
                 }
                 .padding(.horizontal, 20)
                 .padding(.vertical, 12)
+            }
+
+            // Color swatches
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 6) {
+                    // Clear filter
+                    Button {
+                        withAnimation(Anim.snappy) { selectedColor = nil }
+                    } label: {
+                        Text("All")
+                            .font(.system(size: 10, weight: selectedColor == nil ? .bold : .medium))
+                            .foregroundColor(selectedColor == nil ? .white : .white.opacity(0.5))
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 5)
+                            .background(
+                                Capsule().fill(selectedColor == nil ? Color.white.opacity(0.12) : Color.white.opacity(0.04))
+                            )
+                    }
+                    .buttonStyle(.plain)
+
+                    ForEach(ColorCategory.allCases) { cat in
+                        Button {
+                            withAnimation(Anim.snappy) {
+                                selectedColor = selectedColor == cat ? nil : cat
+                            }
+                        } label: {
+                            Circle()
+                                .fill(cat.color)
+                                .frame(width: 18, height: 18)
+                                .overlay(
+                                    Circle().stroke(.white.opacity(selectedColor == cat ? 0.8 : 0.15), lineWidth: selectedColor == cat ? 2 : 0.5)
+                                )
+                                .scaleEffect(selectedColor == cat ? 1.2 : 1.0)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+                .padding(.horizontal, 20)
+                .padding(.bottom, 8)
             }
 
             // Subtle divider with glow

--- a/src/Wallnetic/Views/Main/HomeView.swift
+++ b/src/Wallnetic/Views/Main/HomeView.swift
@@ -32,9 +32,9 @@ struct HomeView: View {
                     }
 
                     if wallpaperManager.wallpapers.count > 3 {
-                        CarouselSection(
+                        Carousel3DSection(
                             title: "All Wallpapers",
-                            icon: "square.grid.2x2.fill",
+                            icon: "cube.fill",
                             iconColor: .blue,
                             wallpapers: wallpaperManager.wallpapers
                         )
@@ -306,6 +306,63 @@ struct CarouselSection: View {
                 }
                 .padding(.horizontal, 48)
                 .padding(.vertical, 8)
+            }
+        }
+    }
+}
+
+// MARK: - 3D Perspective Carousel
+
+struct Carousel3DSection: View {
+    let title: String
+    let icon: String
+    let iconColor: Color
+    let wallpapers: [Wallpaper]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 8) {
+                Image(systemName: icon)
+                    .font(.system(size: 12))
+                    .foregroundColor(iconColor)
+                    .neonGlow(iconColor, isActive: true, radius: 4)
+
+                Text(title)
+                    .font(.system(size: 16, weight: .bold))
+                    .foregroundColor(.white)
+
+                Text("\(wallpapers.count)")
+                    .font(.system(size: 11, weight: .medium, design: .monospaced))
+                    .foregroundColor(.white.opacity(0.3))
+            }
+            .padding(.horizontal, 48)
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                LazyHStack(spacing: 0) {
+                    ForEach(Array(wallpapers.enumerated()), id: \.element.id) { index, wallpaper in
+                        GeometryReader { geo in
+                            let midX = geo.frame(in: .global).midX
+                            let screenMidX = NSScreen.main?.frame.midX ?? 600
+                            let distance = (midX - screenMidX) / 300
+                            let angle = Double(distance) * 25
+                            let scale = max(0.75, 1.0 - abs(distance) * 0.15)
+                            let opacity = max(0.5, 1.0 - abs(distance) * 0.3)
+
+                            CarouselCard(wallpaper: wallpaper)
+                                .scaleEffect(scale)
+                                .rotation3DEffect(
+                                    .degrees(-angle),
+                                    axis: (x: 0, y: 1, z: 0),
+                                    perspective: 0.5
+                                )
+                                .opacity(opacity)
+                                .animation(.easeOut(duration: 0.15), value: angle)
+                        }
+                        .frame(width: 260, height: 185)
+                    }
+                }
+                .padding(.horizontal, 48)
+                .padding(.vertical, 12)
             }
         }
     }

--- a/src/Wallnetic/Views/Main/HomeView.swift
+++ b/src/Wallnetic/Views/Main/HomeView.swift
@@ -48,6 +48,15 @@ struct HomeView: View {
         .background(Color.clear)
         .onAppear { startHeroTimer() }
         .onDisappear { heroTimer?.invalidate() }
+        .modifier(KeyPressModifier(
+            onSpace: {
+                if let wp = wallpaperManager.wallpapers[safe: heroIndex] {
+                    wallpaperManager.setWallpaper(wp)
+                }
+            },
+            onLeft: { heroPrev() },
+            onRight: { heroNext() }
+        ))
     }
 
     // MARK: - Cinematic Hero Banner
@@ -225,6 +234,18 @@ struct HomeView: View {
             guard count > 1 else { return }
             withAnimation { heroIndex = (heroIndex + 1) % count }
         }
+    }
+
+    private func heroNext() {
+        let count = min(wallpaperManager.wallpapers.count, 5)
+        guard count > 1 else { return }
+        withAnimation { heroIndex = (heroIndex + 1) % count }
+    }
+
+    private func heroPrev() {
+        let count = min(wallpaperManager.wallpapers.count, 5)
+        guard count > 1 else { return }
+        withAnimation { heroIndex = (heroIndex - 1 + count) % count }
     }
 }
 

--- a/src/Wallnetic/Views/Main/HomeView.swift
+++ b/src/Wallnetic/Views/Main/HomeView.swift
@@ -32,9 +32,9 @@ struct HomeView: View {
                     }
 
                     if wallpaperManager.wallpapers.count > 3 {
-                        Carousel3DSection(
+                        CarouselSection(
                             title: "All Wallpapers",
-                            icon: "cube.fill",
+                            icon: "square.grid.2x2.fill",
                             iconColor: .blue,
                             wallpapers: wallpaperManager.wallpapers
                         )

--- a/src/Wallnetic/Views/Main/PopularView.swift
+++ b/src/Wallnetic/Views/Main/PopularView.swift
@@ -91,6 +91,10 @@ struct PopularView: View {
             }
         }
         .background(Color.clear)
+        .modifier(KeyPressModifier(
+            onLeft: { wallpaperManager.cycleToNextWallpaper() },
+            onRight: { wallpaperManager.cycleToNextWallpaper() }
+        ))
     }
 }
 

--- a/src/Wallnetic/Views/Main/SettingsView.swift
+++ b/src/Wallnetic/Views/Main/SettingsView.swift
@@ -187,6 +187,7 @@ struct GeneralSettingsView: View {
     @State private var launchAtLoginEnabled = false
     @AppStorage("hideDockIcon") private var hideDockIcon = false
     @AppStorage("island.enabled") private var islandEnabled = false
+    @AppStorage("globalHotkeysEnabled") private var globalHotkeysEnabled = false
 
     var body: some View {
         Form {
@@ -215,6 +216,9 @@ struct GeneralSettingsView: View {
                         }
                     }
                     .help("Show wallpaper controls in a floating pill at the top of the screen")
+
+                Toggle("Global Hotkeys", isOn: $globalHotkeysEnabled)
+                    .help("⌘⇧→ Next, ⌘⇧← Prev, ⌘⇧P Play/Pause, ⌘⇧R Random (restart required)")
             }
 
             Section("Library") {

--- a/src/Wallnetic/Views/Main/SettingsView.swift
+++ b/src/Wallnetic/Views/Main/SettingsView.swift
@@ -135,6 +135,9 @@ struct AppearanceSettingsView: View {
     var body: some View {
         Form {
             Section("Theme") {
+                Toggle("Dynamic accent color from wallpaper", isOn: $themeManager.dynamicThemeEnabled)
+                    .help("UI accent color adapts to the current wallpaper's dominant color")
+
                 ForEach(AppearanceMode.allCases, id: \.self) { mode in
                     HStack {
                         Image(systemName: mode.icon)

--- a/src/Wallnetic/Views/Main/WallpaperGridView.swift
+++ b/src/Wallnetic/Views/Main/WallpaperGridView.swift
@@ -143,48 +143,22 @@ struct WallpaperCard: View {
     let isSelected: Bool
     @State private var thumbnail: NSImage?
     @State private var isHovering = false
+    @State private var isFlipped = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            // Thumbnail
+            // Thumbnail with flip
             ZStack {
-                if let thumbnail = thumbnail {
-                    Image(nsImage: thumbnail)
-                        .resizable()
-                        .aspectRatio(16/9, contentMode: .fill)
-                        .clipped()
+                if !isFlipped {
+                    // Front: thumbnail
+                    frontView
                 } else {
-                    Rectangle()
-                        .fill(Color.gray.opacity(0.3))
-                        .aspectRatio(16/9, contentMode: .fit)
-                        .overlay {
-                            ProgressView()
-                        }
-                }
-
-                // Duration badge
-                VStack {
-                    Spacer()
-                    HStack {
-                        Spacer()
-                        Text(wallpaper.formattedDuration)
-                            .font(.caption2)
-                            .padding(.horizontal, 6)
-                            .padding(.vertical, 2)
-                            .background(.ultraThinMaterial)
-                            .cornerRadius(4)
-                            .padding(8)
-                    }
-                }
-
-                // Hover play icon
-                if isHovering {
-                    Color.black.opacity(0.3)
-                    Image(systemName: "play.circle.fill")
-                        .font(.system(size: 44))
-                        .foregroundColor(.white)
+                    // Back: metadata
+                    backView
                 }
             }
+            .rotation3DEffect(.degrees(isFlipped ? 180 : 0), axis: (x: 0, y: 1, z: 0))
+            .animation(Anim.gentle, value: isFlipped)
             .cornerRadius(8)
             .overlay(
                 RoundedRectangle(cornerRadius: 8)
@@ -209,9 +183,115 @@ struct WallpaperCard: View {
             withAnimation(.easeOut(duration: 0.2)) {
                 isHovering = hovering
             }
+            // Auto-unflip when mouse leaves
+            if !hovering && isFlipped {
+                withAnimation(Anim.gentle) { isFlipped = false }
+            }
         }
         .task {
             thumbnail = await wallpaper.generateThumbnail()
+        }
+    }
+
+    // MARK: - Front View
+
+    private var frontView: some View {
+        ZStack {
+            if let thumbnail = thumbnail {
+                Image(nsImage: thumbnail)
+                    .resizable()
+                    .aspectRatio(16/9, contentMode: .fill)
+                    .clipped()
+            } else {
+                Rectangle()
+                    .fill(Color.gray.opacity(0.3))
+                    .aspectRatio(16/9, contentMode: .fit)
+                    .overlay { ProgressView() }
+            }
+
+            // Duration badge
+            VStack {
+                Spacer()
+                HStack {
+                    Spacer()
+                    Text(wallpaper.formattedDuration)
+                        .font(.caption2)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(.ultraThinMaterial)
+                        .cornerRadius(4)
+                        .padding(8)
+                }
+            }
+
+            // Hover overlay
+            if isHovering {
+                Color.black.opacity(0.3)
+
+                HStack(spacing: 16) {
+                    Image(systemName: "play.circle.fill")
+                        .font(.system(size: 44))
+                        .foregroundColor(.white)
+
+                    // Flip button
+                    Button {
+                        withAnimation(Anim.gentle) { isFlipped = true }
+                    } label: {
+                        Image(systemName: "info.circle.fill")
+                            .font(.system(size: 22))
+                            .foregroundColor(.white.opacity(0.7))
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+    }
+
+    // MARK: - Back View (metadata)
+
+    private var backView: some View {
+        ZStack {
+            Rectangle()
+                .fill(Color(white: 0.12))
+                .aspectRatio(16/9, contentMode: .fit)
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text(wallpaper.displayName)
+                    .font(.system(size: 13, weight: .bold))
+                    .foregroundColor(.white)
+                    .lineLimit(2)
+
+                Divider().background(.white.opacity(0.1))
+
+                metadataRow("Resolution", value: wallpaper.formattedResolution)
+                metadataRow("Duration", value: wallpaper.formattedDuration)
+                metadataRow("File Size", value: wallpaper.formattedFileSize)
+                metadataRow("Added", value: wallpaper.dateAdded.formatted(.dateTime.month().day().year()))
+
+                if wallpaper.isFavorite {
+                    HStack(spacing: 4) {
+                        Image(systemName: "heart.fill")
+                            .foregroundColor(.pink)
+                        Text("Favorite")
+                            .foregroundColor(.pink)
+                    }
+                    .font(.system(size: 10))
+                }
+            }
+            .padding(12)
+            .rotation3DEffect(.degrees(180), axis: (x: 0, y: 1, z: 0))
+        }
+    }
+
+    private func metadataRow(_ label: String, value: String) -> some View {
+        HStack {
+            Text(label)
+                .font(.system(size: 10))
+                .foregroundColor(.white.opacity(0.4))
+            Spacer()
+            Text(value)
+                .font(.system(size: 10, weight: .medium, design: .monospaced))
+                .foregroundColor(.white.opacity(0.8))
         }
     }
 }
@@ -361,19 +441,29 @@ struct AsyncThumbnailView: View {
 // MARK: - Key Press Modifier (macOS 13+ compatible)
 
 struct KeyPressModifier: ViewModifier {
-    let onSpace: () -> Void
-    let onEscape: () -> Void
-    let onReturn: () -> Void
+    var onSpace: (() -> Void)? = nil
+    var onEscape: (() -> Void)? = nil
+    var onReturn: (() -> Void)? = nil
+    var onLeft: (() -> Void)? = nil
+    var onRight: (() -> Void)? = nil
+    var onUp: (() -> Void)? = nil
+    var onDown: (() -> Void)? = nil
+    var onDelete: (() -> Void)? = nil
 
     func body(content: Content) -> some View {
         if #available(macOS 14.0, *) {
             content
-                .onKeyPress(.space) { onSpace(); return .handled }
-                .onKeyPress(.escape) { onEscape(); return .handled }
-                .onKeyPress(.return) { onReturn(); return .handled }
+                .onKeyPress(.space) { onSpace?(); return onSpace != nil ? .handled : .ignored }
+                .onKeyPress(.escape) { onEscape?(); return onEscape != nil ? .handled : .ignored }
+                .onKeyPress(.return) { onReturn?(); return onReturn != nil ? .handled : .ignored }
+                .onKeyPress(.leftArrow) { onLeft?(); return onLeft != nil ? .handled : .ignored }
+                .onKeyPress(.rightArrow) { onRight?(); return onRight != nil ? .handled : .ignored }
+                .onKeyPress(.upArrow) { onUp?(); return onUp != nil ? .handled : .ignored }
+                .onKeyPress(.downArrow) { onDown?(); return onDown != nil ? .handled : .ignored }
+                .onKeyPress(.delete) { onDelete?(); return onDelete != nil ? .handled : .ignored }
         } else {
             content
-                .onExitCommand { onEscape() }
+                .onExitCommand { onEscape?() }
         }
     }
 }

--- a/src/Wallnetic/Views/Settings/EffectsSettingsView.swift
+++ b/src/Wallnetic/Views/Settings/EffectsSettingsView.swift
@@ -3,6 +3,8 @@ import SwiftUI
 /// Settings view for wallpaper visual effects
 struct EffectsSettingsView: View {
     @ObservedObject private var effects = WallpaperEffectsManager.shared
+    @AppStorage("transitionStyle") private var transitionStyle = "crossfade"
+    @AppStorage("transitionDuration") private var transitionDuration = 0.5
 
     var body: some View {
         Form {
@@ -52,6 +54,26 @@ struct EffectsSettingsView: View {
                 if effects.vignetteEnabled {
                     sliderRow("Intensity", icon: "circle.dashed", value: $effects.vignetteIntensity,
                               range: 0...2.0, defaultValue: 0.5)
+                }
+            }
+
+            // Transition
+            Section("Transition") {
+                Picker("Style", selection: $transitionStyle) {
+                    Text("None").tag("none")
+                    Text("Crossfade").tag("crossfade")
+                    Text("Zoom").tag("zoom")
+                    Text("Slide").tag("slide")
+                }
+
+                if transitionStyle != "none" {
+                    HStack {
+                        Text("Duration")
+                        Slider(value: $transitionDuration, in: 0.2...1.5, step: 0.1)
+                        Text("\(transitionDuration, specifier: "%.1f")s")
+                            .foregroundColor(.secondary)
+                            .frame(width: 30)
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary
- **Dynamic Island drag & drop** (#135): Drop video files onto island to auto-import
- **Wallpaper transitions** (#136): Fade/reveal/push via CATransition, configurable in Settings > Effects
- **Global hotkeys** (#128): ⌘⇧→ next, ⌘⇧← prev, ⌘⇧P play/pause, ⌘⇧R random
- **File watching** (#117): Library folder auto-reload on file changes
- **Dual thumbnail cache** (#114): URL+size composite key, 120 entries
- **Post-import pipeline** (#118): Auto thumbnail generation + color extraction
- **Color swatch filter** (#121): 11 color swatches in Explore with CIAreaAverage extraction
- **Dynamic accent color** (#119): UI theme adapts to wallpaper dominant color
- **Tag system + fuzzy search** (#123): Tags on wallpapers, scored fuzzy matching
- **Card flip animation** (#122): Info button on hover reveals metadata back
- **Grid/List view toggle** (#120): ExploreView with list row component
- **Keyboard navigation** (#126): Arrow keys in Home/Explore/Popular
- **Animation polish** (#124): Spring presets, PressEffect modifier
- **Download progress UI** (#125): Progress bar with file name and percentage
- **New sources**: Wallhaven.cc (#111) and Steam Workshop (#112)

## Reverted
- **3D carousel** (#127): Visual quality insufficient, reopened for redesign

## Test plan
- [ ] Dynamic Island: drag video file onto island → should import and set as wallpaper
- [ ] Transitions: Settings > Effects > Transition > change to Zoom/Slide, switch wallpapers
- [ ] Global hotkeys: enable in Settings > General, test ⌘⇧→/←/P/R
- [ ] Color swatches: Explore tab → color circles → filter by color
- [ ] Card flip: hover wallpaper card → click info icon → see metadata
- [ ] Grid/List toggle: Explore tab → top-right grid/list icons
- [ ] New sources: Discover tab → Wallhaven and Steam Workshop should appear
- [ ] Build on arm64 and x86_64

🤖 Generated with [Claude Code](https://claude.ai/code)