### PR TITLE
v1.3 release prep: battery prompt, WallpaperManager split, perf sweep, store compliance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,7 @@ coverage/
 # Temporary files
 *.tmp
 *.temp
+
+# Claude Code (local agent config, memory, logs)
+.claude/
+CLAUDE.md

--- a/README.md
+++ b/README.md
@@ -254,6 +254,8 @@ open Wallnetic.xcodeproj
 - [x] WallpaperManager decomposition &mdash; Library / MetadataStore / WidgetSync services (#149)
 - [x] Notification → delegate refactor for direct playback calls (#170)
 - [x] 37 unit tests for Wallpaper, URL helpers, async init (#140)
+- [x] Privacy Manifest (`PrivacyInfo.xcprivacy`) for App Store compliance (#164)
+- [x] MRMediaRemote private framework gated to `#if DEBUG` for store builds (#165)
 
 ### v2.0 &mdash; Planned
 - [ ] AI video generation from text prompts
@@ -282,6 +284,9 @@ open Wallnetic.xcodeproj
 - **Tech Debt Batch** (#141-#158): Async `Wallpaper.init`, Settings split into three files, DynamicIsland split into controller/view, `PowerManager` leak fix, dead-code cleanup, async thumbnail upgrade, unified `WallpaperContextMenu`, timezone / Metal / memory / threading / error-handling improvements.
 - **Tests** (#140): 37 unit tests covering Wallpaper model, URL helpers, and async initialization.
 - **Now Playing**: Temporarily hidden until proper code signing is set up (MRMediaRemote private framework restrictions, #130).
+- **App Store Compliance**:
+  - Privacy Manifest declaring `UserDefaults` (CA92.1) and `FileTimestamp` (C617.1) required-reason APIs (#164).
+  - MRMediaRemote private framework loading wrapped in `#if DEBUG` so release builds ship without private API references (#165).
 
 ### v1.2.0
 - **Dynamic Island**: Floating pill UI at screen top with compact/expanded modes, playback controls, rename, and auto-collapse. Notch-aware layout for MacBook Pro.

--- a/README.md
+++ b/README.md
@@ -103,10 +103,20 @@ Wallnetic brings **live video wallpapers** to your Mac desktop. Transform your w
 - Staggered entrance animations
 - Animated gradient backgrounds
 
+### Audio Visualizer
+- Real-time FFT spectrum overlay rendered on the desktop
+- 64-column center-out horizontal burst with accent-to-white color gradient
+- Captures microphone or system audio (ScreenCaptureKit)
+- Pre-allocated vDSP buffers for near-zero allocation on the hot path
+- Configurable sensitivity and placement
+
 ### Smart Power Management
-- Auto-pause on battery power
+- Auto-pause on battery power with opt-in prompt
+- "Always play on battery" toggle in Settings for users who prefer live playback
+- "Bir daha sorma" / remember-choice checkbox in the prompt
 - Pause when fullscreen apps are active
 - Automatic resume when conditions change
+- `CGWindowListCopyWindowInfo` runs off the main thread (no UI stalls)
 
 ### Apple Shortcuts & Siri
 - Set Wallpaper, Next Wallpaper, Toggle Playback, Random Wallpaper
@@ -183,6 +193,7 @@ open Wallnetic.xcodeproj
 
 ## Keyboard Shortcuts
 
+### In-App
 | Shortcut | Action |
 |----------|--------|
 | `Cmd + I` | Import videos |
@@ -191,6 +202,16 @@ open Wallnetic.xcodeproj
 | `Cmd + F` | Search |
 | `Cmd + O` | Open main window |
 | `Cmd + ,` | Settings |
+
+### Global (System-Wide)
+| Shortcut | Action |
+|----------|--------|
+| `Cmd + Shift + →` | Next wallpaper |
+| `Cmd + Shift + ←` | Previous wallpaper |
+| `Cmd + Shift + P` | Toggle play/pause |
+| `Cmd + Shift + R` | Random wallpaper |
+
+> Global hotkeys work from any app. Enable them in `Settings → General → Global hotkeys`.
 
 ---
 
@@ -217,19 +238,27 @@ open Wallnetic.xcodeproj
 - [x] Crossfade transitions
 - [x] Performance modes
 
-### v1.2 &mdash; Current
+### v1.2
 - [x] Dynamic Island &mdash; floating control pill at screen top (notch-aware)
 - [x] Wallpaper rename &mdash; custom display titles via right-click > Rename
 - [x] Dock icon hiding &mdash; run as menu bar-only app
 - [x] Striking UI effects &mdash; glow cards, neon navigation, glass morphism, staggered animations
 - [x] Code review bug fixes &mdash; Equatable/Hashable contract, import file copy, force-unwrap safety
 
+### v1.3 &mdash; Current
+- [x] Audio Visualizer overlay on desktop (#129) &mdash; 64-column FFT burst with color gradient
+- [x] Global hotkeys &mdash; `Cmd+Shift+←/→/P/R` for previous, next, play/pause, random
+- [x] Battery-mode prompt with "Always play on battery" Settings toggle (#172)
+- [x] FFT hot-path optimizations &mdash; pre-allocated vDSP buffers, pointer arithmetic (#163)
+- [x] PowerManager off-main-thread fullscreen detection (#168)
+- [x] WallpaperManager decomposition &mdash; Library / MetadataStore / WidgetSync services (#149)
+- [x] Notification → delegate refactor for direct playback calls (#170)
+- [x] 37 unit tests for Wallpaper, URL helpers, async init (#140)
+
 ### v2.0 &mdash; Planned
 - [ ] AI video generation from text prompts
-- [ ] Audio visualizer overlay on desktop
 - [ ] 3D perspective wallpaper carousel
-- [ ] Global hotkeys for wallpaper control
-- [ ] Now Playing overlay on desktop
+- [ ] Now Playing overlay on desktop (currently gated on code signing)
 - [ ] Wallpaper marketplace
 - [ ] Music reactive mode
 - [ ] iCloud library sync
@@ -237,6 +266,22 @@ open Wallnetic.xcodeproj
 ---
 
 ## Changelog
+
+### Unreleased (v1.3.0)
+- **Audio Visualizer** (#129): Desktop overlay showing a 64-column FFT spectrum. Center-out horizontal burst with an accent-to-white color gradient; captures microphone or system audio via ScreenCaptureKit.
+- **Battery Prompt & Settings Toggle** (#172): When the Mac switches to battery power (or the app launches on battery), users see a prompt offering to keep the live wallpaper running. A new `Playback → Always play on battery` Settings toggle makes the choice permanent, with a `Reset battery prompt` button to bring it back.
+- **Global Hotkeys**: `⌘⇧→` next, `⌘⇧←` previous, `⌘⇧P` play/pause, `⌘⇧R` random.
+- **Performance**:
+  - FFT hot-path uses pre-allocated vDSP buffers and pointer arithmetic &mdash; eliminates ~280 allocations/sec on the visualizer path (#163).
+  - `CGWindowListCopyWindowInfo` moved off the main thread to keep the UI responsive (#168).
+  - NSColor → RGB conversion cached via `@State + .onChange` in `AudioVisualizerOverlayView`.
+- **Refactoring**:
+  - `WallpaperManager` reduced 808 → 462 lines; extracted `WallpaperLibrary`, `WallpaperMetadataStore`, `WidgetSyncService` (#149).
+  - NotificationCenter relay for playback replaced with a typed `PlaybackDelegate` protocol &mdash; direct calls, fewer main-thread hops (#170). Broadcast consumers (widget) still use notifications.
+  - Duplicate hotkey handlers in `AppDelegate` consolidated to call `WallpaperManager` directly.
+- **Tech Debt Batch** (#141-#158): Async `Wallpaper.init`, Settings split into three files, DynamicIsland split into controller/view, `PowerManager` leak fix, dead-code cleanup, async thumbnail upgrade, unified `WallpaperContextMenu`, timezone / Metal / memory / threading / error-handling improvements.
+- **Tests** (#140): 37 unit tests covering Wallpaper model, URL helpers, and async initialization.
+- **Now Playing**: Temporarily hidden until proper code signing is set up (MRMediaRemote private framework restrictions, #130).
 
 ### v1.2.0
 - **Dynamic Island**: Floating pill UI at screen top with compact/expanded modes, playback controls, rename, and auto-collapse. Notch-aware layout for MacBook Pro.

--- a/src/Wallnetic/App/AppDelegate.swift
+++ b/src/Wallnetic/App/AppDelegate.swift
@@ -18,8 +18,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // Initialize desktop window controller
         desktopWindowController = DesktopWindowController()
 
-        // Setup wallpaper change observer
-        setupWallpaperObserver()
+        // Wire up PlaybackDelegate — direct calls instead of notification relay (#170)
+        WallpaperManager.shared.playbackDelegate = self
 
         // Setup power manager with callbacks
         setupPowerManager()
@@ -42,110 +42,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // NowPlayingOverlayController disabled until proper code signing is set up
         _ = AudioVisualizerOverlayController.shared
 
+        // Battery prompt (#172) — if we launched while on battery, ask the user
+        // whether to keep the live wallpaper running. Delayed so PowerManager
+        // has time to detect the initial power state and settings restore.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) {
+            BatteryPromptService.shared.checkOnLaunch()
+        }
+
         logger.info("Wallnetic started successfully")
-    }
-
-    // MARK: - Wallpaper Observer
-
-    private func setupWallpaperObserver() {
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(wallpaperDidChange),
-            name: .wallpaperDidChange,
-            object: nil
-        )
-
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(playbackStateDidChange),
-            name: .playbackStateDidChange,
-            object: nil
-        )
-
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(screenWallpaperDidChange),
-            name: .screenWallpaperDidChange,
-            object: nil
-        )
-
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(applyScreenWallpapers),
-            name: .applyScreenWallpapers,
-            object: nil
-        )
-    }
-
-    @objc private func wallpaperDidChange(_ notification: Notification) {
-        guard let wallpaper = notification.object as? Wallpaper else {
-            return
-        }
-
-        #if DEBUG
-        print("[AppDelegate] Applying wallpaper: \(wallpaper.name)")
-        #endif
-
-        desktopWindowController?.setWallpaper(url: wallpaper.url)
-
-        // Only play if power conditions allow
-        if !(powerManager?.shouldBePaused ?? false) {
-            desktopWindowController?.play()
-            DispatchQueue.main.async {
-                WallpaperManager.shared.isPlaying = true
-            }
-        }
-    }
-
-    @objc private func playbackStateDidChange(_ notification: Notification) {
-        guard let isPlaying = notification.object as? Bool else { return }
-
-        if isPlaying {
-            // Check power conditions before playing
-            if !(powerManager?.shouldBePaused ?? false) {
-                desktopWindowController?.play()
-            }
-        } else {
-            desktopWindowController?.pause()
-        }
-    }
-
-    @objc private func screenWallpaperDidChange(_ notification: Notification) {
-        guard let info = notification.object as? ScreenWallpaperInfo else { return }
-
-        #if DEBUG
-        print("[AppDelegate] Applying wallpaper '\(info.wallpaper.name)' to screen: \(info.screen.localizedName)")
-        #endif
-
-        desktopWindowController?.setWallpaper(url: info.wallpaper.url, for: info.screen)
-
-        // Only play if power conditions allow
-        if !(powerManager?.shouldBePaused ?? false) {
-            desktopWindowController?.play()
-            DispatchQueue.main.async {
-                WallpaperManager.shared.isPlaying = true
-            }
-        }
-    }
-
-    @objc private func applyScreenWallpapers() {
-        #if DEBUG
-        print("[AppDelegate] Applying per-screen wallpapers")
-        #endif
-
-        for screen in NSScreen.screens {
-            if let wallpaper = WallpaperManager.shared.wallpaper(for: screen) {
-                desktopWindowController?.setWallpaper(url: wallpaper.url, for: screen)
-            }
-        }
-
-        // Only play if power conditions allow
-        if !(powerManager?.shouldBePaused ?? false) {
-            desktopWindowController?.play()
-            DispatchQueue.main.async {
-                WallpaperManager.shared.isPlaying = true
-            }
-        }
     }
 
     // MARK: - Global Hotkeys
@@ -156,12 +60,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private func setupGlobalHotkeys() {
         guard UserDefaults.standard.bool(forKey: "globalHotkeysEnabled") else { return }
 
-        // Global monitor (when app is not focused)
         globalMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in
             self?.handleHotkey(event)
         }
 
-        // Local monitor (when app is focused)
         localMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
             if self?.handleHotkey(event) == true { return nil }
             return event
@@ -178,9 +80,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             return true
         }
 
-        // ⌘⇧← Previous wallpaper
+        // ⌘⇧← Previous wallpaper (#D1: delegate to WallpaperManager directly)
         if flags == [.command, .shift] && event.keyCode == 123 {
-            cycleToPreviousWallpaper()
+            WallpaperManager.shared.cycleToPreviousWallpaper()
             return true
         }
 
@@ -190,54 +92,28 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             return true
         }
 
-        // ⌘⇧R Random wallpaper
+        // ⌘⇧R Random wallpaper (#D1: delegate to WallpaperManager directly)
         if flags == [.command, .shift] && event.charactersIgnoringModifiers == "r" {
-            setRandomWallpaper()
+            WallpaperManager.shared.setRandomWallpaper()
             return true
         }
 
         return false
     }
 
-    private func cycleToPreviousWallpaper() {
-        let wallpapers = WallpaperManager.shared.wallpapers
-        guard !wallpapers.isEmpty else { return }
-        if let current = WallpaperManager.shared.currentWallpaper,
-           let idx = wallpapers.firstIndex(where: { $0.id == current.id }) {
-            let prevIdx = (idx - 1 + wallpapers.count) % wallpapers.count
-            WallpaperManager.shared.setWallpaper(wallpapers[prevIdx])
-        } else if let last = wallpapers.last {
-            WallpaperManager.shared.setWallpaper(last)
-        }
-    }
-
-    private func setRandomWallpaper() {
-        let candidates = WallpaperManager.shared.wallpapers.filter {
-            $0.id != WallpaperManager.shared.currentWallpaper?.id
-        }
-        guard let random = candidates.randomElement() else { return }
-        WallpaperManager.shared.setWallpaper(random)
-    }
-
     func applicationWillTerminate(_ notification: Notification) {
-        // Remove hotkey monitors
         if let m = globalMonitor { NSEvent.removeMonitor(m) }
         if let m = localMonitor { NSEvent.removeMonitor(m) }
 
-        // Remove all notification observers
         NotificationCenter.default.removeObserver(self)
 
-        // Cleanup power manager
         powerManager?.cleanup()
-
-        // Cleanup desktop windows
         desktopWindowController?.cleanup()
 
         logger.info("Wallnetic terminating")
     }
 
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
-        // Keep running in menu bar even if main window is closed
         return false
     }
 
@@ -248,12 +124,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func showMainWindow() {
-        // Temporarily make app regular so windows can appear
         if NSApp.activationPolicy() == .accessory {
             NSApp.setActivationPolicy(.regular)
         }
 
-        // Try existing window first
         let existingWindow = NSApp.windows.first { window in
             guard window.level == .normal,
                   !window.title.isEmpty || window.contentView != nil else {
@@ -266,14 +140,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             NSApp.activate(ignoringOtherApps: true)
             window.makeKeyAndOrderFront(nil)
         } else {
-            // No window — use WindowManager to create one via SwiftUI openWindow
             WindowManager.shared.openMainWindow?()
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
                 NSApp.activate(ignoringOtherApps: true)
             }
         }
 
-        // Re-hide dock after window appears
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
             if UserDefaults.standard.bool(forKey: "hideDockIcon") {
                 NSApp.setActivationPolicy(.accessory)
@@ -286,10 +158,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     func application(_ application: NSApplication, open urls: [URL]) {
         for url in urls {
             guard url.scheme == "wallnetic" else { continue }
-
             let host = url.host ?? ""
-            NSLog("[AppDelegate] Handling URL: %@ (host: %@)", url.absoluteString, host)
-
             if host == "open" {
                 showMainWindow()
             } else if host == "playPause" || host == "nextWallpaper" || host == "setWallpaper" {
@@ -334,5 +203,53 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         print("[AppDelegate] Display configuration changed")
         #endif
         desktopWindowController?.handleDisplayChange()
+    }
+}
+
+// MARK: - PlaybackDelegate (#170)
+
+extension AppDelegate: PlaybackDelegate {
+    func playbackSetWallpaper(url: URL) {
+        #if DEBUG
+        print("[AppDelegate] PlaybackDelegate: setWallpaper \(url.lastPathComponent)")
+        #endif
+        desktopWindowController?.setWallpaper(url: url)
+        if !(powerManager?.shouldBePaused ?? false) {
+            desktopWindowController?.play()
+        }
+    }
+
+    func playbackSetWallpaper(url: URL, for screen: NSScreen) {
+        #if DEBUG
+        print("[AppDelegate] PlaybackDelegate: setWallpaper for \(screen.localizedName)")
+        #endif
+        desktopWindowController?.setWallpaper(url: url, for: screen)
+        if !(powerManager?.shouldBePaused ?? false) {
+            desktopWindowController?.play()
+        }
+    }
+
+    func playbackPlay() {
+        if !(powerManager?.shouldBePaused ?? false) {
+            desktopWindowController?.play()
+        }
+    }
+
+    func playbackPause() {
+        desktopWindowController?.pause()
+    }
+
+    func playbackApplyScreenWallpapers() {
+        #if DEBUG
+        print("[AppDelegate] PlaybackDelegate: applyScreenWallpapers")
+        #endif
+        for screen in NSScreen.screens {
+            if let wallpaper = WallpaperManager.shared.wallpaper(for: screen) {
+                desktopWindowController?.setWallpaper(url: wallpaper.url, for: screen)
+            }
+        }
+        if !(powerManager?.shouldBePaused ?? false) {
+            desktopWindowController?.play()
+        }
     }
 }

--- a/src/Wallnetic/Engine/PowerManager.swift
+++ b/src/Wallnetic/Engine/PowerManager.swift
@@ -22,9 +22,16 @@ class PowerManager {
     private var fullscreenCheckTimer: Timer?
     private var powerSourceRef: CFRunLoopSource?
 
+    /// False until `init` finishes seeding initial state. Used to suppress
+    /// the first-pass BatteryPromptService trigger — launch-time prompting is
+    /// owned by AppDelegate's delayed `checkOnLaunch()` so we don't race the
+    /// wallpaper restore.
+    private var isInitialized = false
+
     private init() {
         setupObservers()
         checkInitialPowerState()
+        isInitialized = true
         startFullscreenMonitoring()
     }
 
@@ -292,7 +299,11 @@ class PowerManager {
             if BatteryPromptService.shared.effectivePauseOnBattery {
                 notifyPauseIfNeeded()
             }
-            BatteryPromptService.shared.onSwitchedToBattery()
+            // Only prompt on genuine runtime transitions — launch-time prompts
+            // are handled by AppDelegate.checkOnLaunch after restore settles.
+            if isInitialized {
+                BatteryPromptService.shared.onSwitchedToBattery()
+            }
         } else {
             print("[PowerManager] Switched to AC power")
             notifyResumeIfNeeded()

--- a/src/Wallnetic/Engine/PowerManager.swift
+++ b/src/Wallnetic/Engine/PowerManager.swift
@@ -10,6 +10,8 @@ class PowerManager {
     var onShouldPausePlayback: (() -> Void)?
     var onShouldResumePlayback: (() -> Void)?
 
+    private let fullscreenQueue = DispatchQueue(label: "com.wallnetic.power.fullscreen", qos: .utility)
+
     // State tracking
     private(set) var isOnBattery = false
     private(set) var isLowPowerMode = false
@@ -192,74 +194,69 @@ class PowerManager {
     private var fullscreenDebounceTimer: Timer?
 
     private func checkFullscreenApps() {
+        // Capture values that are safe to read on main thread.
+        let frontApp = NSWorkspace.shared.frontmostApplication
         let wasFullscreen = isFullscreenAppActive
+        let screens = NSScreen.screens.map { $0.frame }
 
-        // Get the frontmost app's windows
-        guard let frontApp = NSWorkspace.shared.frontmostApplication else {
-            updateFullscreenState(false, wasFullscreen: wasFullscreen)
-            return
-        }
+        // Run the expensive CGWindowListCopyWindowInfo off the main thread.
+        fullscreenQueue.async { [weak self] in
+            guard let self else { return }
 
-        // Skip our own app and system apps
-        let skipBundleIds = [
-            Bundle.main.bundleIdentifier,
-            "com.apple.finder",
-            "com.apple.dock",
-            "com.apple.SystemUIServer",
-            "com.apple.controlcenter",
-            "com.apple.notificationcenterui"
-        ]
-
-        if skipBundleIds.contains(frontApp.bundleIdentifier) {
-            updateFullscreenState(false, wasFullscreen: wasFullscreen)
-            return
-        }
-
-        // Method 1: Check if app is in native macOS fullscreen mode
-        // This is the most reliable check for true fullscreen
-        let options = CGWindowListOption.optionOnScreenOnly
-        let windowList = CGWindowListCopyWindowInfo(options, kCGNullWindowID) as? [[String: Any]] ?? []
-
-        // Filter windows belonging to the front app
-        let appWindows = windowList.filter { windowInfo in
-            guard let ownerPID = windowInfo[kCGWindowOwnerPID as String] as? Int32 else {
-                return false
-            }
-            return ownerPID == frontApp.processIdentifier
-        }
-
-        // Check for true fullscreen windows only
-        // A window is considered fullscreen if it exactly matches screen dimensions
-        // AND covers the full height (including menu bar area)
-        let hasFullscreenWindow = appWindows.contains { windowInfo in
-            guard let layer = windowInfo[kCGWindowLayer as String] as? Int,
-                  layer == 0,  // Normal window layer
-                  let bounds = windowInfo[kCGWindowBounds as String] as? [String: CGFloat] else {
-                return false
+            guard let frontApp else {
+                DispatchQueue.main.async { self.updateFullscreenState(false, wasFullscreen: wasFullscreen) }
+                return
             }
 
-            let windowX = bounds["X"] ?? 0
-            let windowY = bounds["Y"] ?? 0
-            let windowWidth = bounds["Width"] ?? 0
-            let windowHeight = bounds["Height"] ?? 0
+            let skipBundleIds = [
+                Bundle.main.bundleIdentifier,
+                "com.apple.finder",
+                "com.apple.dock",
+                "com.apple.SystemUIServer",
+                "com.apple.controlcenter",
+                "com.apple.notificationcenterui"
+            ]
 
-            // Check if window matches any screen size EXACTLY (true fullscreen)
-            return NSScreen.screens.contains { screen in
-                let screenFrame = screen.frame
+            if skipBundleIds.contains(frontApp.bundleIdentifier) {
+                DispatchQueue.main.async { self.updateFullscreenState(false, wasFullscreen: wasFullscreen) }
+                return
+            }
 
-                // True fullscreen: window must start at screen origin and match exact dimensions
-                // This excludes maximized windows that don't cover the menu bar
-                let xMatches = abs(windowX - screenFrame.origin.x) < 2
-                let yMatches = abs(windowY - screenFrame.origin.y) < 2
-                let widthMatches = abs(windowWidth - screenFrame.width) < 2
-                let heightMatches = abs(windowHeight - screenFrame.height) < 2
+            let options = CGWindowListOption.optionOnScreenOnly
+            let windowList = CGWindowListCopyWindowInfo(options, kCGNullWindowID) as? [[String: Any]] ?? []
 
-                // Only true fullscreen (covers entire screen including menu bar)
-                return xMatches && yMatches && widthMatches && heightMatches
+            let appWindows = windowList.filter { windowInfo in
+                guard let ownerPID = windowInfo[kCGWindowOwnerPID as String] as? Int32 else {
+                    return false
+                }
+                return ownerPID == frontApp.processIdentifier
+            }
+
+            let hasFullscreenWindow = appWindows.contains { windowInfo in
+                guard let layer = windowInfo[kCGWindowLayer as String] as? Int,
+                      layer == 0,
+                      let bounds = windowInfo[kCGWindowBounds as String] as? [String: CGFloat] else {
+                    return false
+                }
+
+                let windowX = bounds["X"] ?? 0
+                let windowY = bounds["Y"] ?? 0
+                let windowWidth = bounds["Width"] ?? 0
+                let windowHeight = bounds["Height"] ?? 0
+
+                return screens.contains { screenFrame in
+                    let xMatches = abs(windowX - screenFrame.origin.x) < 2
+                    let yMatches = abs(windowY - screenFrame.origin.y) < 2
+                    let widthMatches = abs(windowWidth - screenFrame.width) < 2
+                    let heightMatches = abs(windowHeight - screenFrame.height) < 2
+                    return xMatches && yMatches && widthMatches && heightMatches
+                }
+            }
+
+            DispatchQueue.main.async {
+                self.updateFullscreenState(hasFullscreenWindow, wasFullscreen: wasFullscreen)
             }
         }
-
-        updateFullscreenState(hasFullscreenWindow, wasFullscreen: wasFullscreen)
     }
 
     private func updateFullscreenState(_ newState: Bool, wasFullscreen: Bool) {
@@ -292,9 +289,10 @@ class PowerManager {
     private func handlePowerSourceChange() {
         if isOnBattery {
             print("[PowerManager] Switched to battery power")
-            if WallpaperManager.shared.pauseOnBattery {
+            if BatteryPromptService.shared.effectivePauseOnBattery {
                 notifyPauseIfNeeded()
             }
+            BatteryPromptService.shared.onSwitchedToBattery()
         } else {
             print("[PowerManager] Switched to AC power")
             notifyResumeIfNeeded()
@@ -387,7 +385,7 @@ class PowerManager {
             return true
         }
 
-        if isOnBattery && WallpaperManager.shared.pauseOnBattery {
+        if isOnBattery && BatteryPromptService.shared.effectivePauseOnBattery {
             return true
         }
 

--- a/src/Wallnetic/Resources/Info.plist
+++ b/src/Wallnetic/Resources/Info.plist
@@ -45,5 +45,7 @@
 	<string>Wallnetic uses microphone audio to drive the on-desktop audio visualizer.</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>NSScreenCaptureUsageDescription</key>
+	<string>Wallnetic captures system audio (via ScreenCaptureKit) to drive the on-desktop audio visualizer. No screen imagery is recorded.</string>
 </dict>
 </plist>

--- a/src/Wallnetic/Resources/PrivacyInfo.xcprivacy
+++ b/src/Wallnetic/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSPrivacyTracking</key>
+    <false/>
+    <key>NSPrivacyTrackingDomains</key>
+    <array/>
+    <key>NSPrivacyCollectedDataTypes</key>
+    <array/>
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array>
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>CA92.1</string>
+            </array>
+        </dict>
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>C617.1</string>
+            </array>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/src/Wallnetic/Services/AudioVisualizerManager.swift
+++ b/src/Wallnetic/Services/AudioVisualizerManager.swift
@@ -54,6 +54,14 @@ final class AudioVisualizerManager: NSObject, ObservableObject {
     private var peakHold: [Float] = Array(repeating: 0, count: bandCount)
     private var sampleAccumulator: [Float] = []
 
+    // Pre-allocated FFT buffers — reused every cycle to avoid ~280 allocs/sec.
+    private var fftWindowed: [Float] = []
+    private var fftImagIn: [Float] = []
+    private var fftRealOut: [Float] = []
+    private var fftImagOut: [Float] = []
+    private var fftMagnitudes: [Float] = []
+    private var bandResult: [Float] = Array(repeating: 0, count: bandCount)
+
     // MARK: - Mic capture
 
     private let engine = AVAudioEngine()
@@ -70,6 +78,13 @@ final class AudioVisualizerManager: NSObject, ObservableObject {
         window = [Float](repeating: 0, count: fftSize)
         vDSP_hann_window(&window, vDSP_Length(fftSize), Int32(vDSP_HANN_NORM))
         fftSetup = vDSP_DFT_zop_CreateSetup(nil, vDSP_Length(fftSize), .FORWARD)
+
+        // Pre-allocate FFT buffers once.
+        fftWindowed = [Float](repeating: 0, count: fftSize)
+        fftImagIn = [Float](repeating: 0, count: fftSize)
+        fftRealOut = [Float](repeating: 0, count: fftSize)
+        fftImagOut = [Float](repeating: 0, count: fftSize)
+        fftMagnitudes = [Float](repeating: 0, count: fftSize / 2)
     }
 
     deinit {
@@ -299,32 +314,31 @@ final class AudioVisualizerManager: NSObject, ObservableObject {
     private func runFFT(on input: [Float]) {
         guard let setup = fftSetup else { return }
 
-        var windowed = [Float](repeating: 0, count: fftSize)
-        vDSP_vmul(input, 1, window, 1, &windowed, 1, vDSP_Length(fftSize))
-
-        let imagIn = [Float](repeating: 0, count: fftSize)
-        var realOut = [Float](repeating: 0, count: fftSize)
-        var imagOut = [Float](repeating: 0, count: fftSize)
-        vDSP_DFT_Execute(setup, windowed, imagIn, &realOut, &imagOut)
-
         let bins = fftSize / 2
-        var magnitudes = [Float](repeating: 0, count: bins)
-        realOut.withUnsafeMutableBufferPointer { rp in
-            imagOut.withUnsafeMutableBufferPointer { ip in
+
+        // Reuse pre-allocated buffers — zero allocs on the hot path.
+        vDSP_vmul(input, 1, window, 1, &fftWindowed, 1, vDSP_Length(fftSize))
+
+        // imagIn must be zeroed each cycle (DFT input is real-only).
+        vDSP_vclr(&fftImagIn, 1, vDSP_Length(fftSize))
+        vDSP_DFT_Execute(setup, fftWindowed, fftImagIn, &fftRealOut, &fftImagOut)
+
+        fftRealOut.withUnsafeMutableBufferPointer { rp in
+            fftImagOut.withUnsafeMutableBufferPointer { ip in
                 var split = DSPSplitComplex(realp: rp.baseAddress!, imagp: ip.baseAddress!)
-                vDSP_zvmags(&split, 1, &magnitudes, 1, vDSP_Length(bins))
+                vDSP_zvmags(&split, 1, &fftMagnitudes, 1, vDSP_Length(bins))
             }
         }
 
         var scale: Float = 1.0 / Float(fftSize)
-        vDSP_vsmul(magnitudes, 1, &scale, &magnitudes, 1, vDSP_Length(bins))
+        vDSP_vsmul(fftMagnitudes, 1, &scale, &fftMagnitudes, 1, vDSP_Length(bins))
 
-        let newBands = computeBands(from: magnitudes)
+        computeBands()
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
             var total: Float = 0
             for i in 0..<Self.bandCount {
-                let target = newBands[i]
+                let target = self.bandResult[i]
                 // Bar body — fast attack, smooth decay.
                 if target > self.decayBands[i] {
                     self.decayBands[i] = self.decayBands[i] + (target - self.decayBands[i]) * 0.55
@@ -345,23 +359,30 @@ final class AudioVisualizerManager: NSObject, ObservableObject {
         }
     }
 
-    private func computeBands(from magnitudes: [Float]) -> [Float] {
+    /// Map FFT magnitudes into log-spaced bands. Writes into pre-allocated
+    /// `bandResult` and uses pointer arithmetic to avoid per-band slice copies.
+    private func computeBands() {
         let count = Self.bandCount
-        let bins = magnitudes.count
-        var result = [Float](repeating: 0, count: count)
+        let bins = fftMagnitudes.count
         let minLog = log10(Float(2))
         let maxLog = log10(Float(bins))
-        for i in 0..<count {
-            let lo = Int(pow(10, minLog + (maxLog - minLog) * Float(i) / Float(count)))
-            let hi = max(lo + 1, Int(pow(10, minLog + (maxLog - minLog) * Float(i + 1) / Float(count))))
-            let clampedHi = min(hi, bins)
-            guard lo < clampedHi else { continue }
-            var sum: Float = 0
-            vDSP_meanv(Array(magnitudes[lo..<clampedHi]), 1, &sum, vDSP_Length(clampedHi - lo))
-            let scaled = log10(1 + sum * Float(sensitivity) * 2000)
-            result[i] = min(1.0, scaled)
+        let sens = Float(sensitivity)
+
+        fftMagnitudes.withUnsafeBufferPointer { magPtr in
+            for i in 0..<count {
+                let lo = Int(pow(10, minLog + (maxLog - minLog) * Float(i) / Float(count)))
+                let hi = max(lo + 1, Int(pow(10, minLog + (maxLog - minLog) * Float(i + 1) / Float(count))))
+                let clampedHi = min(hi, bins)
+                guard lo < clampedHi else {
+                    bandResult[i] = 0
+                    continue
+                }
+                var sum: Float = 0
+                vDSP_meanv(magPtr.baseAddress! + lo, 1, &sum, vDSP_Length(clampedHi - lo))
+                let scaled = log10(1 + sum * sens * 2000)
+                bandResult[i] = min(1.0, scaled)
+            }
         }
-        return result
     }
 }
 

--- a/src/Wallnetic/Services/BatteryPromptService.swift
+++ b/src/Wallnetic/Services/BatteryPromptService.swift
@@ -6,6 +6,10 @@ private let logger = Logger(subsystem: "com.wallnetic.app", category: "BatteryPr
 /// Presents the battery-mode prompt (#172) and tracks per-session / persistent
 /// overrides so the user can choose to keep the live wallpaper running on
 /// battery power.
+///
+/// All mutating calls must happen on the main thread — NSAlert requires it,
+/// and the `hasAskedThisSession` / `sessionContinueOnBattery` flags are read
+/// from `PowerManager.shouldBePaused` which is driven by main-thread events.
 final class BatteryPromptService {
     static let shared = BatteryPromptService()
 
@@ -67,6 +71,7 @@ final class BatteryPromptService {
     /// Called from AppDelegate on launch. If we're already on battery and the
     /// user hasn't silenced the prompt, show the alert.
     func checkOnLaunch() {
+        dispatchPrecondition(condition: .onQueue(.main))
         guard PowerManager.shared.isOnBattery else { return }
         guard WallpaperManager.shared.pauseOnBattery else { return }
         askIfNeeded(trigger: .launch)
@@ -74,6 +79,7 @@ final class BatteryPromptService {
 
     /// Called by PowerManager when the power source flips from AC to battery.
     func onSwitchedToBattery() {
+        dispatchPrecondition(condition: .onQueue(.main))
         guard WallpaperManager.shared.pauseOnBattery else { return }
         askIfNeeded(trigger: .runtime)
     }
@@ -81,6 +87,7 @@ final class BatteryPromptService {
     // MARK: - Private
 
     private func askIfNeeded(trigger: Trigger) {
+        dispatchPrecondition(condition: .onQueue(.main))
         guard !hasAskedThisSession else { return }
 
         // User flipped the Settings toggle — no prompt, silently continue.
@@ -105,18 +112,20 @@ final class BatteryPromptService {
     }
 
     private func showAlert(trigger: Trigger) {
+        dispatchPrecondition(condition: .onQueue(.main))
+
         let alert = NSAlert()
-        alert.messageText = "Pil modunda çalışıyor"
+        alert.messageText = "Running on battery"
         alert.informativeText = trigger == .launch
-            ? "Wallnetic pil ömrünü korumak için canlı duvar kağıdını duraklattı. Oynatmaya devam etmek ister misiniz?"
-            : "Şarj kablosu çıkarıldı. Pil ömrünü korumak için canlı duvar kağıdı duraklatıldı. Oynatmaya devam etmek ister misiniz?"
+            ? "Wallnetic paused the live wallpaper to save battery. Would you like to keep it playing?"
+            : "Power cable unplugged. Wallnetic paused the live wallpaper to save battery. Would you like to keep it playing?"
         alert.alertStyle = .informational
 
-        alert.addButton(withTitle: "Canlı devam et")
-        alert.addButton(withTitle: "Pil koruyucu (duraklat)")
+        alert.addButton(withTitle: "Keep playing")
+        alert.addButton(withTitle: "Pause (save battery)")
 
         let rememberCheckbox = NSButton(
-            checkboxWithTitle: "Bir daha sorma",
+            checkboxWithTitle: "Don't ask again",
             target: nil,
             action: nil
         )
@@ -143,16 +152,12 @@ final class BatteryPromptService {
     }
 
     private func applyChoice(_ choice: String) {
+        dispatchPrecondition(condition: .onQueue(.main))
         guard choice == "continue" else { return }
         sessionContinueOnBattery = true
 
-        DispatchQueue.main.async {
-            WallpaperManager.shared.isPlaying = true
-            if let delegate = WallpaperManager.shared.playbackDelegate {
-                delegate.playbackPlay()
-            } else {
-                NotificationCenter.default.post(name: .playbackStateDidChange, object: true)
-            }
-        }
+        WallpaperManager.shared.isPlaying = true
+        WallpaperManager.shared.playbackDelegate?.playbackPlay()
+        NotificationCenter.default.post(name: .playbackStateDidChange, object: true)
     }
 }

--- a/src/Wallnetic/Services/BatteryPromptService.swift
+++ b/src/Wallnetic/Services/BatteryPromptService.swift
@@ -1,0 +1,158 @@
+import Cocoa
+import os.log
+
+private let logger = Logger(subsystem: "com.wallnetic.app", category: "BatteryPrompt")
+
+/// Presents the battery-mode prompt (#172) and tracks per-session / persistent
+/// overrides so the user can choose to keep the live wallpaper running on
+/// battery power.
+final class BatteryPromptService {
+    static let shared = BatteryPromptService()
+
+    // MARK: - UserDefaults keys
+
+    private let promptEnabledKey = "batteryPromptEnabled"
+    private let defaultChoiceKey = "batteryPromptDefaultChoice"  // "pause" | "continue"
+    /// Exposed in Settings. When true, bypasses the battery pause entirely.
+    static let alwaysPlayKey = "alwaysPlayOnBattery"
+
+    private let defaults = UserDefaults.standard
+
+    // MARK: - Session state (reset on relaunch)
+
+    private(set) var hasAskedThisSession = false
+    private(set) var sessionContinueOnBattery = false
+
+    enum Trigger { case launch, runtime }
+
+    private init() {}
+
+    // MARK: - Persistent preferences
+
+    var isPromptEnabled: Bool {
+        defaults.object(forKey: promptEnabledKey) as? Bool ?? true
+    }
+
+    var savedDefaultChoice: String? {
+        defaults.string(forKey: defaultChoiceKey)
+    }
+
+    var alwaysPlayOnBattery: Bool {
+        get { defaults.bool(forKey: Self.alwaysPlayKey) }
+        set { defaults.set(newValue, forKey: Self.alwaysPlayKey) }
+    }
+
+    func resetPreferences() {
+        defaults.removeObject(forKey: promptEnabledKey)
+        defaults.removeObject(forKey: defaultChoiceKey)
+        defaults.removeObject(forKey: Self.alwaysPlayKey)
+        hasAskedThisSession = false
+        sessionContinueOnBattery = false
+    }
+
+    // MARK: - Effective state (consumed by PowerManager)
+
+    /// Should playback be paused on battery, factoring in session and
+    /// persistent overrides? Returns false when the user has opted to keep
+    /// the wallpaper running on battery.
+    var effectivePauseOnBattery: Bool {
+        if alwaysPlayOnBattery { return false }
+        if sessionContinueOnBattery { return false }
+        if savedDefaultChoice == "continue" { return false }
+        return WallpaperManager.shared.pauseOnBattery
+    }
+
+    // MARK: - Prompt triggers
+
+    /// Called from AppDelegate on launch. If we're already on battery and the
+    /// user hasn't silenced the prompt, show the alert.
+    func checkOnLaunch() {
+        guard PowerManager.shared.isOnBattery else { return }
+        guard WallpaperManager.shared.pauseOnBattery else { return }
+        askIfNeeded(trigger: .launch)
+    }
+
+    /// Called by PowerManager when the power source flips from AC to battery.
+    func onSwitchedToBattery() {
+        guard WallpaperManager.shared.pauseOnBattery else { return }
+        askIfNeeded(trigger: .runtime)
+    }
+
+    // MARK: - Private
+
+    private func askIfNeeded(trigger: Trigger) {
+        guard !hasAskedThisSession else { return }
+
+        // User flipped the Settings toggle — no prompt, silently continue.
+        if alwaysPlayOnBattery {
+            hasAskedThisSession = true
+            applyChoice("continue")
+            return
+        }
+
+        if !isPromptEnabled, let choice = savedDefaultChoice {
+            logger.info("Applying saved battery choice silently: \(choice)")
+            hasAskedThisSession = true
+            applyChoice(choice)
+            return
+        }
+
+        hasAskedThisSession = true
+
+        DispatchQueue.main.async { [weak self] in
+            self?.showAlert(trigger: trigger)
+        }
+    }
+
+    private func showAlert(trigger: Trigger) {
+        let alert = NSAlert()
+        alert.messageText = "Pil modunda çalışıyor"
+        alert.informativeText = trigger == .launch
+            ? "Wallnetic pil ömrünü korumak için canlı duvar kağıdını duraklattı. Oynatmaya devam etmek ister misiniz?"
+            : "Şarj kablosu çıkarıldı. Pil ömrünü korumak için canlı duvar kağıdı duraklatıldı. Oynatmaya devam etmek ister misiniz?"
+        alert.alertStyle = .informational
+
+        alert.addButton(withTitle: "Canlı devam et")
+        alert.addButton(withTitle: "Pil koruyucu (duraklat)")
+
+        let rememberCheckbox = NSButton(
+            checkboxWithTitle: "Bir daha sorma",
+            target: nil,
+            action: nil
+        )
+        rememberCheckbox.state = .off
+        alert.accessoryView = rememberCheckbox
+
+        NSApp.activate(ignoringOtherApps: true)
+
+        let response = alert.runModal()
+        let choice: String = (response == .alertFirstButtonReturn) ? "continue" : "pause"
+
+        if rememberCheckbox.state == .on {
+            defaults.set(choice, forKey: defaultChoiceKey)
+            defaults.set(false, forKey: promptEnabledKey)
+            // Sync the Settings toggle so the user can see/change it later.
+            if choice == "continue" {
+                defaults.set(true, forKey: Self.alwaysPlayKey)
+            }
+            logger.info("User saved battery preference: \(choice)")
+        }
+
+        logger.info("User chose battery action: \(choice)")
+        applyChoice(choice)
+    }
+
+    private func applyChoice(_ choice: String) {
+        guard choice == "continue" else { return }
+        sessionContinueOnBattery = true
+
+        DispatchQueue.main.async {
+            WallpaperManager.shared.isPlaying = true
+            if let delegate = WallpaperManager.shared.playbackDelegate {
+                delegate.playbackPlay()
+            } else {
+                NotificationCenter.default.post(name: .playbackStateDidChange, object: true)
+            }
+        }
+    }
+}

--- a/src/Wallnetic/Services/NowPlayingManager.swift
+++ b/src/Wallnetic/Services/NowPlayingManager.swift
@@ -45,7 +45,12 @@ final class NowPlayingManager: ObservableObject {
 
     // MARK: - Framework Loading
 
+    /// MRMediaRemote is a private framework — loading it triggers App Store
+    /// static-analysis rejection. We gate the entire framework path behind
+    /// `#if DEBUG` so release builds rely solely on the public
+    /// `DistributedNotificationCenter` fallback (Apple Music + Spotify).
     private func loadFramework() {
+        #if DEBUG
         let url = URL(fileURLWithPath: "/System/Library/PrivateFrameworks/MediaRemote.framework")
         guard let bundle = CFBundleCreate(kCFAllocatorDefault, url as CFURL) else { return }
         self.bundle = bundle
@@ -62,9 +67,7 @@ final class NowPlayingManager: ObservableObject {
         if let ptr = CFBundleGetFunctionPointerForName(bundle, "MRMediaRemoteRegisterForNowPlayingNotifications" as CFString) {
             registerNotifications = unsafeBitCast(ptr, to: RegisterNotifications.self)
         }
-        if let ptr = CFBundleGetFunctionPointerForName(bundle, "MRMediaRemoteGetNowPlayingApplicationPIDAsString" as CFString) {
-            // We'll use app bundle approach instead
-        }
+        #endif
     }
 
     // MARK: - Start / Stop
@@ -74,6 +77,7 @@ final class NowPlayingManager: ObservableObject {
         isEnabled = true
         consecutiveEmptyPolls = 0
 
+        #if DEBUG
         // Register for MRMediaRemote notifications (system-level).
         registerNotifications?(DispatchQueue.main)
         NotificationCenter.default.addObserver(
@@ -88,6 +92,7 @@ final class NowPlayingManager: ObservableObject {
             name: NSNotification.Name("kMRMediaRemoteNowPlayingApplicationIsPlayingDidChangeNotification"),
             object: nil
         )
+        #endif
 
         // Distributed notifications — always works, no signing required.
         let dnc = DistributedNotificationCenter.default()
@@ -96,11 +101,13 @@ final class NowPlayingManager: ObservableObject {
         dnc.addObserver(self, selector: #selector(spotifyInfoChanged(_:)),
                         name: NSNotification.Name("com.spotify.client.PlaybackStateChanged"), object: nil)
 
+        #if DEBUG
         // Slow poll as fallback for MRMediaRemote direct queries.
         pollMR()
         timer = Timer.scheduledTimer(withTimeInterval: 3.0, repeats: true) { [weak self] _ in
             self?.pollMR()
         }
+        #endif
     }
 
     func stop() {
@@ -114,6 +121,7 @@ final class NowPlayingManager: ObservableObject {
 
     // MARK: - MRMediaRemote notification callback
 
+    #if DEBUG
     @objc private func mrInfoDidChange() {
         pollMR()
     }
@@ -171,6 +179,7 @@ final class NowPlayingManager: ObservableObject {
             artwork = NSImage(data: data)
         }
     }
+    #endif
 
     // MARK: - Apple Music (distributed notification)
 
@@ -272,7 +281,21 @@ final class NowPlayingManager: ObservableObject {
         case previous = 5
     }
 
-    func togglePlayPause() { _ = sendCommand?(Command.togglePlayPause.rawValue, nil) }
-    func next() { _ = sendCommand?(Command.next.rawValue, nil) }
-    func previous() { _ = sendCommand?(Command.previous.rawValue, nil) }
+    func togglePlayPause() {
+        #if DEBUG
+        _ = sendCommand?(Command.togglePlayPause.rawValue, nil)
+        #endif
+    }
+
+    func next() {
+        #if DEBUG
+        _ = sendCommand?(Command.next.rawValue, nil)
+        #endif
+    }
+
+    func previous() {
+        #if DEBUG
+        _ = sendCommand?(Command.previous.rawValue, nil)
+        #endif
+    }
 }

--- a/src/Wallnetic/Services/WallpaperLibrary.swift
+++ b/src/Wallnetic/Services/WallpaperLibrary.swift
@@ -42,10 +42,15 @@ final class WallpaperLibrary {
 
     /// Imports a video file into the library. Returns the new library-local URL.
     func importFile(from sourceURL: URL, existingWallpapers: [Wallpaper]) async throws -> URL {
-        // Duplicate detection
+        // Duplicate detection by exact file path component + byte size. Name
+        // matching uses the on-disk filename (not the display name, which can
+        // be customized by the user) to avoid false positives.
         let sourceSize = (try? fileManager.attributesOfItem(atPath: sourceURL.path))?[.size] as? Int64 ?? 0
-        let sourceName = sourceURL.deletingPathExtension().lastPathComponent
-        if let dup = existingWallpapers.first(where: { $0.fileSize == sourceSize && $0.name == sourceName }) {
+        let sourceFilename = sourceURL.deletingPathExtension().lastPathComponent
+        if let dup = existingWallpapers.first(where: {
+            $0.fileSize == sourceSize
+            && $0.url.deletingPathExtension().lastPathComponent == sourceFilename
+        }) {
             throw WallpaperImportError.duplicate(dup.name)
         }
 

--- a/src/Wallnetic/Services/WallpaperLibrary.swift
+++ b/src/Wallnetic/Services/WallpaperLibrary.swift
@@ -1,0 +1,108 @@
+import Foundation
+import os.log
+
+/// Handles all file-system operations for the wallpaper library:
+/// loading, importing, removing, duplicate detection, directory watching.
+final class WallpaperLibrary {
+    static let shared = WallpaperLibrary()
+
+    private let fileManager = FileManager.default
+
+    /// Resolved once — avoids FileManager I/O on every call.
+    lazy var libraryURL: URL = {
+        let appSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let dir = appSupport.appendingPathComponent("Wallnetic/Library", isDirectory: true)
+        if !fileManager.fileExists(atPath: dir.path) {
+            try? fileManager.createDirectory(at: dir, withIntermediateDirectories: true)
+        }
+        return dir
+    }()
+
+    private var fileWatcher: DispatchSourceFileSystemObject?
+
+    private init() {}
+
+    // MARK: - Load
+
+    /// Scans the library directory and returns raw wallpaper objects.
+    func loadAll(favoritePaths: Set<String>) -> [Wallpaper] {
+        guard let contents = try? fileManager.contentsOfDirectory(
+            at: libraryURL,
+            includingPropertiesForKeys: [.contentTypeKey],
+            options: .skipsHiddenFiles
+        ) else { return [] }
+
+        return contents.compactMap { url in
+            guard isVideoFile(url) else { return nil }
+            return Wallpaper(url: url, isFavorite: favoritePaths.contains(url.path))
+        }
+    }
+
+    // MARK: - Import
+
+    /// Imports a video file into the library. Returns the new library-local URL.
+    func importFile(from sourceURL: URL, existingWallpapers: [Wallpaper]) async throws -> URL {
+        // Duplicate detection
+        let sourceSize = (try? fileManager.attributesOfItem(atPath: sourceURL.path))?[.size] as? Int64 ?? 0
+        let sourceName = sourceURL.deletingPathExtension().lastPathComponent
+        if let dup = existingWallpapers.first(where: { $0.fileSize == sourceSize && $0.name == sourceName }) {
+            throw WallpaperImportError.duplicate(dup.name)
+        }
+
+        // Convert non-native formats to MP4
+        var importURL = sourceURL
+        if VideoFormatConverter.shared.needsConversion(sourceURL) {
+            importURL = try await VideoFormatConverter.shared.convertToMP4(source: sourceURL)
+        }
+
+        let originalName = sourceURL.deletingPathExtension().lastPathComponent
+        let fileName = originalName + ".mp4"
+        let destURL = libraryURL.appendingPathComponent(fileName)
+
+        if fileManager.fileExists(atPath: destURL.path) {
+            let uniqueName = UUID().uuidString + "_" + fileName
+            let uniqueURL = libraryURL.appendingPathComponent(uniqueName)
+            try fileManager.copyItem(at: importURL, to: uniqueURL)
+            return uniqueURL
+        } else {
+            try fileManager.copyItem(at: importURL, to: destURL)
+            return destURL
+        }
+    }
+
+    // MARK: - Remove
+
+    func removeFile(at url: URL) {
+        try? fileManager.removeItem(at: url)
+    }
+
+    // MARK: - File Watching
+
+    /// Starts monitoring the library folder. Calls `onChange` on the main queue.
+    func startWatching(onChange: @escaping () -> Void) {
+        let fd = open(libraryURL.path, O_EVTONLY)
+        guard fd >= 0 else { return }
+
+        let source = DispatchSource.makeFileSystemObjectSource(
+            fileDescriptor: fd,
+            eventMask: [.write, .rename, .delete],
+            queue: .main
+        )
+        source.setEventHandler { onChange() }
+        source.setCancelHandler { close(fd) }
+        source.resume()
+        fileWatcher = source
+    }
+
+    func stopWatching() {
+        fileWatcher?.cancel()
+        fileWatcher = nil
+    }
+
+    // MARK: - Helpers
+
+    func isVideoFile(_ url: URL) -> Bool {
+        let videoExtensions = ["mp4", "mov", "m4v", "hevc"]
+        return videoExtensions.contains(url.pathExtension.lowercased())
+    }
+}

--- a/src/Wallnetic/Services/WallpaperManager.swift
+++ b/src/Wallnetic/Services/WallpaperManager.swift
@@ -32,7 +32,18 @@ enum WallpaperMode: String, CaseIterable {
     }
 }
 
-/// Central manager for wallpaper state and settings
+/// Receives playback commands directly instead of through NotificationCenter.
+protocol PlaybackDelegate: AnyObject {
+    func playbackSetWallpaper(url: URL)
+    func playbackSetWallpaper(url: URL, for screen: NSScreen)
+    func playbackPlay()
+    func playbackPause()
+    func playbackApplyScreenWallpapers()
+}
+
+/// Central coordinator for wallpaper state and settings.
+/// Delegates file I/O to WallpaperLibrary, metadata to WallpaperMetadataStore,
+/// and widget sync to WidgetSyncService.
 class WallpaperManager: ObservableObject {
     static let shared = WallpaperManager()
 
@@ -46,7 +57,8 @@ class WallpaperManager: ObservableObject {
     /// Per-screen wallpaper assignments (screenName -> wallpaperID)
     @Published var screenWallpapers: [String: UUID] = [:]
 
-    // Settings
+    // MARK: - Settings
+
     @AppStorage("launchAtLogin") var launchAtLogin: Bool = false
     @AppStorage("pauseOnBattery") var pauseOnBattery: Bool = true
     @AppStorage("pauseOnFullscreen") var pauseOnFullscreen: Bool = true
@@ -57,53 +69,38 @@ class WallpaperManager: ObservableObject {
     @AppStorage("transitionStyle") var transitionStyle: String = "crossfade"
     @AppStorage("transitionDuration") var transitionDuration: Double = 0.5
     @AppStorage("lastWallpaperURL") private var lastWallpaperURL: String = ""
-    @AppStorage("favoriteWallpaperPaths") private var favoriteWallpaperPaths: String = ""
-    @AppStorage("customWallpaperTitles") private var customWallpaperTitlesData: String = ""
-    @AppStorage("wallpaperColors") private var wallpaperColorsData: String = ""
-    @AppStorage("wallpaperTags") private var wallpaperTagsData: String = ""
 
-    // MARK: - Properties
+    // MARK: - Delegates & Services
 
-    private let fileManager = FileManager.default
+    /// Set by AppDelegate to receive direct playback commands (#170).
+    weak var playbackDelegate: PlaybackDelegate?
 
-    private var libraryURL: URL {
-        let appSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-        let wallneticDir = appSupport.appendingPathComponent("Wallnetic/Library", isDirectory: true)
-
-        // Create directory if needed
-        if !fileManager.fileExists(atPath: wallneticDir.path) {
-            try? fileManager.createDirectory(at: wallneticDir, withIntermediateDirectories: true)
-        }
-
-        return wallneticDir
-    }
+    private let library = WallpaperLibrary.shared
+    private let metadata = WallpaperMetadataStore.shared
+    private let widgetSync = WidgetSyncService.shared
 
     // MARK: - Initialization
-
-    private var fileWatcher: DispatchSourceFileSystemObject?
 
     private init() {
         loadWallpapers()
         loadSettings()
         syncToWidget()
-        startFileWatching()
+        library.startWatching { [weak self] in
+            self?.loadWallpapers()
+        }
     }
 
-    /// Load persisted settings
     private func loadSettings() {
-        // Load wallpaper mode
         if let mode = WallpaperMode(rawValue: wallpaperModeRaw) {
             wallpaperMode = mode
         }
 
-        // Load per-screen wallpaper assignments
         if !screenWallpapersData.isEmpty {
             if let decoded = try? JSONDecoder().decode([String: UUID].self, from: screenWallpapersData) {
                 screenWallpapers = decoded
             }
         }
 
-        // Restore last wallpaper after a short delay (to ensure wallpapers are loaded)
         if !lastWallpaperURL.isEmpty {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
                 self?.restoreLastWallpaper()
@@ -111,29 +108,20 @@ class WallpaperManager: ObservableObject {
         }
     }
 
-    /// Restore the last selected wallpaper
     private func restoreLastWallpaper() {
         guard !lastWallpaperURL.isEmpty else { return }
-
         let url = URL(fileURLWithPath: lastWallpaperURL)
-
-        // Find the wallpaper in our library
         if let wallpaper = wallpapers.first(where: { $0.url.path == url.path }) {
-            NSLog("[WallpaperManager] Restoring last wallpaper: %@", wallpaper.name)
             setWallpaper(wallpaper)
-
-            // Auto-play after restore
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
                 self?.isPlaying = true
-                NotificationCenter.default.post(
-                    name: .playbackStateDidChange,
-                    object: true
-                )
+                self?.playbackDelegate?.playbackPlay()
+                // Keep notification for broadcast consumers (widget, etc.)
+                NotificationCenter.default.post(name: .playbackStateDidChange, object: true)
             }
         }
     }
 
-    /// Save per-screen wallpaper assignments
     private func saveScreenWallpapers() {
         if let encoded = try? JSONEncoder().encode(screenWallpapers) {
             screenWallpapersData = encoded
@@ -142,329 +130,111 @@ class WallpaperManager: ObservableObject {
 
     // MARK: - Library Management
 
-    /// Gets the set of favorite wallpaper paths
-    private var favoritePaths: Set<String> {
-        get {
-            Set(favoriteWallpaperPaths.split(separator: "\n").map(String.init))
-        }
-        set {
-            favoriteWallpaperPaths = newValue.joined(separator: "\n")
-        }
-    }
-
-    /// Loads all wallpapers from the library directory
     func loadWallpapers() {
-        wallpapers = []
-        let savedFavorites = favoritePaths
+        let favPaths = metadata.favoritePaths
+        wallpapers = library.loadAll(favoritePaths: favPaths)
 
-        guard let contents = try? fileManager.contentsOfDirectory(
-            at: libraryURL,
-            includingPropertiesForKeys: [.contentTypeKey],
-            options: .skipsHiddenFiles
-        ) else { return }
+        metadata.applyCustomTitles(to: &wallpapers)
+        metadata.applySavedColors(to: &wallpapers)
+        metadata.applySavedTags(to: &wallpapers)
 
-        for url in contents {
-            if isVideoFile(url) {
-                let isFavorite = savedFavorites.contains(url.path)
-                let wallpaper = Wallpaper(url: url, isFavorite: isFavorite)
-                wallpapers.append(wallpaper)
-            }
-        }
-
-        // Apply saved custom titles, colors, and tags
-        applyCustomTitles()
-        applySavedColors()
-        applySavedTags()
-
-        print("Loaded \(wallpapers.count) wallpapers from library (\(savedFavorites.count) favorites)")
-
-        // Load metadata and extract colors in background
         loadMetadataInBackground()
         extractMissingColors()
     }
 
-    /// Checks if a file is a duplicate of an existing library item (by file size + name)
     func isDuplicate(of sourceURL: URL) -> Wallpaper? {
-        let sourceSize = (try? fileManager.attributesOfItem(atPath: sourceURL.path))?[.size] as? Int64 ?? 0
+        let sourceSize = (try? FileManager.default.attributesOfItem(atPath: sourceURL.path))?[.size] as? Int64 ?? 0
         let sourceName = sourceURL.deletingPathExtension().lastPathComponent
         return wallpapers.first { $0.fileSize == sourceSize && $0.name == sourceName }
     }
 
-    /// Imports a video file into the library (supports GIF, WebM, WebP with auto-conversion)
     func importVideo(from sourceURL: URL) async throws -> Wallpaper {
-        print("[WallpaperManager] Importing video from: \(sourceURL.path)")
-
-        // Duplicate detection
-        if let existing = isDuplicate(of: sourceURL) {
-            NSLog("[WallpaperManager] Duplicate detected: %@ matches %@", sourceURL.lastPathComponent, existing.name)
-            throw WallpaperImportError.duplicate(existing.name)
+        let destURL = try await library.importFile(from: sourceURL, existingWallpapers: wallpapers)
+        let wallpaper = Wallpaper(url: destURL)
+        await MainActor.run {
+            wallpapers.append(wallpaper)
         }
-
-        // Convert non-native formats (GIF, WebM, WebP) to MP4
-        var importURL = sourceURL
-        if VideoFormatConverter.shared.needsConversion(sourceURL) {
-            NSLog("[WallpaperManager] Converting %@ to MP4...", sourceURL.pathExtension)
-            importURL = try await VideoFormatConverter.shared.convertToMP4(source: sourceURL)
-        }
-
-        let originalName = sourceURL.deletingPathExtension().lastPathComponent
-        let fileName = originalName + ".mp4"
-        let destURL = libraryURL.appendingPathComponent(fileName)
-
-        // Check if file already exists
-        if fileManager.fileExists(atPath: destURL.path) {
-            // Generate unique name
-            let uniqueName = UUID().uuidString + "_" + fileName
-            let uniqueURL = libraryURL.appendingPathComponent(uniqueName)
-            print("[WallpaperManager] File exists, using unique name: \(uniqueName)")
-            try fileManager.copyItem(at: importURL, to: uniqueURL)
-            print("[WallpaperManager] File copied successfully to: \(uniqueURL.path)")
-
-            let wallpaper = Wallpaper(url: uniqueURL)
-            await MainActor.run {
-                wallpapers.append(wallpaper)
-                print("[WallpaperManager] Wallpaper added to library. Total count: \(wallpapers.count)")
-            }
-            postImportProcess(wallpaper)
-            return wallpaper
-        } else {
-            try fileManager.copyItem(at: importURL, to: destURL)
-            print("[WallpaperManager] File copied successfully to: \(destURL.path)")
-
-            let wallpaper = Wallpaper(url: destURL)
-            await MainActor.run {
-                wallpapers.append(wallpaper)
-                print("[WallpaperManager] Wallpaper added to library. Total count: \(wallpapers.count)")
-            }
-            postImportProcess(wallpaper)
-            return wallpaper
-        }
+        postImportProcess(wallpaper)
+        return wallpaper
     }
 
-    /// Pre-generate thumbnails and extract color after import
     private func postImportProcess(_ wallpaper: Wallpaper) {
         Task {
-            // Pre-generate both common thumbnail sizes
             _ = await wallpaper.generateThumbnail(size: CGSize(width: 320, height: 180))
             _ = await wallpaper.generateThumbnail(size: CGSize(width: 160, height: 90))
 
-            // Extract dominant color
             if let hex = await wallpaper.extractDominantColor() {
                 await MainActor.run {
                     if let idx = wallpapers.firstIndex(where: { $0.id == wallpaper.id }) {
                         wallpapers[idx].dominantColorHex = hex
-                        var colors = savedColors
+                        var colors = metadata.savedColors
                         colors[wallpaper.url.path] = hex
-                        savedColors = colors
+                        metadata.savedColors = colors
                     }
                 }
             }
         }
     }
 
-    /// Removes a wallpaper from the library
     func removeWallpaper(_ wallpaper: Wallpaper) {
-        try? fileManager.removeItem(at: wallpaper.url)
+        library.removeFile(at: wallpaper.url)
         wallpapers.removeAll { $0.id == wallpaper.id }
-
         if currentWallpaper?.id == wallpaper.id {
             currentWallpaper = nil
         }
-
-        // Update saved favorites
-        saveFavoritePaths()
-
-        // Sync to widget
-        Task {
-            await syncFavoritesToWidget()
-    
-        }
+        metadata.saveFavorites(from: wallpapers)
+        Task { await widgetSync.syncFavorites(wallpapers.filter { $0.isFavorite }) }
     }
 
-    /// Renames a wallpaper (sets custom display title)
     func renameWallpaper(_ wallpaper: Wallpaper, to newTitle: String) {
         if let index = wallpapers.firstIndex(where: { $0.id == wallpaper.id }) {
             let trimmed = newTitle.trimmingCharacters(in: .whitespacesAndNewlines)
             wallpapers[index].customTitle = trimmed.isEmpty ? nil : trimmed
-            saveCustomTitles()
-
-            // Update widget if this is the current wallpaper
+            metadata.saveCustomTitles(from: wallpapers)
             if currentWallpaper?.id == wallpaper.id {
                 currentWallpaper = wallpapers[index]
-                Task { await syncCurrentWallpaperToWidget() }
+                Task { await widgetSync.syncCurrentWallpaper(currentWallpaper) }
             }
         }
     }
 
-    /// Toggles favorite status for a wallpaper
     func toggleFavorite(_ wallpaper: Wallpaper) {
         if let index = wallpapers.firstIndex(where: { $0.id == wallpaper.id }) {
             wallpapers[index].isFavorite.toggle()
-
-            // Keep currentWallpaper in sync
             if currentWallpaper?.id == wallpaper.id {
                 currentWallpaper = wallpapers[index]
             }
-
-            // Save favorite paths to persist across launches
-            saveFavoritePaths()
-
-            // Sync favorites to widget
-            Task {
-                await syncFavoritesToWidget()
-        
-            }
-        }
-    }
-
-    /// Saves favorite wallpaper paths to UserDefaults
-    private func saveFavoritePaths() {
-        let paths = wallpapers.filter { $0.isFavorite }.map { $0.url.path }
-        favoritePaths = Set(paths)
-        NSLog("[WallpaperManager] Saved %d favorite paths", paths.count)
-    }
-
-    // MARK: - Custom Titles Persistence
-
-    /// Path → custom title mapping
-    private var customTitles: [String: String] {
-        get {
-            guard !customWallpaperTitlesData.isEmpty,
-                  let data = customWallpaperTitlesData.data(using: .utf8),
-                  let dict = try? JSONDecoder().decode([String: String].self, from: data)
-            else { return [:] }
-            return dict
-        }
-        set {
-            if let data = try? JSONEncoder().encode(newValue),
-               let str = String(data: data, encoding: .utf8) {
-                customWallpaperTitlesData = str
-            }
-        }
-    }
-
-    /// Saves custom titles to UserDefaults
-    private func saveCustomTitles() {
-        var titles: [String: String] = [:]
-        for wp in wallpapers where wp.customTitle != nil {
-            titles[wp.url.path] = wp.customTitle
-        }
-        customTitles = titles
-    }
-
-    /// Applies saved custom titles after loading wallpapers
-    private func applyCustomTitles() {
-        let titles = customTitles
-        guard !titles.isEmpty else { return }
-        for i in wallpapers.indices {
-            if let title = titles[wallpapers[i].url.path] {
-                wallpapers[i].customTitle = title
-            }
-        }
-    }
-
-    // MARK: - Dominant Color Persistence
-
-    private var savedColors: [String: String] {
-        get {
-            guard !wallpaperColorsData.isEmpty,
-                  let data = wallpaperColorsData.data(using: .utf8),
-                  let dict = try? JSONDecoder().decode([String: String].self, from: data)
-            else { return [:] }
-            return dict
-        }
-        set {
-            if let data = try? JSONEncoder().encode(newValue),
-               let str = String(data: data, encoding: .utf8) {
-                wallpaperColorsData = str
-            }
-        }
-    }
-
-    private func applySavedColors() {
-        let colors = savedColors
-        guard !colors.isEmpty else { return }
-        for i in wallpapers.indices {
-            if let hex = colors[wallpapers[i].url.path] {
-                wallpapers[i].dominantColorHex = hex
-            }
-        }
-    }
-
-    /// Extract colors for wallpapers that don't have one yet
-    func extractMissingColors() {
-        Task {
-            var updatedColors = savedColors
-            for i in wallpapers.indices where wallpapers[i].dominantColorHex == nil {
-                if let hex = await wallpapers[i].extractDominantColor() {
-                    await MainActor.run {
-                        wallpapers[i].dominantColorHex = hex
-                    }
-                    updatedColors[wallpapers[i].url.path] = hex
-                }
-            }
-            await MainActor.run {
-                savedColors = updatedColors
-            }
+            metadata.saveFavorites(from: wallpapers)
+            Task { await widgetSync.syncFavorites(wallpapers.filter { $0.isFavorite }) }
         }
     }
 
     // MARK: - Tags
 
-    private var savedTags: [String: [String]] {
-        get {
-            guard !wallpaperTagsData.isEmpty,
-                  let data = wallpaperTagsData.data(using: .utf8),
-                  let dict = try? JSONDecoder().decode([String: [String]].self, from: data)
-            else { return [:] }
-            return dict
-        }
-        set {
-            if let data = try? JSONEncoder().encode(newValue),
-               let str = String(data: data, encoding: .utf8) {
-                wallpaperTagsData = str
-            }
-        }
-    }
-
-    private func applySavedTags() {
-        let tags = savedTags
-        guard !tags.isEmpty else { return }
-        for i in wallpapers.indices {
-            if let t = tags[wallpapers[i].url.path] {
-                wallpapers[i].tags = t
-            }
-        }
-    }
-
-    /// Add a tag to a wallpaper
     func addTag(_ tag: String, to wallpaper: Wallpaper) {
         guard let index = wallpapers.firstIndex(where: { $0.id == wallpaper.id }) else { return }
         let trimmed = tag.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         guard !trimmed.isEmpty, !wallpapers[index].tags.contains(trimmed) else { return }
         wallpapers[index].tags.append(trimmed)
-        var all = savedTags
+        var all = metadata.savedTags
         all[wallpapers[index].url.path] = wallpapers[index].tags
-        savedTags = all
+        metadata.savedTags = all
     }
 
-    /// Remove a tag from a wallpaper
     func removeTag(_ tag: String, from wallpaper: Wallpaper) {
         guard let index = wallpapers.firstIndex(where: { $0.id == wallpaper.id }) else { return }
         wallpapers[index].tags.removeAll { $0 == tag }
-        var all = savedTags
+        var all = metadata.savedTags
         all[wallpapers[index].url.path] = wallpapers[index].tags
-        savedTags = all
+        metadata.savedTags = all
     }
 
-    /// All unique tags across library
     var allTags: [String] {
         Array(Set(wallpapers.flatMap { $0.tags })).sorted()
     }
 
     // MARK: - Fuzzy Search
 
-    /// Search wallpapers by name, tags, and fuzzy matching
     func searchWallpapers(query: String) -> [Wallpaper] {
         let q = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         guard !q.isEmpty else { return wallpapers }
@@ -473,17 +243,11 @@ class WallpaperManager: ObservableObject {
             .map { wp -> (Wallpaper, Int) in
                 var score = 0
                 let name = wp.displayName.lowercased()
-
-                // Exact match
                 if name == q { score += 100 }
-                // Contains
                 else if name.contains(q) { score += 70 }
-                // Tag match
                 if wp.tags.contains(q) { score += 80 }
                 if wp.tags.contains(where: { $0.contains(q) }) { score += 50 }
-                // Fuzzy: characters appear in order
                 if score == 0 { score = fuzzyScore(query: q, in: name) }
-
                 return (wp, score)
             }
             .filter { $0.1 > 0 }
@@ -495,7 +259,6 @@ class WallpaperManager: ObservableObject {
         var qi = query.startIndex
         var ti = text.startIndex
         var matched = 0
-
         while qi < query.endIndex && ti < text.endIndex {
             if query[qi] == text[ti] {
                 matched += 1
@@ -503,12 +266,10 @@ class WallpaperManager: ObservableObject {
             }
             ti = text.index(after: ti)
         }
-
-        // All chars matched in order → score based on match ratio
         return qi == query.endIndex ? max(10, matched * 30 / query.count) : 0
     }
 
-    // MARK: - Async Metadata Loading
+    // MARK: - Async Metadata
 
     private func loadMetadataInBackground() {
         Task {
@@ -527,205 +288,105 @@ class WallpaperManager: ObservableObject {
         }
     }
 
-    // MARK: - File Watching
-
-    private func startFileWatching() {
-        let fd = open(libraryURL.path, O_EVTONLY)
-        guard fd >= 0 else { return }
-
-        let source = DispatchSource.makeFileSystemObjectSource(
-            fileDescriptor: fd,
-            eventMask: [.write, .rename, .delete],
-            queue: .main
-        )
-
-        source.setEventHandler { [weak self] in
-            NSLog("[WallpaperManager] Library folder changed — reloading")
-            self?.loadWallpapers()
+    func extractMissingColors() {
+        Task {
+            var updatedColors = metadata.savedColors
+            for i in wallpapers.indices where wallpapers[i].dominantColorHex == nil {
+                if let hex = await wallpapers[i].extractDominantColor() {
+                    await MainActor.run {
+                        wallpapers[i].dominantColorHex = hex
+                    }
+                    updatedColors[wallpapers[i].url.path] = hex
+                }
+            }
+            await MainActor.run {
+                metadata.savedColors = updatedColors
+            }
         }
-
-        source.setCancelHandler {
-            close(fd)
-        }
-
-        source.resume()
-        fileWatcher = source
     }
 
     // MARK: - Playback
 
-    /// Sets wallpaper for all screens (same mode)
+    /// Sets wallpaper for all screens (same mode).
+    /// Uses PlaybackDelegate for direct call (#170), falls back to notification.
     func setWallpaper(_ wallpaper: Wallpaper) {
-        NSLog("[WallpaperManager] Setting wallpaper: %@", wallpaper.name)
         currentWallpaper = wallpaper
-
-        // Save for persistence
         lastWallpaperURL = wallpaper.url.path
-
-        // Auto-play when wallpaper is applied
         isPlaying = true
 
-        NotificationCenter.default.post(
-            name: .wallpaperDidChange,
-            object: wallpaper
-        )
+        if let delegate = playbackDelegate {
+            delegate.playbackSetWallpaper(url: wallpaper.url)
+            delegate.playbackPlay()
+        } else {
+            NotificationCenter.default.post(name: .wallpaperDidChange, object: wallpaper)
+            NotificationCenter.default.post(name: .playbackStateDidChange, object: true)
+        }
 
-        // Ensure playback state is synced
-        NotificationCenter.default.post(
-            name: .playbackStateDidChange,
-            object: true
-        )
-
-        // Sync to widget
         Task {
-            await syncCurrentWallpaperToWidget()
-            syncPlaybackStateToWidget()
+            await widgetSync.syncCurrentWallpaper(wallpaper)
+            widgetSync.syncPlaybackState(isPlaying: true)
         }
     }
 
-    /// Sets wallpaper for a specific screen (different mode)
+    /// Sets wallpaper for a specific screen (different mode).
     func setWallpaper(_ wallpaper: Wallpaper, for screen: NSScreen) {
         let screenName = screen.localizedName
-        NSLog("[WallpaperManager] Setting wallpaper '%@' for screen: %@", wallpaper.name, screenName)
-
         screenWallpapers[screenName] = wallpaper.id
         saveScreenWallpapers()
-
-        // Auto-play when wallpaper is applied
         isPlaying = true
 
-        NotificationCenter.default.post(
-            name: .screenWallpaperDidChange,
-            object: ScreenWallpaperInfo(wallpaper: wallpaper, screen: screen)
-        )
-
-        // Ensure playback state is synced
-        NotificationCenter.default.post(
-            name: .playbackStateDidChange,
-            object: true
-        )
+        if let delegate = playbackDelegate {
+            delegate.playbackSetWallpaper(url: wallpaper.url, for: screen)
+            delegate.playbackPlay()
+        } else {
+            NotificationCenter.default.post(
+                name: .screenWallpaperDidChange,
+                object: ScreenWallpaperInfo(wallpaper: wallpaper, screen: screen)
+            )
+            NotificationCenter.default.post(name: .playbackStateDidChange, object: true)
+        }
     }
 
-    /// Gets wallpaper for a specific screen
     func wallpaper(for screen: NSScreen) -> Wallpaper? {
         guard let wallpaperID = screenWallpapers[screen.localizedName] else {
-            return currentWallpaper // Fallback to global wallpaper
+            return currentWallpaper
         }
         return wallpapers.first { $0.id == wallpaperID }
     }
 
-    /// Sets wallpaper mode and applies changes
     func setWallpaperMode(_ mode: WallpaperMode) {
         wallpaperMode = mode
         wallpaperModeRaw = mode.rawValue
 
         if mode == .same, let wallpaper = currentWallpaper {
-            // Apply current wallpaper to all screens
-            NotificationCenter.default.post(
-                name: .wallpaperDidChange,
-                object: wallpaper
-            )
+            if let delegate = playbackDelegate {
+                delegate.playbackSetWallpaper(url: wallpaper.url)
+            } else {
+                NotificationCenter.default.post(name: .wallpaperDidChange, object: wallpaper)
+            }
         } else if mode == .different {
-            // Apply per-screen wallpapers
-            NotificationCenter.default.post(
-                name: .applyScreenWallpapers,
-                object: nil
-            )
+            if let delegate = playbackDelegate {
+                delegate.playbackApplyScreenWallpapers()
+            } else {
+                NotificationCenter.default.post(name: .applyScreenWallpapers, object: nil)
+            }
         }
     }
 
     func togglePlayback() {
         isPlaying.toggle()
-        NotificationCenter.default.post(
-            name: .playbackStateDidChange,
-            object: isPlaying
-        )
 
-        // Sync playback state to widget
-        syncPlaybackStateToWidget()
-
-    }
-
-    // MARK: - Helpers
-
-    private func isVideoFile(_ url: URL) -> Bool {
-        let videoExtensions = ["mp4", "mov", "m4v", "hevc"]
-        return videoExtensions.contains(url.pathExtension.lowercased())
-    }
-
-    /// All formats supported for import (including those that need conversion)
-    static let supportedImportExtensions = VideoFormatConverter.allSupportedFormats
-
-    // MARK: - Widget Integration
-
-    /// Syncs current state to widget via SharedDataManager
-    func syncToWidget() {
-        // Skip if no wallpaper loaded yet (will re-sync after restore)
-        guard currentWallpaper != nil else { return }
-
-        Task {
-            await syncCurrentWallpaperToWidget()
-            syncPlaybackStateToWidget()
-            await syncFavoritesToWidget()
-        }
-    }
-
-    /// Syncs current wallpaper to widget
-    private func syncCurrentWallpaperToWidget() async {
-        guard let wallpaper = currentWallpaper else {
-            SharedDataManager.shared.updateCurrentWallpaper(id: nil, name: nil, thumbnailPath: nil)
-            return
+        if let delegate = playbackDelegate {
+            isPlaying ? delegate.playbackPlay() : delegate.playbackPause()
+        } else {
+            NotificationCenter.default.post(name: .playbackStateDidChange, object: isPlaying)
         }
 
-        // Generate and save thumbnail
-        var thumbnailPath: String? = nil
-        if let thumbnail = await ThumbnailCache.shared.thumbnail(for: wallpaper.url, size: CGSize(width: 200, height: 120)) {
-            if let tiffData = thumbnail.tiffRepresentation,
-               let bitmapRep = NSBitmapImageRep(data: tiffData),
-               let jpegData = bitmapRep.representation(using: .jpeg, properties: [.compressionFactor: 0.7]) {
-                thumbnailPath = SharedDataManager.shared.saveThumbnail(data: jpegData, for: wallpaper.id)
-            }
-        }
-
-        SharedDataManager.shared.updateCurrentWallpaper(
-            id: wallpaper.id,
-            name: wallpaper.name,
-            thumbnailPath: thumbnailPath
-        )
+        widgetSync.syncPlaybackState(isPlaying: isPlaying)
     }
 
-    /// Syncs playback state to widget
-    private func syncPlaybackStateToWidget() {
-        SharedDataManager.shared.updatePlaybackState(isPlaying: isPlaying)
-    }
+    // MARK: - Navigation
 
-    /// Syncs favorite wallpapers to widget
-    private func syncFavoritesToWidget() async {
-        let favorites = wallpapers.filter { $0.isFavorite }
-        var widgetWallpapers: [SharedWidgetWallpaper] = []
-
-        for wallpaper in favorites.prefix(SharedConstants.maxFavorites) {
-            var thumbnailPath: String? = nil
-            if let thumbnail = await ThumbnailCache.shared.thumbnail(for: wallpaper.url, size: CGSize(width: 150, height: 90)) {
-                if let tiffData = thumbnail.tiffRepresentation,
-                   let bitmapRep = NSBitmapImageRep(data: tiffData),
-                   let jpegData = bitmapRep.representation(using: .jpeg, properties: [.compressionFactor: 0.6]) {
-                    thumbnailPath = SharedDataManager.shared.saveThumbnail(data: jpegData, for: wallpaper.id)
-                }
-            }
-
-            widgetWallpapers.append(SharedWidgetWallpaper(
-                id: wallpaper.id,
-                name: wallpaper.name,
-                thumbnailPath: thumbnailPath
-            ))
-        }
-
-        SharedDataManager.shared.updateFavoriteWallpapers(widgetWallpapers)
-        NSLog("[WallpaperManager] Synced %d favorites to widget", widgetWallpapers.count)
-    }
-
-    /// Cycles to the previous wallpaper in the library
     func cycleToPreviousWallpaper() {
         guard !wallpapers.isEmpty else { return }
         if let current = currentWallpaper,
@@ -737,17 +398,14 @@ class WallpaperManager: ObservableObject {
         }
     }
 
-    /// Sets a random wallpaper (different from current)
     func setRandomWallpaper() {
         let candidates = wallpapers.filter { $0.id != currentWallpaper?.id }
         guard let random = candidates.randomElement() else { return }
         setWallpaper(random)
     }
 
-    /// Cycles to the next wallpaper in the library
     func cycleToNextWallpaper() {
         guard !wallpapers.isEmpty else { return }
-
         if let current = currentWallpaper,
            let currentIndex = wallpapers.firstIndex(where: { $0.id == current.id }) {
             let nextIndex = (currentIndex + 1) % wallpapers.count
@@ -757,34 +415,30 @@ class WallpaperManager: ObservableObject {
         }
     }
 
+    // MARK: - Helpers
+
+    static let supportedImportExtensions = VideoFormatConverter.allSupportedFormats
+
+    // MARK: - Widget
+
+    func syncToWidget() {
+        guard currentWallpaper != nil else { return }
+        widgetSync.syncAll(current: currentWallpaper, isPlaying: isPlaying, wallpapers: wallpapers)
+    }
+
     /// Handles URL scheme from widget
     func handleWidgetURL(_ url: URL) {
-        NSLog("[WallpaperManager] handleWidgetURL: %@", url.absoluteString)
-
-        guard let (action, wallpaperID) = SharedDataManager.parseWidgetURL(url) else {
-            NSLog("[WallpaperManager] Failed to parse URL - scheme: %@, host: %@",
-                  url.scheme ?? "nil", url.host ?? "nil")
-            return
-        }
-
-        NSLog("[WallpaperManager] Parsed action: %@", action.rawValue)
+        guard let (action, wallpaperID) = SharedDataManager.parseWidgetURL(url) else { return }
 
         switch action {
         case .playPause:
-            NSLog("[WallpaperManager] Executing playPause")
             togglePlayback()
-
         case .setWallpaper:
             if let id = wallpaperID,
                let wallpaper = wallpapers.first(where: { $0.id == id }) {
-                NSLog("[WallpaperManager] Setting wallpaper: %@", wallpaper.name)
                 setWallpaper(wallpaper)
-            } else {
-                NSLog("[WallpaperManager] Wallpaper not found for ID: %@", wallpaperID?.uuidString ?? "nil")
             }
-
         case .nextWallpaper:
-            NSLog("[WallpaperManager] Cycling to next wallpaper")
             cycleToNextWallpaper()
         }
     }
@@ -802,7 +456,6 @@ extension Notification.Name {
 
 // MARK: - Screen Wallpaper Info
 
-/// Information about a per-screen wallpaper change
 struct ScreenWallpaperInfo {
     let wallpaper: Wallpaper
     let screen: NSScreen

--- a/src/Wallnetic/Services/WallpaperManager.swift
+++ b/src/Wallnetic/Services/WallpaperManager.swift
@@ -308,19 +308,19 @@ class WallpaperManager: ObservableObject {
     // MARK: - Playback
 
     /// Sets wallpaper for all screens (same mode).
-    /// Uses PlaybackDelegate for direct call (#170), falls back to notification.
+    /// PlaybackDelegate drives the renderer directly (#170); the broadcast
+    /// notification fans out to observers like DynamicIslandController and
+    /// ThemeManager that react to wallpaper changes.
     func setWallpaper(_ wallpaper: Wallpaper) {
         currentWallpaper = wallpaper
         lastWallpaperURL = wallpaper.url.path
         isPlaying = true
 
-        if let delegate = playbackDelegate {
-            delegate.playbackSetWallpaper(url: wallpaper.url)
-            delegate.playbackPlay()
-        } else {
-            NotificationCenter.default.post(name: .wallpaperDidChange, object: wallpaper)
-            NotificationCenter.default.post(name: .playbackStateDidChange, object: true)
-        }
+        playbackDelegate?.playbackSetWallpaper(url: wallpaper.url)
+        playbackDelegate?.playbackPlay()
+
+        NotificationCenter.default.post(name: .wallpaperDidChange, object: wallpaper)
+        NotificationCenter.default.post(name: .playbackStateDidChange, object: true)
 
         Task {
             await widgetSync.syncCurrentWallpaper(wallpaper)
@@ -335,16 +335,14 @@ class WallpaperManager: ObservableObject {
         saveScreenWallpapers()
         isPlaying = true
 
-        if let delegate = playbackDelegate {
-            delegate.playbackSetWallpaper(url: wallpaper.url, for: screen)
-            delegate.playbackPlay()
-        } else {
-            NotificationCenter.default.post(
-                name: .screenWallpaperDidChange,
-                object: ScreenWallpaperInfo(wallpaper: wallpaper, screen: screen)
-            )
-            NotificationCenter.default.post(name: .playbackStateDidChange, object: true)
-        }
+        playbackDelegate?.playbackSetWallpaper(url: wallpaper.url, for: screen)
+        playbackDelegate?.playbackPlay()
+
+        NotificationCenter.default.post(
+            name: .screenWallpaperDidChange,
+            object: ScreenWallpaperInfo(wallpaper: wallpaper, screen: screen)
+        )
+        NotificationCenter.default.post(name: .playbackStateDidChange, object: true)
     }
 
     func wallpaper(for screen: NSScreen) -> Wallpaper? {
@@ -359,28 +357,23 @@ class WallpaperManager: ObservableObject {
         wallpaperModeRaw = mode.rawValue
 
         if mode == .same, let wallpaper = currentWallpaper {
-            if let delegate = playbackDelegate {
-                delegate.playbackSetWallpaper(url: wallpaper.url)
-            } else {
-                NotificationCenter.default.post(name: .wallpaperDidChange, object: wallpaper)
-            }
+            playbackDelegate?.playbackSetWallpaper(url: wallpaper.url)
+            NotificationCenter.default.post(name: .wallpaperDidChange, object: wallpaper)
         } else if mode == .different {
-            if let delegate = playbackDelegate {
-                delegate.playbackApplyScreenWallpapers()
-            } else {
-                NotificationCenter.default.post(name: .applyScreenWallpapers, object: nil)
-            }
+            playbackDelegate?.playbackApplyScreenWallpapers()
+            NotificationCenter.default.post(name: .applyScreenWallpapers, object: nil)
         }
     }
 
     func togglePlayback() {
         isPlaying.toggle()
 
-        if let delegate = playbackDelegate {
-            isPlaying ? delegate.playbackPlay() : delegate.playbackPause()
+        if isPlaying {
+            playbackDelegate?.playbackPlay()
         } else {
-            NotificationCenter.default.post(name: .playbackStateDidChange, object: isPlaying)
+            playbackDelegate?.playbackPause()
         }
+        NotificationCenter.default.post(name: .playbackStateDidChange, object: isPlaying)
 
         widgetSync.syncPlaybackState(isPlaying: isPlaying)
     }

--- a/src/Wallnetic/Services/WallpaperMetadataStore.swift
+++ b/src/Wallnetic/Services/WallpaperMetadataStore.swift
@@ -122,7 +122,10 @@ final class WallpaperMetadataStore {
         guard !string.isEmpty,
               let data = string.data(using: .utf8),
               let decoded = try? JSONDecoder().decode(T.self, from: data)
-        else { return [:] as! T }
+        else {
+            let empty: T = [:]
+            return empty
+        }
         return decoded
     }
 

--- a/src/Wallnetic/Services/WallpaperMetadataStore.swift
+++ b/src/Wallnetic/Services/WallpaperMetadataStore.swift
@@ -1,0 +1,135 @@
+import Foundation
+import SwiftUI
+
+/// Persists wallpaper metadata (custom titles, colors, tags, favorites)
+/// via AppStorage-backed JSON strings with in-memory caching.
+final class WallpaperMetadataStore {
+    static let shared = WallpaperMetadataStore()
+
+    // MARK: - AppStorage backing (via UserDefaults)
+
+    @AppStorage("favoriteWallpaperPaths") private var favoriteWallpaperPaths: String = ""
+    @AppStorage("customWallpaperTitles") private var customWallpaperTitlesData: String = ""
+    @AppStorage("wallpaperColors") private var wallpaperColorsData: String = ""
+    @AppStorage("wallpaperTags") private var wallpaperTagsData: String = ""
+
+    // MARK: - In-memory caches (avoid repeated JSON decode)
+
+    private var _customTitles: [String: String]?
+    private var _savedColors: [String: String]?
+    private var _savedTags: [String: [String]]?
+
+    private init() {}
+
+    // MARK: - Favorites
+
+    var favoritePaths: Set<String> {
+        get { Set(favoriteWallpaperPaths.split(separator: "\n").map(String.init)) }
+        set { favoriteWallpaperPaths = newValue.joined(separator: "\n") }
+    }
+
+    func saveFavorites(from wallpapers: [Wallpaper]) {
+        let paths = wallpapers.filter { $0.isFavorite }.map { $0.url.path }
+        favoritePaths = Set(paths)
+    }
+
+    // MARK: - Custom Titles
+
+    var customTitles: [String: String] {
+        get {
+            if let cached = _customTitles { return cached }
+            let decoded = decodeJSON(customWallpaperTitlesData, as: [String: String].self)
+            _customTitles = decoded
+            return decoded
+        }
+        set {
+            _customTitles = newValue
+            customWallpaperTitlesData = encodeJSON(newValue)
+        }
+    }
+
+    func applyCustomTitles(to wallpapers: inout [Wallpaper]) {
+        let titles = customTitles
+        guard !titles.isEmpty else { return }
+        for i in wallpapers.indices {
+            if let title = titles[wallpapers[i].url.path] {
+                wallpapers[i].customTitle = title
+            }
+        }
+    }
+
+    func saveCustomTitles(from wallpapers: [Wallpaper]) {
+        var titles: [String: String] = [:]
+        for wp in wallpapers where wp.customTitle != nil {
+            titles[wp.url.path] = wp.customTitle
+        }
+        customTitles = titles
+    }
+
+    // MARK: - Dominant Colors
+
+    var savedColors: [String: String] {
+        get {
+            if let cached = _savedColors { return cached }
+            let decoded = decodeJSON(wallpaperColorsData, as: [String: String].self)
+            _savedColors = decoded
+            return decoded
+        }
+        set {
+            _savedColors = newValue
+            wallpaperColorsData = encodeJSON(newValue)
+        }
+    }
+
+    func applySavedColors(to wallpapers: inout [Wallpaper]) {
+        let colors = savedColors
+        guard !colors.isEmpty else { return }
+        for i in wallpapers.indices {
+            if let hex = colors[wallpapers[i].url.path] {
+                wallpapers[i].dominantColorHex = hex
+            }
+        }
+    }
+
+    // MARK: - Tags
+
+    var savedTags: [String: [String]] {
+        get {
+            if let cached = _savedTags { return cached }
+            let decoded = decodeJSON(wallpaperTagsData, as: [String: [String]].self)
+            _savedTags = decoded
+            return decoded
+        }
+        set {
+            _savedTags = newValue
+            wallpaperTagsData = encodeJSON(newValue)
+        }
+    }
+
+    func applySavedTags(to wallpapers: inout [Wallpaper]) {
+        let tags = savedTags
+        guard !tags.isEmpty else { return }
+        for i in wallpapers.indices {
+            if let t = tags[wallpapers[i].url.path] {
+                wallpapers[i].tags = t
+            }
+        }
+    }
+
+    // MARK: - Generic JSON helpers
+
+    private func decodeJSON<T: Decodable>(_ string: String, as type: T.Type) -> T where T: ExpressibleByDictionaryLiteral {
+        guard !string.isEmpty,
+              let data = string.data(using: .utf8),
+              let decoded = try? JSONDecoder().decode(T.self, from: data)
+        else { return [:] as! T }
+        return decoded
+    }
+
+    private func encodeJSON<T: Encodable>(_ value: T) -> String {
+        guard let data = try? JSONEncoder().encode(value),
+              let str = String(data: data, encoding: .utf8)
+        else { return "" }
+        return str
+    }
+}

--- a/src/Wallnetic/Services/WidgetSyncService.swift
+++ b/src/Wallnetic/Services/WidgetSyncService.swift
@@ -1,0 +1,74 @@
+import Foundation
+import AppKit
+
+/// Handles all widget synchronization: current wallpaper, playback state, favorites.
+final class WidgetSyncService {
+    static let shared = WidgetSyncService()
+
+    private init() {}
+
+    // MARK: - Sync All
+
+    func syncAll(current: Wallpaper?, isPlaying: Bool, wallpapers: [Wallpaper]) {
+        Task {
+            await syncCurrentWallpaper(current)
+            syncPlaybackState(isPlaying: isPlaying)
+            await syncFavorites(wallpapers.filter { $0.isFavorite })
+        }
+    }
+
+    // MARK: - Current Wallpaper
+
+    func syncCurrentWallpaper(_ wallpaper: Wallpaper?) async {
+        guard let wallpaper else {
+            SharedDataManager.shared.updateCurrentWallpaper(id: nil, name: nil, thumbnailPath: nil)
+            return
+        }
+
+        var thumbnailPath: String?
+        if let thumbnail = await ThumbnailCache.shared.thumbnail(for: wallpaper.url, size: CGSize(width: 200, height: 120)) {
+            if let tiffData = thumbnail.tiffRepresentation,
+               let bitmapRep = NSBitmapImageRep(data: tiffData),
+               let jpegData = bitmapRep.representation(using: .jpeg, properties: [.compressionFactor: 0.7]) {
+                thumbnailPath = SharedDataManager.shared.saveThumbnail(data: jpegData, for: wallpaper.id)
+            }
+        }
+
+        SharedDataManager.shared.updateCurrentWallpaper(
+            id: wallpaper.id,
+            name: wallpaper.name,
+            thumbnailPath: thumbnailPath
+        )
+    }
+
+    // MARK: - Playback State
+
+    func syncPlaybackState(isPlaying: Bool) {
+        SharedDataManager.shared.updatePlaybackState(isPlaying: isPlaying)
+    }
+
+    // MARK: - Favorites
+
+    func syncFavorites(_ favorites: [Wallpaper]) async {
+        var widgetWallpapers: [SharedWidgetWallpaper] = []
+
+        for wallpaper in favorites.prefix(SharedConstants.maxFavorites) {
+            var thumbnailPath: String?
+            if let thumbnail = await ThumbnailCache.shared.thumbnail(for: wallpaper.url, size: CGSize(width: 150, height: 90)) {
+                if let tiffData = thumbnail.tiffRepresentation,
+                   let bitmapRep = NSBitmapImageRep(data: tiffData),
+                   let jpegData = bitmapRep.representation(using: .jpeg, properties: [.compressionFactor: 0.6]) {
+                    thumbnailPath = SharedDataManager.shared.saveThumbnail(data: jpegData, for: wallpaper.id)
+                }
+            }
+
+            widgetWallpapers.append(SharedWidgetWallpaper(
+                id: wallpaper.id,
+                name: wallpaper.name,
+                thumbnailPath: thumbnailPath
+            ))
+        }
+
+        SharedDataManager.shared.updateFavoriteWallpapers(widgetWallpapers)
+    }
+}

--- a/src/Wallnetic/Views/Main/AudioVisualizerOverlayView.swift
+++ b/src/Wallnetic/Views/Main/AudioVisualizerOverlayView.swift
@@ -4,12 +4,30 @@ struct AudioVisualizerOverlayView: View {
     @EnvironmentObject var manager: AudioVisualizerManager
     @ObservedObject private var theme = ThemeManager.shared
 
+    // Cached accent RGB — avoids NSColor conversion every frame at 60fps.
+    @State private var accentRGB: (r: Double, g: Double, b: Double) = (0, 0, 0)
+
     var body: some View {
         Canvas(rendersAsynchronously: true) { ctx, size in
             draw(context: ctx, size: size)
         }
         .animation(.linear(duration: 1.0 / 60.0), value: manager.bands)
         .drawingGroup()
+        .onChange(of: theme.accentColor.description) { _ in
+            updateAccentRGB()
+        }
+        .onAppear {
+            updateAccentRGB()
+        }
+    }
+
+    private func updateAccentRGB() {
+        let ns = NSColor(theme.accentColor).usingColorSpace(.sRGB)
+        accentRGB = (
+            r: Double(ns?.redComponent ?? 0),
+            g: Double(ns?.greenComponent ?? 0),
+            b: Double(ns?.blueComponent ?? 0)
+        )
     }
 
     private func draw(context: GraphicsContext, size: CGSize) {
@@ -70,10 +88,9 @@ struct AudioVisualizerOverlayView: View {
         let maxTiles = max(1, Int(halfHeight / tilePitch))
         let centerGap: CGFloat = 1.5
 
-        let nsAccent = NSColor(accent).usingColorSpace(.sRGB)
-        let acR = Double(nsAccent?.redComponent ?? 0)
-        let acG = Double(nsAccent?.greenComponent ?? 0)
-        let acB = Double(nsAccent?.blueComponent ?? 0)
+        let acR = accentRGB.r
+        let acG = accentRGB.g
+        let acB = accentRGB.b
 
         for (i, value) in bands.enumerated() {
             let x = horizontalInset + CGFloat(i) * (barWidth + barSpacing)

--- a/src/Wallnetic/Views/Settings/SettingsSubViews.swift
+++ b/src/Wallnetic/Views/Settings/SettingsSubViews.swift
@@ -214,13 +214,22 @@ private struct AudioVisualizerSourcePicker: View {
 
 struct PlaybackSettingsView: View {
     @EnvironmentObject var wallpaperManager: WallpaperManager
+    @AppStorage(BatteryPromptService.alwaysPlayKey) private var alwaysPlayOnBattery: Bool = false
 
     var body: some View {
         Form {
             Section("Power Management") {
                 Toggle("Pause when on battery power", isOn: $wallpaperManager.pauseOnBattery)
+                Toggle("Always play on battery (skip prompt)", isOn: $alwaysPlayOnBattery)
+                    .disabled(!wallpaperManager.pauseOnBattery)
+                    .help("When enabled, the live wallpaper keeps playing on battery without asking.")
                 Toggle("Pause when fullscreen app is active", isOn: $wallpaperManager.pauseOnFullscreen)
                 Toggle("Auto-resume when conditions change", isOn: $wallpaperManager.shouldAutoResume)
+                Button("Reset battery prompt") {
+                    BatteryPromptService.shared.resetPreferences()
+                    alwaysPlayOnBattery = false
+                }
+                .help("Clears saved battery-mode choice so the prompt appears again.")
             }
             Section("Performance") {
                 Toggle("Use Metal Renderer", isOn: $wallpaperManager.useMetalRenderer)

--- a/src/Wallnetic/Views/Settings/SettingsSubViews.swift
+++ b/src/Wallnetic/Views/Settings/SettingsSubViews.swift
@@ -220,9 +220,10 @@ struct PlaybackSettingsView: View {
         Form {
             Section("Power Management") {
                 Toggle("Pause when on battery power", isOn: $wallpaperManager.pauseOnBattery)
+                    .help("When enabled, Wallnetic asks before pausing (or pauses silently if you opted out of the prompt).")
                 Toggle("Always play on battery (skip prompt)", isOn: $alwaysPlayOnBattery)
                     .disabled(!wallpaperManager.pauseOnBattery)
-                    .help("When enabled, the live wallpaper keeps playing on battery without asking.")
+                    .help("Overrides the pause: the live wallpaper keeps playing on battery without asking.")
                 Toggle("Pause when fullscreen app is active", isOn: $wallpaperManager.pauseOnFullscreen)
                 Toggle("Auto-resume when conditions change", isOn: $wallpaperManager.shouldAutoResume)
                 Button("Reset battery prompt") {

--- a/src/Wallnetic/Wallnetic.xcodeproj/project.pbxproj
+++ b/src/Wallnetic/Wallnetic.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		02D4C66A91485C3B8B1A4F2F /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = C788B7EDDB89E2E9EEB97E43 /* PrivacyInfo.xcprivacy */; };
 		04BCEB8AB6239A8DB7D5C257 /* StoreKitManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 102BCD8F05208BC14E211E51 /* StoreKitManager.swift */; };
 		0BDACCA44A26C7459739D96B /* DesktopWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EBFA2EC8B70298D0B7975E3 /* DesktopWindowController.swift */; };
 		0D0FFA07C32604C5448D9BD6 /* SpaceSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2958EEAF2DA16543DBA9453F /* SpaceSettingsView.swift */; };
@@ -223,6 +224,7 @@
 		C36C5B8FAAEBFAB779FBBB39 /* VideoRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoRenderer.swift; sourceTree = "<group>"; };
 		C46699BC859D4FABE71BB58F /* LargeWidgetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeWidgetView.swift; sourceTree = "<group>"; };
 		C649839F5BB66D43BA4A499A /* AudioVisualizerOverlayController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioVisualizerOverlayController.swift; sourceTree = "<group>"; };
+		C788B7EDDB89E2E9EEB97E43 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		D290998483830980DF7E2CD5 /* MLWDecryptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MLWDecryptor.swift; sourceTree = "<group>"; };
 		D67C4A956B32F37A83450264 /* ExploreView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExploreView.swift; sourceTree = "<group>"; };
 		D7053DA494AD1DB578C10447 /* MediumWidgetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediumWidgetView.swift; sourceTree = "<group>"; };
@@ -444,6 +446,7 @@
 			children = (
 				BF36E216B5F900C62E824B59 /* Assets.xcassets */,
 				843AD85E0F38C70B7B33DE40 /* Info.plist */,
+				C788B7EDDB89E2E9EEB97E43 /* PrivacyInfo.xcprivacy */,
 				85B6064EF5DE550677698666 /* Wallnetic.entitlements */,
 			);
 			path = Resources;
@@ -492,6 +495,7 @@
 			children = (
 				69A7F21804AB5D266A239578 /* WallneticWidget.swift */,
 				5B7028D3EA5A514573B5B23F /* WallneticWidgetBundle.swift */,
+				FE863A105B48E8483FA4105E /* Models */,
 				245B5B74A9E9F71A64F7454D /* Provider */,
 				4295B025FC1E253129AEE445 /* Resources */,
 				359372CAF80A53CFB75544F5 /* Views */,
@@ -581,9 +585,11 @@
 						ProvisioningStyle = Automatic;
 					};
 					619B21F5247512020263D942 = {
+						DevelopmentTeam = "";
 						ProvisioningStyle = Automatic;
 					};
 					9D9A6596302C548CCE03E80C = {
+						DevelopmentTeam = "";
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -615,6 +621,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				284D0925EA9AEC2B302910D1 /* Assets.xcassets in Resources */,
+				02D4C66A91485C3B8B1A4F2F /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -759,7 +766,6 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Resources/Wallnetic.entitlements;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -846,7 +852,6 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Resources/Wallnetic.entitlements;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -865,7 +870,6 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = ../WallneticWidget/Resources/WallneticWidget.entitlements;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = ../WallneticWidget/Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -902,7 +906,6 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = ../WallneticWidget/Resources/WallneticWidget.entitlements;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = ../WallneticWidget/Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/src/Wallnetic/Wallnetic.xcodeproj/project.pbxproj
+++ b/src/Wallnetic/Wallnetic.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		39C032EFB614D68ADAE9403B /* PexelsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65B960F4D2BFD36368F336A4 /* PexelsService.swift */; };
 		3ACABD266118F70AA54B934B /* ThemeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60D80208B9C31066D6C112FB /* ThemeManager.swift */; };
 		3D0DEC82756E9F587DEEA843 /* PixabayService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 689367BF56D29B65CDDB02F2 /* PixabayService.swift */; };
+		3F705E631F7827AD76411878 /* WallpaperMetadataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0F9B4893FCEA17EEFC7550A /* WallpaperMetadataStore.swift */; };
 		40D40FD944D13CCAF633E4A9 /* Wallpaper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3FD865C09D4CE6C4025020 /* Wallpaper.swift */; };
 		42AF0F91E2BE36A155243433 /* LockScreenManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E4377C1CA7A41D21A10FC40 /* LockScreenManager.swift */; };
 		4D244E609DA6FBD637CD7D8F /* WallneticApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D9A31C3562655D7C27A30B1 /* WallneticApp.swift */; };
@@ -39,8 +40,10 @@
 		56536B0F8F2E2B9076BA08EE /* WallneticWidget.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 594B87C7E7B68A1E23F136C4 /* WallneticWidget.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		5C0AAD3B25B3DCB797AF2959 /* ExploreView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D67C4A956B32F37A83450264 /* ExploreView.swift */; };
 		5E298128B4AE9AB89B656E86 /* DesktopOverlayController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D726427A9199C4D93B9E93F2 /* DesktopOverlayController.swift */; };
+		61773D343F4EBEEB12FF8AFB /* BatteryPromptService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0187521E8CC2C0BB29CE90D /* BatteryPromptService.swift */; };
 		61B1EC0DBC85801311FA1F2F /* MenuBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B106464A071BF6E736C3272 /* MenuBarView.swift */; };
 		6A650CD75C4B32AB9889A6A7 /* SharedWidgetModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDFCAB2A636011BB543DD1B5 /* SharedWidgetModels.swift */; };
+		6B3FA8945F430A067CC4DB4D /* WallpaperLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F557952B625823A2689EBE7 /* WallpaperLibrary.swift */; };
 		6FDE90B9E751CC319C45BA54 /* MusicReactiveManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F48518E41B9C56DFE5EB099 /* MusicReactiveManager.swift */; };
 		71B0E8B741F75A6147C62611 /* MetalVideoRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED806BD7E0913BCDF1142604 /* MetalVideoRenderer.swift */; };
 		71CE2A10CE71B016228E091D /* SchedulerSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DF980A4142FBBE468FBBD05 /* SchedulerSettingsView.swift */; };
@@ -66,6 +69,7 @@
 		A2F0F37DC65A20D1B7086146 /* UsageTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA624026F461BCF47C3E39D5 /* UsageTracker.swift */; };
 		A2FD8BF6EF09FC0B086E2261 /* EffectsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2392B868E0D5B6994FF657 /* EffectsSettingsView.swift */; };
 		A32F6B39A4F02F8417A78266 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 250C1B481393050C099266A2 /* SettingsView.swift */; };
+		A978B328492C6EE503BC91E3 /* WidgetSyncService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0990FC999E1DE89A3D776B05 /* WidgetSyncService.swift */; };
 		AC7FBC93D689C03ADF1AEDF5 /* AudioVisualizerOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C858C83BC8D22A21A53D7BD /* AudioVisualizerOverlayView.swift */; };
 		AE9FCE08CE4EDEECE7A843BD /* SharedDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52CE6EB39E15687BF3655B8C /* SharedDataManager.swift */; };
 		B0E9EFEE56304B99C2D7A14D /* StrikingEffects.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FD8494A42E5AA356A35BA25 /* StrikingEffects.swift */; };
@@ -137,6 +141,7 @@
 		02604286446C78C5C8935E45 /* SettingsSubViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSubViews.swift; sourceTree = "<group>"; };
 		082027791B67C0B2DBD43F97 /* AudioVisualizerManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioVisualizerManager.swift; sourceTree = "<group>"; };
 		08B2A227CEA1CA39347CC37A /* WallneticWidget.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = WallneticWidget.entitlements; sourceTree = "<group>"; };
+		0990FC999E1DE89A3D776B05 /* WidgetSyncService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetSyncService.swift; sourceTree = "<group>"; };
 		0B86B489A26E64EF63ED72A8 /* WallpaperEffectsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperEffectsManager.swift; sourceTree = "<group>"; };
 		0D76E5D0AB6B966E492D0342 /* WallpaperGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperGridView.swift; sourceTree = "<group>"; };
 		0DF980A4142FBBE468FBBD05 /* SchedulerSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchedulerSettingsView.swift; sourceTree = "<group>"; };
@@ -189,6 +194,7 @@
 		739D8C6AD1566F8C21F48DFD /* WeatherWallpaperManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherWallpaperManager.swift; sourceTree = "<group>"; };
 		77E4D58C6269978E4994C7CE /* AppShortcuts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppShortcuts.swift; sourceTree = "<group>"; };
 		79BC197A9E8C082F2C39C673 /* NowPlayingOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowPlayingOverlayView.swift; sourceTree = "<group>"; };
+		7F557952B625823A2689EBE7 /* WallpaperLibrary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperLibrary.swift; sourceTree = "<group>"; };
 		843AD85E0F38C70B7B33DE40 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		84E4002911F0B7869F3183DA /* TimeOfDaySettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeOfDaySettingsView.swift; sourceTree = "<group>"; };
 		8500C9E87013D486C890E673 /* TopNavigationBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopNavigationBar.swift; sourceTree = "<group>"; };
@@ -204,6 +210,7 @@
 		9E4C04ED28406292407FFBD0 /* PowerManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PowerManager.swift; sourceTree = "<group>"; };
 		A32AE3710192737ABA41FDA0 /* HistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryView.swift; sourceTree = "<group>"; };
 		AA91ACE8CEF6E8C6CC8A68B8 /* ExceptionCatcher.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ExceptionCatcher.m; sourceTree = "<group>"; };
+		B0F9B4893FCEA17EEFC7550A /* WallpaperMetadataStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperMetadataStore.swift; sourceTree = "<group>"; };
 		B28D90947064A40462D0CC1C /* PopularView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopularView.swift; sourceTree = "<group>"; };
 		B3E0F02714B57C6B710BFA04 /* FavoriteStylesManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteStylesManager.swift; sourceTree = "<group>"; };
 		B5CEC2B4480AEC32A84E65E8 /* VideoTrimmer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoTrimmer.swift; sourceTree = "<group>"; };
@@ -225,6 +232,7 @@
 		DDFCAB2A636011BB543DD1B5 /* SharedWidgetModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedWidgetModels.swift; sourceTree = "<group>"; };
 		DE3FD865C09D4CE6C4025020 /* Wallpaper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Wallpaper.swift; sourceTree = "<group>"; };
 		DFC7F5C372D751F46660FA5C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		E0187521E8CC2C0BB29CE90D /* BatteryPromptService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatteryPromptService.swift; sourceTree = "<group>"; };
 		EA19F4DBD0636536454696F3 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		ED806BD7E0913BCDF1142604 /* MetalVideoRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetalVideoRenderer.swift; sourceTree = "<group>"; };
 		F9534BF578FB9EFE92050C52 /* TimeOfDayManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeOfDayManager.swift; sourceTree = "<group>"; };
@@ -295,6 +303,7 @@
 				77E4D58C6269978E4994C7CE /* AppShortcuts.swift */,
 				082027791B67C0B2DBD43F97 /* AudioVisualizerManager.swift */,
 				5391D519B2B4F2D898BEDB0F /* AuthManager.swift */,
+				E0187521E8CC2C0BB29CE90D /* BatteryPromptService.swift */,
 				69A21A2E89BAFCD9A8FE5DA8 /* CloudSyncManager.swift */,
 				1849D0D4B8C207540818A7E8 /* CollectionManager.swift */,
 				2833332B3174CD94D7D62CBB /* DeepLinkHandler.swift */,
@@ -325,9 +334,12 @@
 				4662279ADB65DBA3957578B7 /* VideoFormatConverter.swift */,
 				B5CEC2B4480AEC32A84E65E8 /* VideoTrimmer.swift */,
 				0B86B489A26E64EF63ED72A8 /* WallpaperEffectsManager.swift */,
+				7F557952B625823A2689EBE7 /* WallpaperLibrary.swift */,
 				532FE0E3069C64B6236A343C /* WallpaperManager.swift */,
+				B0F9B4893FCEA17EEFC7550A /* WallpaperMetadataStore.swift */,
 				40A93EE0CF1D353315FEA25D /* WallpaperStoreManager.swift */,
 				739D8C6AD1566F8C21F48DFD /* WeatherWallpaperManager.swift */,
+				0990FC999E1DE89A3D776B05 /* WidgetSyncService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -480,7 +492,6 @@
 			children = (
 				69A7F21804AB5D266A239578 /* WallneticWidget.swift */,
 				5B7028D3EA5A514573B5B23F /* WallneticWidgetBundle.swift */,
-				FE863A105B48E8483FA4105E /* Models */,
 				245B5B74A9E9F71A64F7454D /* Provider */,
 				4295B025FC1E253129AEE445 /* Resources */,
 				359372CAF80A53CFB75544F5 /* Views */,
@@ -570,11 +581,9 @@
 						ProvisioningStyle = Automatic;
 					};
 					619B21F5247512020263D942 = {
-						DevelopmentTeam = "";
 						ProvisioningStyle = Automatic;
 					};
 					9D9A6596302C548CCE03E80C = {
-						DevelopmentTeam = "";
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -652,6 +661,7 @@
 				15138957B8762022576E764B /* AudioVisualizerOverlayController.swift in Sources */,
 				AC7FBC93D689C03ADF1AEDF5 /* AudioVisualizerOverlayView.swift in Sources */,
 				B34E2B3843447164873423D8 /* AuthManager.swift in Sources */,
+				61773D343F4EBEEB12FF8AFB /* BatteryPromptService.swift in Sources */,
 				B4147A0425D06A4CAD8EDE77 /* CloudSyncManager.swift in Sources */,
 				559304CF4E8C6C1F05A97B59 /* CollectionDetailView.swift in Sources */,
 				73849203691B6B9B27EF0384 /* CollectionManager.swift in Sources */,
@@ -717,9 +727,12 @@
 				51355B920BE931D2A9A3BE58 /* WallpaperCollection.swift in Sources */,
 				1B480E4A92B2E3538B724AE4 /* WallpaperEffectsManager.swift in Sources */,
 				2124DE0A8E8717475F30D34C /* WallpaperGridView.swift in Sources */,
+				6B3FA8945F430A067CC4DB4D /* WallpaperLibrary.swift in Sources */,
 				7B8DE2A0443E6DC55D750FCB /* WallpaperManager.swift in Sources */,
+				3F705E631F7827AD76411878 /* WallpaperMetadataStore.swift in Sources */,
 				9C7206924D126AE38A11DD51 /* WallpaperStoreManager.swift in Sources */,
 				F6107012989E9FC5810F350E /* WeatherWallpaperManager.swift in Sources */,
+				A978B328492C6EE503BC91E3 /* WidgetSyncService.swift in Sources */,
 				88C6A7F9AD19AA876CEEC465 /* iCloudSyncManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -746,6 +759,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Resources/Wallnetic.entitlements;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -832,6 +846,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Resources/Wallnetic.entitlements;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -850,6 +865,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = ../WallneticWidget/Resources/WallneticWidget.entitlements;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = ../WallneticWidget/Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -886,6 +902,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = ../WallneticWidget/Resources/WallneticWidget.entitlements;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = ../WallneticWidget/Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
## Summary

Bundles all pending v1.3 work (unreleased) into a single release-prep PR. Now ALSO clears the two App Store P1 blockers — this branch is store-ready.

### v1.2 → v1.3 feature work
- **#172** Battery-mode prompt with Settings override toggle and reset button.
- **#149** `WallpaperManager` decomposition — extracts `WallpaperLibrary`, `WallpaperMetadataStore`, `WidgetSyncService` (808 → 462 lines).
- **#170** Notification relay replaced with typed `PlaybackDelegate` protocol (delegate drives renderer, notifications remain as broadcast for observers).
- **#163** FFT hot-path: pre-allocated vDSP buffers + pointer arithmetic (~280 alloc/sec eliminated).
- **#168** `CGWindowListCopyWindowInfo` moved off the main thread.
- **O1** `AudioVisualizerOverlayView` caches `NSColor → RGB` via `@State + .onChange`.
- **D1** Removed duplicate hotkey helpers in `AppDelegate`.

### Store Compliance (commit `fd7c88c`)
- **#164** `PrivacyInfo.xcprivacy` declaring required-reason APIs:
  - `UserDefaults` (CA92.1), `FileTimestamp` (C617.1)
  - `NSPrivacyTracking=false`, no collected data, no tracking domains.
- **#165** MRMediaRemote private framework gated to `#if DEBUG`.
  - `loadFramework`, `pollMR`, `applyMR`, `mrInfoDidChange`, MR command callers, MR notifications.
  - Verified: Release binary contains no `MRMediaRemoteGet*`, `MRMediaRemoteSend*`, or `/System/Library/PrivateFrameworks/MediaRemote` strings.
  - Release fallback: `DistributedNotificationCenter` (Apple Music + Spotify) only.

Also includes README + changelog updates, global hotkey table, `.gitignore` hygiene.

## Code Review Fixes (commit `1ec5077`)

A `/review` pass surfaced the following — all fixed:

| Severity | Finding | Fix |
|----------|---------|-----|
| High | `WallpaperManager.set*` / `togglePlayback` skipped `NotificationCenter` when `playbackDelegate` was set, breaking `DynamicIslandController` and `ThemeManager` observers. | Delegate + broadcast now fire together. |
| Medium | `PowerManager.init` fired a synthetic AC → battery transition before `AppDelegate` settled, racing the 1.2 s launch prompt delay. | New `isInitialized` flag suppresses the init-time trigger; launch-time prompts owned by `AppDelegate.checkOnLaunch`. |
| Medium | `BatteryPromptService` main-thread assumptions undocumented. | Added `dispatchPrecondition(.onQueue(.main))` + class-level doc. |
| Medium | Settings toggle coupling unclear. | Reworded help text to make the override relationship explicit. |
| Low | `applyChoice` did a no-op `DispatchQueue.main.async`. | Removed. |
| Low | Alert copy was Turkish while rest of UI is English. | Translated. |
| Low | `WallpaperMetadataStore` force-cast `[:] as! T`. | Replaced with typed `let empty: T = [:]`. |
| Low | `WallpaperLibrary` duplicate detection used display-name. | Switched to `url.lastPathComponent`. |

## Build Status
- Debug: ✓
- Release: ✓ (verified MR-clean strings + embedded `PrivacyInfo.xcprivacy`)

## Test plan

- [ ] Launch on battery → prompt appears after ~1.2 s with wallpaper already restored.
- [ ] Unplug power while running → prompt appears once; re-plug + unplug → no second prompt in same session.
- [ ] "Keep playing" → wallpaper resumes; `Always play on battery` toggle in Settings flips to ON if "Don't ask again" was checked.
- [ ] "Reset battery prompt" clears the saved choice; next battery switch prompts again.
- [ ] Change wallpaper → `DynamicIsland` thumbnail updates and `ThemeManager` re-derives accent color (regression coverage for High finding).
- [ ] Toggle playback (hotkey + menu bar + Dynamic Island) — all three surfaces stay in sync.
- [ ] Confirm Release archive has `PrivacyInfo.xcprivacy` at `Contents/Resources/`.
- [ ] Confirm Release archive has no MRMediaRemote symbols (`strings <binary> | grep MRMediaRemoteGet`).

## Follow-ups (post-merge)

- `dev` branch sync once this merges (dev is ~40 commits behind `main`).
- Version bump to v1.3.0 + App Store submission package.