### PR TITLE
Centralize logging via os.log (#169)

### DIFF
--- a/src/Wallnetic/App/AppDelegate.swift
+++ b/src/Wallnetic/App/AppDelegate.swift
@@ -3,7 +3,7 @@ import SwiftUI
 import Foundation
 import os.log
 
-private let logger = Logger(subsystem: "com.wallnetic.app", category: "AppDelegate")
+private let logger = Log.app
 
 class AppDelegate: NSObject, NSApplicationDelegate {
     private var desktopWindowController: DesktopWindowController?
@@ -199,9 +199,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     @objc private func displaysChanged() {
-        #if DEBUG
-        print("[AppDelegate] Display configuration changed")
-        #endif
+        Log.app.debug("Display configuration changed")
         desktopWindowController?.handleDisplayChange()
     }
 }
@@ -210,9 +208,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
 extension AppDelegate: PlaybackDelegate {
     func playbackSetWallpaper(url: URL) {
-        #if DEBUG
-        print("[AppDelegate] PlaybackDelegate: setWallpaper \(url.lastPathComponent)")
-        #endif
+        Log.app.debug("PlaybackDelegate: setWallpaper \(url.lastPathComponent, privacy: .public)")
         desktopWindowController?.setWallpaper(url: url)
         if !(powerManager?.shouldBePaused ?? false) {
             desktopWindowController?.play()
@@ -220,9 +216,7 @@ extension AppDelegate: PlaybackDelegate {
     }
 
     func playbackSetWallpaper(url: URL, for screen: NSScreen) {
-        #if DEBUG
-        print("[AppDelegate] PlaybackDelegate: setWallpaper for \(screen.localizedName)")
-        #endif
+        Log.app.debug("PlaybackDelegate: setWallpaper for \(screen.localizedName, privacy: .public)")
         desktopWindowController?.setWallpaper(url: url, for: screen)
         if !(powerManager?.shouldBePaused ?? false) {
             desktopWindowController?.play()
@@ -240,9 +234,7 @@ extension AppDelegate: PlaybackDelegate {
     }
 
     func playbackApplyScreenWallpapers() {
-        #if DEBUG
-        print("[AppDelegate] PlaybackDelegate: applyScreenWallpapers")
-        #endif
+        Log.app.debug("PlaybackDelegate: applyScreenWallpapers")
         for screen in NSScreen.screens {
             if let wallpaper = WallpaperManager.shared.wallpaper(for: screen) {
                 desktopWindowController?.setWallpaper(url: wallpaper.url, for: screen)

--- a/src/Wallnetic/Engine/DesktopWindowController.swift
+++ b/src/Wallnetic/Engine/DesktopWindowController.swift
@@ -121,9 +121,8 @@ class DesktopWindowController {
         // Show window
         window.orderFront(nil)
 
-        #if DEBUG
-        print("[DesktopWindow] Created window for: \(screen.localizedName) using \(useMetalRenderer ? "Metal" : "AVFoundation") renderer")
-        #endif
+        let rendererName = useMetalRenderer ? "Metal" : "AVFoundation"
+        Log.window.debug("Created window for: \(screen.localizedName, privacy: .public) using \(rendererName, privacy: .public) renderer")
     }
 
     // MARK: - Playback Control

--- a/src/Wallnetic/Engine/PowerManager.swift
+++ b/src/Wallnetic/Engine/PowerManager.swift
@@ -285,17 +285,17 @@ class PowerManager {
         isLowPowerMode = ProcessInfo.processInfo.isLowPowerModeEnabled
 
         if isLowPowerMode && !wasLowPower {
-            print("[PowerManager] Low Power Mode enabled")
+            Log.power.info("Low Power Mode enabled")
             notifyPauseIfNeeded()
         } else if !isLowPowerMode && wasLowPower {
-            print("[PowerManager] Low Power Mode disabled")
+            Log.power.info("Low Power Mode disabled")
             notifyResumeIfNeeded()
         }
     }
 
     private func handlePowerSourceChange() {
         if isOnBattery {
-            print("[PowerManager] Switched to battery power")
+            Log.power.info("Switched to battery power")
             if BatteryPromptService.shared.effectivePauseOnBattery {
                 notifyPauseIfNeeded()
             }
@@ -305,42 +305,42 @@ class PowerManager {
                 BatteryPromptService.shared.onSwitchedToBattery()
             }
         } else {
-            print("[PowerManager] Switched to AC power")
+            Log.power.info("Switched to AC power")
             notifyResumeIfNeeded()
         }
     }
 
     private func handleFullscreenChange() {
         if isFullscreenAppActive {
-            print("[PowerManager] Fullscreen app detected")
+            Log.power.info("Fullscreen app detected")
             if WallpaperManager.shared.pauseOnFullscreen {
                 notifyPauseIfNeeded()
             }
         } else {
-            print("[PowerManager] Fullscreen app closed")
+            Log.power.info("Fullscreen app closed")
             notifyResumeIfNeeded()
         }
     }
 
     @objc private func screensDidSleep() {
-        print("[PowerManager] Screens did sleep")
+        Log.power.info("Screens did sleep")
         isScreenAsleep = true
         notifyPauseIfNeeded()
     }
 
     @objc private func screensDidWake() {
-        print("[PowerManager] Screens did wake")
+        Log.power.info("Screens did wake")
         isScreenAsleep = false
         notifyResumeIfNeeded()
     }
 
     @objc private func systemWillSleep() {
-        print("[PowerManager] System will sleep")
+        Log.power.info("System will sleep")
         notifyPauseIfNeeded()
     }
 
     @objc private func systemDidWake() {
-        print("[PowerManager] System did wake")
+        Log.power.info("System did wake")
         // Small delay to let system stabilize
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
             self?.notifyResumeIfNeeded()
@@ -348,13 +348,13 @@ class PowerManager {
     }
 
     @objc private func screenSaverDidStart() {
-        print("[PowerManager] Screen saver started")
+        Log.power.info("Screen saver started")
         isScreenSaverActive = true
         notifyPauseIfNeeded()
     }
 
     @objc private func screenSaverDidStop() {
-        print("[PowerManager] Screen saver stopped")
+        Log.power.info("Screen saver stopped")
         isScreenSaverActive = false
         notifyResumeIfNeeded()
     }

--- a/src/Wallnetic/Engine/VideoRenderer.swift
+++ b/src/Wallnetic/Engine/VideoRenderer.swift
@@ -47,7 +47,7 @@ class VideoRenderer: NSObject {
     /// Loads a video file for playback with performance optimizations
     func loadVideo(url: URL) {
         guard FileManager.default.fileExists(atPath: url.path) else {
-            print("[VideoRenderer] ERROR: File does not exist")
+            Log.video.error("File does not exist: \(url.path, privacy: .public)")
             return
         }
 
@@ -70,7 +70,7 @@ class VideoRenderer: NSObject {
             // Pre-load required properties asynchronously
             let isPlayable = try await asset.load(.isPlayable)
             guard isPlayable else {
-                print("[VideoRenderer] Asset is not playable")
+                Log.video.error("Asset is not playable")
                 return
             }
 
@@ -78,7 +78,7 @@ class VideoRenderer: NSObject {
                 self?.setupPlayer(with: asset)
             }
         } catch {
-            print("[VideoRenderer] Failed to load asset: \(error)")
+            Log.video.error("Failed to load asset: \(error.localizedDescription, privacy: .public)")
         }
     }
 
@@ -120,9 +120,7 @@ class VideoRenderer: NSObject {
         if shouldPlayWhenReady {
             player?.play()
             shouldPlayWhenReady = false
-            #if DEBUG
-            print("[VideoRenderer] Auto-playing after video ready")
-            #endif
+            Log.video.debug("Auto-playing after video ready")
         }
     }
 
@@ -133,9 +131,9 @@ class VideoRenderer: NSObject {
         playerItemObserver = playerItem.observe(\.status) { item, _ in
             switch item.status {
             case .readyToPlay:
-                print("[VideoRenderer] Ready to play")
+                Log.video.debug("Ready to play")
             case .failed:
-                print("[VideoRenderer] Failed: \(item.error?.localizedDescription ?? "unknown")")
+                Log.video.error("Failed: \(item.error?.localizedDescription ?? "unknown", privacy: .public)")
             default:
                 break
             }
@@ -151,9 +149,7 @@ class VideoRenderer: NSObject {
         } else {
             // Video not ready yet, play when ready
             shouldPlayWhenReady = true
-            #if DEBUG
-            print("[VideoRenderer] Play requested, will auto-play when ready")
-            #endif
+            Log.video.debug("Play requested, will auto-play when ready")
         }
     }
 

--- a/src/Wallnetic/Models/GenerationHistory.swift
+++ b/src/Wallnetic/Models/GenerationHistory.swift
@@ -121,7 +121,7 @@ class GenerationHistoryManager: ObservableObject {
             // Sort by date, newest first
             items.sort { $0.createdAt > $1.createdAt }
         } catch {
-            print("Failed to load history: \(error)")
+            Log.history.error("Failed to load history: \(error.localizedDescription, privacy: .public)")
             items = []
         }
     }
@@ -136,7 +136,7 @@ class GenerationHistoryManager: ObservableObject {
             let data = try encoder.encode(items)
             try data.write(to: fileURL)
         } catch {
-            print("Failed to save history: \(error)")
+            Log.history.error("Failed to save history: \(error.localizedDescription, privacy: .public)")
         }
     }
 
@@ -163,7 +163,7 @@ class GenerationHistoryManager: ObservableObject {
         do {
             try FileManager.default.copyItem(at: videoURL, to: destVideoURL)
         } catch {
-            print("Failed to copy video: \(error)")
+            Log.history.error("Failed to copy video: \(error.localizedDescription, privacy: .public)")
             return
         }
 
@@ -256,7 +256,7 @@ class GenerationHistoryManager: ObservableObject {
                 try jpegData.write(to: thumbnailURL)
             }
         } catch {
-            print("Failed to generate thumbnail: \(error)")
+            Log.history.error("Failed to generate thumbnail: \(error.localizedDescription, privacy: .public)")
         }
     }
 }

--- a/src/Wallnetic/Services/AIService.swift
+++ b/src/Wallnetic/Services/AIService.swift
@@ -107,7 +107,7 @@ class AIService {
         // Parse queue response
         guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
               let requestId = json["request_id"] as? String else {
-            print("[AIService] Failed to parse queue response: \(String(data: data, encoding: .utf8) ?? "nil")")
+            Log.ai.error("Failed to parse queue response: \(String(data: data, encoding: .utf8) ?? "nil", privacy: .public)")
             throw AIServiceError.invalidResponse
         }
 
@@ -366,7 +366,7 @@ class AIService {
         }
 
         // Log for debugging
-        print("[AIService] Unknown response format. Keys: \(json.keys)")
+        Log.ai.error("Unknown response format. Keys: \(json.keys.description, privacy: .public)")
         throw AIServiceError.invalidResponse
     }
 

--- a/src/Wallnetic/Services/AnalyticsManager.swift
+++ b/src/Wallnetic/Services/AnalyticsManager.swift
@@ -18,7 +18,7 @@ class AnalyticsManager {
         // In production, send to TelemetryDeck API
         // For now, log locally
         #if DEBUG
-        NSLog("[Analytics] %@ %@", event, properties.description)
+        Log.analytics.debug("\(event, privacy: .public) \(properties.description, privacy: .public)")
         #endif
     }
 

--- a/src/Wallnetic/Services/AudioVisualizerManager.swift
+++ b/src/Wallnetic/Services/AudioVisualizerManager.swift
@@ -393,7 +393,7 @@ extension AudioVisualizerManager: SCStreamOutput, SCStreamDelegate {
         switch type {
         case .audio:
             guard let mono = samples(from: sampleBuffer) else {
-                NSLog("[AudioVisualizer] failed to extract samples from audio buffer")
+                Log.visualizer.error("Failed to extract samples from audio buffer")
                 return
             }
             feed(samples: mono)

--- a/src/Wallnetic/Services/AuthManager.swift
+++ b/src/Wallnetic/Services/AuthManager.swift
@@ -41,7 +41,7 @@ class AuthManager: NSObject, ObservableObject {
         userId = nil
         UserDefaults.standard.removeObject(forKey: "auth.userEmail")
         UserDefaults.standard.removeObject(forKey: "auth.userId")
-        NSLog("[Auth] Signed out")
+        Log.auth.info("Signed out")
     }
 
     // MARK: - Session
@@ -50,7 +50,8 @@ class AuthManager: NSObject, ObservableObject {
         userEmail = UserDefaults.standard.string(forKey: "auth.userEmail")
         userId = UserDefaults.standard.string(forKey: "auth.userId")
         isAuthenticated = true
-        NSLog("[Auth] Session restored for: %@", userEmail ?? "unknown")
+        let email = userEmail ?? "unknown"
+        Log.auth.info("Session restored for: \(email, privacy: .private)")
     }
 
     private func handleSignIn(idToken: String, email: String?) {
@@ -83,14 +84,14 @@ class AuthManager: NSObject, ObservableObject {
                         UserDefaults.standard.set(userEmail, forKey: "auth.userEmail")
                         UserDefaults.standard.set(uid, forKey: "auth.userId")
 
-                        NSLog("[Auth] Signed in: %@", userEmail ?? "unknown")
+                        Log.auth.info("Signed in: \(userEmail ?? "unknown", privacy: .private)")
                     }
                 }
             } catch {
                 await MainActor.run {
                     self.error = error.localizedDescription
                     self.isLoading = false
-                    NSLog("[Auth] Sign in error: %@", error.localizedDescription)
+                    Log.auth.error("Sign in error: \(error.localizedDescription, privacy: .public)")
                 }
             }
         }

--- a/src/Wallnetic/Services/CloudSyncManager.swift
+++ b/src/Wallnetic/Services/CloudSyncManager.swift
@@ -40,9 +40,9 @@ class CloudSyncManager: ObservableObject {
                 ],
                 headers: ["Prefer": "return=minimal"]
             )
-            NSLog("[CloudSync] Generation synced")
+            Log.cloud.info("Generation synced")
         } catch {
-            NSLog("[CloudSync] Sync error: %@", error.localizedDescription)
+            Log.cloud.error("Sync error: \(error.localizedDescription, privacy: .public)")
         }
     }
 
@@ -65,7 +65,7 @@ class CloudSyncManager: ObservableObject {
             }
             return generations
         } catch {
-            NSLog("[CloudSync] Fetch error: %@", error.localizedDescription)
+            Log.cloud.error("Fetch error: \(error.localizedDescription, privacy: .public)")
             return []
         }
     }

--- a/src/Wallnetic/Services/DeepLinkHandler.swift
+++ b/src/Wallnetic/Services/DeepLinkHandler.swift
@@ -18,7 +18,7 @@ class DeepLinkHandler {
             }
         )
 
-        NSLog("[DeepLink] %@", url.absoluteString)
+        Log.deepLink.info("\(url.absoluteString, privacy: .public)")
 
         switch host {
         case "playPause":
@@ -63,7 +63,7 @@ class DeepLinkHandler {
             }
 
         default:
-            NSLog("[DeepLink] Unknown action: %@", host)
+            Log.deepLink.info("Unknown action: \(host, privacy: .public)")
         }
     }
 }

--- a/src/Wallnetic/Services/DownloadManager.swift
+++ b/src/Wallnetic/Services/DownloadManager.swift
@@ -132,12 +132,12 @@ class DownloadManager: NSObject, ObservableObject {
                         if importURL != localURL {
                             try? FileManager.default.removeItem(at: localURL)
                         }
-                        NSLog("[DownloadManager] Imported: %@", name)
+                        Log.download.info("Imported: \(name, privacy: .public)")
                     } catch {
-                        NSLog("[DownloadManager] Import failed: %@", error.localizedDescription)
+                        Log.download.error("Import failed: \(error.localizedDescription, privacy: .public)")
                     }
                 case .failure(let error):
-                    NSLog("[DownloadManager] Download failed: %@", error.localizedDescription)
+                    Log.download.error("Download failed: \(error.localizedDescription, privacy: .public)")
                 }
             }
         }
@@ -149,7 +149,7 @@ class DownloadManager: NSObject, ObservableObject {
 
         // ZIP file (likely from mylivewallpapers.com) — extract .mlw and decrypt
         if ext == "zip" || isZIPFile(at: localURL) {
-            NSLog("[DownloadManager] Processing ZIP for MLW content: %@", name)
+            Log.download.info("Processing ZIP for MLW content: \(name, privacy: .public)")
             let mp4URL = FileManager.default.temporaryDirectory
                 .appendingPathComponent(UUID().uuidString)
                 .appendingPathExtension("mp4")
@@ -159,7 +159,7 @@ class DownloadManager: NSObject, ObservableObject {
 
         // Direct .mlw file
         if ext == "mlw" || isMLWFile(at: localURL) {
-            NSLog("[DownloadManager] Processing MLW file: %@", name)
+            Log.download.info("Processing MLW file: \(name, privacy: .public)")
             let mp4URL = FileManager.default.temporaryDirectory
                 .appendingPathComponent(UUID().uuidString)
                 .appendingPathExtension("mp4")

--- a/src/Wallnetic/Services/KeychainManager.swift
+++ b/src/Wallnetic/Services/KeychainManager.swift
@@ -35,7 +35,7 @@ class KeychainManager {
 
         #if DEBUG
         if status != errSecSuccess {
-            print("[KeychainManager] Failed to save API key: \(status)")
+            Log.keychain.error("Failed to save API key: \(status)")
         }
         #endif
 

--- a/src/Wallnetic/Services/LockScreenManager.swift
+++ b/src/Wallnetic/Services/LockScreenManager.swift
@@ -50,13 +50,13 @@ class LockScreenManager: ObservableObject {
     private func onScreenLocked() {
         guard isEnabled else { return }
         isLocked = true
-        NSLog("[LockScreen] Screen locked - showing video wallpaper")
+        Log.lockScreen.info("Screen locked - showing video wallpaper")
         showLockScreenWallpaper()
     }
 
     private func onScreenUnlocked() {
         isLocked = false
-        NSLog("[LockScreen] Screen unlocked")
+        Log.lockScreen.info("Screen unlocked")
         hideLockScreenWallpaper()
     }
 
@@ -132,7 +132,7 @@ class LockScreenManager: ObservableObject {
     func setLockScreenWallpaper(_ wallpaper: Wallpaper) {
         wallpaperPath = wallpaper.url.path
         useCurrentWallpaper = false
-        NSLog("[LockScreen] Set lock screen wallpaper: %@", wallpaper.name)
+        Log.lockScreen.info("Set lock screen wallpaper: \(wallpaper.name, privacy: .public)")
     }
 
     func useCurrent() {

--- a/src/Wallnetic/Services/MLWDecryptor.swift
+++ b/src/Wallnetic/Services/MLWDecryptor.swift
@@ -102,7 +102,7 @@ enum MLWDecryptor {
             let decrypted = try AES.GCM.open(sealedBox, using: key)
             return decrypted
         } catch {
-            NSLog("[MLWDecryptor] Decryption error: %@", error.localizedDescription)
+            Log.mlw.error("Decryption error: \(error.localizedDescription, privacy: .public)")
             throw MLWError.decryptionFailed
         }
     }
@@ -113,7 +113,7 @@ enum MLWDecryptor {
         let data = try Data(contentsOf: input)
         let mp4 = try decrypt(data: data)
         try mp4.write(to: output)
-        NSLog("[MLWDecryptor] Decrypted %d bytes → %@", mp4.count, output.lastPathComponent)
+        Log.mlw.info("Decrypted \(mp4.count) bytes → \(output.lastPathComponent, privacy: .public)")
         return output
     }
 
@@ -131,7 +131,7 @@ enum MLWDecryptor {
         let zipData = try Data(contentsOf: zipURL)
         let mp4 = try decryptFromZIP(data: zipData)
         try mp4.write(to: output)
-        NSLog("[MLWDecryptor] ZIP → MLW → MP4: %d bytes → %@", mp4.count, output.lastPathComponent)
+        Log.mlw.info("ZIP → MLW → MP4: \(mp4.count) bytes → \(output.lastPathComponent, privacy: .public)")
         return output
     }
 

--- a/src/Wallnetic/Services/MusicReactiveManager.swift
+++ b/src/Wallnetic/Services/MusicReactiveManager.swift
@@ -63,8 +63,7 @@ class MusicReactiveManager: ObservableObject {
             self?.updateAudioLevel()
         }
 
-        NSLog("[MusicReactive] Started with effect: %@ (demo mode: %@)",
-              selectedEffect.rawValue, isDemoMode ? "yes" : "no")
+        Log.music.info("Started with effect: \(self.selectedEffect.rawValue, privacy: .public) (demo mode: \(self.isDemoMode ? "yes" : "no", privacy: .public))")
     }
 
     func stop() {

--- a/src/Wallnetic/Services/NotificationManager.swift
+++ b/src/Wallnetic/Services/NotificationManager.swift
@@ -78,7 +78,7 @@ class NotificationManager: ObservableObject {
             DispatchQueue.main.async {
                 self.isAuthorized = granted
                 if let error = error {
-                    print("Notification authorization error: \(error)")
+                    Log.notification.error("Authorization error: \(error.localizedDescription, privacy: .public)")
                 }
             }
         }
@@ -132,7 +132,7 @@ class NotificationManager: ObservableObject {
 
         UNUserNotificationCenter.current().add(request) { error in
             if let error = error {
-                print("Failed to send notification: \(error)")
+                Log.notification.error("Failed to send notification: \(error.localizedDescription, privacy: .public)")
             }
         }
     }

--- a/src/Wallnetic/Services/SchedulerService.swift
+++ b/src/Wallnetic/Services/SchedulerService.swift
@@ -292,7 +292,7 @@ class SchedulerService: ObservableObject {
     func requestNotificationPermission() {
         UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { granted, error in
             if let error = error {
-                print("Notification permission error: \(error)")
+                Log.scheduler.error("Notification permission error: \(error.localizedDescription, privacy: .public)")
             }
         }
     }

--- a/src/Wallnetic/Services/ScreenSaverBridge.swift
+++ b/src/Wallnetic/Services/ScreenSaverBridge.swift
@@ -39,7 +39,7 @@ class ScreenSaverBridge {
         defaults?.set(showClock, forKey: "showClock")
         defaults?.synchronize()
 
-        NSLog("[ScreenSaver] Synced wallpaper info to screen saver defaults")
+        Log.screenSaver.info("Synced wallpaper info to screen saver defaults")
     }
 
     /// Returns the path to install a .saver bundle

--- a/src/Wallnetic/Services/SharedDataManager.swift
+++ b/src/Wallnetic/Services/SharedDataManager.swift
@@ -26,7 +26,8 @@ class SharedDataManager {
         if let thumbnailsDir = thumbnailsDirectory {
             try? FileManager.default.createDirectory(at: thumbnailsDir, withIntermediateDirectories: true)
         }
-        NSLog("[SharedDataManager] Container: %@", sharedContainerURL?.path ?? "nil")
+        let containerPath = sharedContainerURL?.path ?? "nil"
+        Log.shared.info("Container: \(containerPath, privacy: .public)")
     }
 
     // MARK: - File-Based Read/Write
@@ -47,7 +48,7 @@ class SharedDataManager {
             let data = try JSONEncoder().encode(sharedData)
             try data.write(to: fileURL, options: .atomic)
         } catch {
-            NSLog("[SharedDataManager] Write error: %@", error.localizedDescription)
+            Log.shared.error("Write error: \(error.localizedDescription, privacy: .public)")
         }
     }
 
@@ -80,7 +81,7 @@ class SharedDataManager {
         data.favorites = wallpapers
         data.lastUpdated = Date()
         writeSharedData(data)
-        NSLog("[SharedDataManager] Saved %d favorites", wallpapers.count)
+        Log.shared.info("Saved \(wallpapers.count) favorites")
         reloadWidgetTimelines()
     }
 
@@ -94,7 +95,7 @@ class SharedDataManager {
             try data.write(to: fileURL)
             return filename
         } catch {
-            NSLog("[SharedDataManager] Thumbnail save error: %@", error.localizedDescription)
+            Log.shared.error("Thumbnail save error: \(error.localizedDescription, privacy: .public)")
             return nil
         }
     }

--- a/src/Wallnetic/Services/SpaceWallpaperManager.swift
+++ b/src/Wallnetic/Services/SpaceWallpaperManager.swift
@@ -56,7 +56,7 @@ class SpaceWallpaperManager: ObservableObject {
     func setWallpaper(_ wallpaper: Wallpaper, forSpace spaceIndex: Int) {
         spaceAssignments[spaceIndex] = wallpaper.url.path
         saveAssignments()
-        NSLog("[Spaces] Set wallpaper '%@' for space %d", wallpaper.name, spaceIndex)
+        Log.space.info("Set wallpaper '\(wallpaper.name, privacy: .public)' for space \(spaceIndex)")
 
         // Apply immediately if this is the current space
         if spaceIndex == currentSpaceIndex {
@@ -84,7 +84,8 @@ class SpaceWallpaperManager: ObservableObject {
 
         // Apply wallpaper for new space
         if let wallpaper = wallpaper(forSpace: currentSpaceIndex) {
-            NSLog("[Spaces] Space changed to %d, applying: %@", currentSpaceIndex, wallpaper.name)
+            let idx = currentSpaceIndex
+            Log.space.info("Space changed to \(idx), applying: \(wallpaper.name, privacy: .public)")
             WallpaperManager.shared.setWallpaper(wallpaper)
         }
     }
@@ -116,7 +117,7 @@ class SpaceWallpaperManager: ObservableObject {
         if let index = knownSpaceIDs.firstIndex(of: spaceSignature) {
             if index != currentSpaceIndex {
                 currentSpaceIndex = index
-                NSLog("[Spaces] Space changed to index %d", index)
+                Log.space.info("Space changed to index \(index)")
             }
         }
     }

--- a/src/Wallnetic/Services/SupabaseClient.swift
+++ b/src/Wallnetic/Services/SupabaseClient.swift
@@ -31,7 +31,7 @@ class SupabaseClient {
     func configure(url: String, anonKey: String) {
         supabaseURL = url
         supabaseAnonKey = anonKey
-        NSLog("[Supabase] Configured: %@", url)
+        Log.supabase.info("Configured: \(url, privacy: .public)")
     }
 
     // MARK: - Auth

--- a/src/Wallnetic/Services/ThumbnailCache.swift
+++ b/src/Wallnetic/Services/ThumbnailCache.swift
@@ -23,7 +23,7 @@ final class ThumbnailCache {
         let source = DispatchSource.makeMemoryPressureSource(eventMask: [.warning, .critical], queue: .main)
         source.setEventHandler { [weak self] in
             self?.clearCache()
-            print("[ThumbnailCache] Cleared cache due to memory pressure")
+            Log.thumbnail.info("Cleared cache due to memory pressure")
         }
         source.resume()
         memoryPressureSource = source

--- a/src/Wallnetic/Services/TimeOfDayManager.swift
+++ b/src/Wallnetic/Services/TimeOfDayManager.swift
@@ -154,7 +154,8 @@ class TimeOfDayManager: ObservableObject {
 
         let url = URL(fileURLWithPath: path)
         if let wallpaper = WallpaperManager.shared.wallpapers.first(where: { $0.url.path == path }) {
-            NSLog("[TimeOfDay] Switching to %@ wallpaper: %@", currentSlot.rawValue, wallpaper.name)
+            let slot = currentSlot.rawValue
+            Log.timeOfDay.info("Switching to \(slot, privacy: .public) wallpaper: \(wallpaper.name, privacy: .public)")
             WallpaperManager.shared.setWallpaper(wallpaper)
         }
     }

--- a/src/Wallnetic/Services/UpdateChecker.swift
+++ b/src/Wallnetic/Services/UpdateChecker.swift
@@ -59,7 +59,7 @@ class UpdateChecker: ObservableObject {
 
             lastCheckTimestamp = Date().timeIntervalSince1970
         } catch {
-            NSLog("[UpdateChecker] Error: %@", error.localizedDescription)
+            Log.update.error("Error: \(error.localizedDescription, privacy: .public)")
         }
     }
 

--- a/src/Wallnetic/Services/UsageTracker.swift
+++ b/src/Wallnetic/Services/UsageTracker.swift
@@ -97,7 +97,7 @@ class UsageTracker: ObservableObject {
             }
 
         } catch {
-            NSLog("[UsageTracker] Refresh error: %@", error.localizedDescription)
+            Log.usage.error("Refresh error: \(error.localizedDescription, privacy: .public)")
         }
 
         await MainActor.run { isLoading = false }
@@ -125,7 +125,7 @@ class UsageTracker: ObservableObject {
                 ]
             )
         } catch {
-            NSLog("[UsageTracker] Sync error: %@", error.localizedDescription)
+            Log.usage.error("Sync error: \(error.localizedDescription, privacy: .public)")
         }
     }
 

--- a/src/Wallnetic/Services/WallpaperStoreManager.swift
+++ b/src/Wallnetic/Services/WallpaperStoreManager.swift
@@ -83,7 +83,7 @@ class WallpaperStoreManager: ObservableObject {
         // Cleanup temp file
         try? FileManager.default.removeItem(at: downloadedURL)
 
-        NSLog("[Store] Downloaded: %@", wallpaper.name)
+        Log.store.info("Downloaded: \(wallpaper.name, privacy: .public)")
     }
 }
 

--- a/src/Wallnetic/Services/WeatherWallpaperManager.swift
+++ b/src/Wallnetic/Services/WeatherWallpaperManager.swift
@@ -134,7 +134,7 @@ class WeatherWallpaperManager: NSObject, ObservableObject, CLLocationManagerDele
         guard !path.isEmpty else { return }
 
         if let wallpaper = WallpaperManager.shared.wallpapers.first(where: { $0.url.path == path }) {
-            NSLog("[Weather] Condition: %@ -> wallpaper: %@", condition.rawValue, wallpaper.name)
+            Log.weather.info("Condition: \(condition.rawValue, privacy: .public) -> wallpaper: \(wallpaper.name, privacy: .public)")
             WallpaperManager.shared.setWallpaper(wallpaper)
         }
     }

--- a/src/Wallnetic/Services/iCloudSyncManager.swift
+++ b/src/Wallnetic/Services/iCloudSyncManager.swift
@@ -122,7 +122,7 @@ class iCloudSyncManager: ObservableObject {
 
         syncStatus = .synced
         lastSyncDate = Date()
-        NSLog("[iCloud] Synced to cloud: %d favorites", favoriteNames.count)
+        Log.icloud.info("Synced to cloud: \(favoriteNames.count) favorites")
     }
 
     // MARK: - Sync From Cloud
@@ -152,14 +152,14 @@ class iCloudSyncManager: ObservableObject {
         }
 
         syncStatus = .synced
-        NSLog("[iCloud] Synced from cloud")
+        Log.icloud.info("Synced from cloud")
     }
 
     // MARK: - External Changes
 
     private func handleExternalChange(_ notification: Notification) {
         guard isEnabled else { return }
-        NSLog("[iCloud] External change detected")
+        Log.icloud.info("External change detected")
         syncFromCloud()
     }
 }

--- a/src/Wallnetic/Utils/Log.swift
+++ b/src/Wallnetic/Utils/Log.swift
@@ -1,0 +1,48 @@
+import Foundation
+import os.log
+
+/// Centralized `os.log` Logger registry. Replaces ad-hoc `print`/`NSLog`
+/// calls throughout the app so log output is filterable in Console.app
+/// (`subsystem == "com.wallnetic.app"`) and `.debug` entries are stripped
+/// from Release builds automatically by the OSLog system.
+///
+/// Usage:
+///     Log.power.info("Switched to battery power")
+///     Log.auth.error("Sign in failed: \(error.localizedDescription, privacy: .public)")
+///     Log.video.debug("Frame decoded — pts=\(pts)")          // Release: hidden
+enum Log {
+    private static let subsystem = "com.wallnetic.app"
+
+    static let app          = Logger(subsystem: subsystem, category: "App")
+    static let ai           = Logger(subsystem: subsystem, category: "AI")
+    static let browser      = Logger(subsystem: subsystem, category: "Browser")
+    static let analytics    = Logger(subsystem: subsystem, category: "Analytics")
+    static let auth         = Logger(subsystem: subsystem, category: "Auth")
+    static let cloud        = Logger(subsystem: subsystem, category: "Cloud")
+    static let deepLink     = Logger(subsystem: subsystem, category: "DeepLink")
+    static let download     = Logger(subsystem: subsystem, category: "Download")
+    static let history      = Logger(subsystem: subsystem, category: "GenerationHistory")
+    static let icloud       = Logger(subsystem: subsystem, category: "iCloud")
+    static let keychain     = Logger(subsystem: subsystem, category: "Keychain")
+    static let lockScreen   = Logger(subsystem: subsystem, category: "LockScreen")
+    static let mlw          = Logger(subsystem: subsystem, category: "MLWDecryptor")
+    static let music        = Logger(subsystem: subsystem, category: "MusicReactive")
+    static let notification = Logger(subsystem: subsystem, category: "Notification")
+    static let power        = Logger(subsystem: subsystem, category: "Power")
+    static let render       = Logger(subsystem: subsystem, category: "Render")
+    static let scheduler    = Logger(subsystem: subsystem, category: "Scheduler")
+    static let screenSaver  = Logger(subsystem: subsystem, category: "ScreenSaver")
+    static let shared       = Logger(subsystem: subsystem, category: "SharedData")
+    static let space        = Logger(subsystem: subsystem, category: "SpaceWallpaper")
+    static let store        = Logger(subsystem: subsystem, category: "WallpaperStore")
+    static let supabase     = Logger(subsystem: subsystem, category: "Supabase")
+    static let thumbnail    = Logger(subsystem: subsystem, category: "Thumbnail")
+    static let timeOfDay    = Logger(subsystem: subsystem, category: "TimeOfDay")
+    static let update       = Logger(subsystem: subsystem, category: "UpdateChecker")
+    static let usage        = Logger(subsystem: subsystem, category: "Usage")
+    static let video        = Logger(subsystem: subsystem, category: "Video")
+    static let visualizer   = Logger(subsystem: subsystem, category: "AudioVisualizer")
+    static let weather      = Logger(subsystem: subsystem, category: "Weather")
+    static let ui           = Logger(subsystem: subsystem, category: "UI")
+    static let window       = Logger(subsystem: subsystem, category: "Window")
+}

--- a/src/Wallnetic/Views/Main/ContentView.swift
+++ b/src/Wallnetic/Views/Main/ContentView.swift
@@ -104,7 +104,7 @@ struct ContentView: View {
                 }
             }
         case .failure(let error):
-            print("File picker error: \(error)")
+            Log.ui.error("File picker error: \(error.localizedDescription, privacy: .public)")
         }
     }
 

--- a/src/Wallnetic/Views/Main/DiscoverView.swift
+++ b/src/Wallnetic/Views/Main/DiscoverView.swift
@@ -465,9 +465,9 @@ struct InAppBrowserView: View {
                 DispatchQueue.main.async {
                     self.foundVideos = urls
                     if urls.isEmpty {
-                        NSLog("[Browser] No videos found on page")
+                        Log.browser.info("No videos found on page")
                     } else {
-                        NSLog("[Browser] Found %d videos", urls.count)
+                        Log.browser.info("Found \(urls.count) videos")
                     }
                 }
             }
@@ -549,7 +549,7 @@ struct WebViewWrapper: NSViewRepresentable {
                      for navigationAction: WKNavigationAction,
                      windowFeatures: WKWindowFeatures) -> WKWebView? {
             if let url = navigationAction.request.url {
-                NSLog("[Browser] Popup intercepted: %@", url.absoluteString)
+                Log.browser.info("Popup intercepted: \(url.absoluteString, privacy: .public)")
                 webView.load(navigationAction.request)
             }
             return nil
@@ -570,7 +570,7 @@ struct WebViewWrapper: NSViewRepresentable {
             if WebViewWrapper.videoExtensions.contains(ext) {
                 decisionHandler(.cancel)
                 let name = url.deletingPathExtension().lastPathComponent
-                NSLog("[Browser] Intercepted video: %@", url.absoluteString)
+                Log.browser.info("Intercepted video: \(url.absoluteString, privacy: .public)")
                 DownloadManager.shared.downloadAndImport(name: name, from: url)
                 return
             }
@@ -587,7 +587,7 @@ struct WebViewWrapper: NSViewRepresentable {
 
             // Intercept video responses → WKDownload
             if mimeType.starts(with: "video/") {
-                NSLog("[Browser] Starting WKDownload for video: %@ (%@)", url?.absoluteString ?? "?", mimeType)
+                Log.browser.info("Starting WKDownload for video: \(url?.absoluteString ?? "?", privacy: .public) (\(mimeType, privacy: .public))")
                 decisionHandler(.download)
                 return
             }
@@ -595,7 +595,7 @@ struct WebViewWrapper: NSViewRepresentable {
             // Archives (zip/mlw) → WKDownload
             let archiveMimes = ["application/zip", "application/x-zip-compressed"]
             if archiveMimes.contains(mimeType) {
-                NSLog("[Browser] Starting WKDownload for archive: %@ (%@)", url?.absoluteString ?? "?", mimeType)
+                Log.browser.info("Starting WKDownload for archive: \(url?.absoluteString ?? "?", privacy: .public) (\(mimeType, privacy: .public))")
                 decisionHandler(.download)
                 return
             }
@@ -609,8 +609,7 @@ struct WebViewWrapper: NSViewRepresentable {
                 let hasVideoFilename = videoExts.contains { disposition.lowercased().contains(".\($0)") }
 
                 if hasVideoFilename {
-                    NSLog("[Browser] Starting WKDownload for octet-stream: %@ (disposition: %@)",
-                          url?.absoluteString ?? "?", disposition)
+                    Log.browser.info("Starting WKDownload for octet-stream: \(url?.absoluteString ?? "?", privacy: .public) (disposition: \(disposition, privacy: .public))")
                     decisionHandler(.download)
                     return
                 }
@@ -660,7 +659,7 @@ struct WebViewWrapper: NSViewRepresentable {
             }
             progressObservations[download] = obs
 
-            NSLog("[Browser] WKDownload saving to: %@ (name: %@)", dest.lastPathComponent, name)
+            Log.browser.info("WKDownload saving to: \(dest.lastPathComponent, privacy: .public) (name: \(name, privacy: .public))")
             completionHandler(dest)
         }
 
@@ -670,7 +669,7 @@ struct WebViewWrapper: NSViewRepresentable {
 
             // Update UI: show "Processing..." state at 100%
             DownloadManager.shared.updateProgress(id: info.trackingID, progress: 1.0)
-            NSLog("[Browser] WKDownload complete: %@", info.name)
+            Log.browser.info("WKDownload complete: \(info.name, privacy: .public)")
 
             // Process: ZIP → MLW → MP4 → import
             let trackingID = info.trackingID
@@ -682,12 +681,12 @@ struct WebViewWrapper: NSViewRepresentable {
                     if importURL != info.dest {
                         try? FileManager.default.removeItem(at: info.dest)
                     }
-                    NSLog("[Browser] Imported: %@", info.name)
+                    Log.browser.info("Imported: \(info.name, privacy: .public)")
                     await MainActor.run {
                         DownloadManager.shared.completeDownload(id: trackingID)
                     }
                 } catch {
-                    NSLog("[Browser] Import failed for %@: %@", info.name, error.localizedDescription)
+                    Log.browser.error("Import failed for \(info.name, privacy: .public): \(error.localizedDescription, privacy: .public)")
                     await MainActor.run {
                         DownloadManager.shared.failDownload(id: trackingID)
                     }
@@ -701,7 +700,7 @@ struct WebViewWrapper: NSViewRepresentable {
             if let info {
                 DownloadManager.shared.failDownload(id: info.trackingID)
             }
-            NSLog("[Browser] WKDownload failed: %@ – %@", info?.name ?? "?", error.localizedDescription)
+            Log.browser.error("WKDownload failed: \(info?.name ?? "?", privacy: .public) – \(error.localizedDescription, privacy: .public)")
         }
 
         /// Process a downloaded file — detect format and decrypt if needed
@@ -714,7 +713,7 @@ struct WebViewWrapper: NSViewRepresentable {
             // ZIP file → extract .mlw → decrypt
             if header.count >= 4 && header[0] == 0x50 && header[1] == 0x4b
                 && header[2] == 0x03 && header[3] == 0x04 {
-                NSLog("[Browser] Processing ZIP for MLW: %@", name)
+                Log.browser.info("Processing ZIP for MLW: \(name, privacy: .public)")
                 let mp4URL = FileManager.default.temporaryDirectory
                     .appendingPathComponent(UUID().uuidString)
                     .appendingPathExtension("mp4")
@@ -725,7 +724,7 @@ struct WebViewWrapper: NSViewRepresentable {
             // MLW file → decrypt directly
             if header.count >= 9 && (header.starts(with: Data("MLW.VIDEO".utf8))
                 || header.starts(with: Data("MLW.DEPTH".utf8))) {
-                NSLog("[Browser] Processing MLW: %@", name)
+                Log.browser.info("Processing MLW: \(name, privacy: .public)")
                 let mp4URL = FileManager.default.temporaryDirectory
                     .appendingPathComponent(UUID().uuidString)
                     .appendingPathExtension("mp4")

--- a/src/Wallnetic/Views/Main/DynamicIslandView.swift
+++ b/src/Wallnetic/Views/Main/DynamicIslandView.swift
@@ -312,7 +312,7 @@ struct DynamicIslandView: View {
                 }
             } catch {
                 await MainActor.run { island.isImporting = false }
-                print("[DynamicIsland] Drop import failed: \(error)")
+                Log.ui.error("Drop import failed: \(error.localizedDescription, privacy: .public)")
             }
         }
     }

--- a/src/Wallnetic/Views/Settings/SettingsSubViews.swift
+++ b/src/Wallnetic/Views/Settings/SettingsSubViews.swift
@@ -176,7 +176,7 @@ struct GeneralSettingsView: View {
             if enabled { try SMAppService.mainApp.register() }
             else { try SMAppService.mainApp.unregister() }
         } catch {
-            print("Failed to set launch at login: \(error)")
+            Log.app.error("Failed to set launch at login: \(error.localizedDescription, privacy: .public)")
         }
     }
 }

--- a/src/Wallnetic/Wallnetic.xcodeproj/project.pbxproj
+++ b/src/Wallnetic/Wallnetic.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		3F705E631F7827AD76411878 /* WallpaperMetadataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0F9B4893FCEA17EEFC7550A /* WallpaperMetadataStore.swift */; };
 		40D40FD944D13CCAF633E4A9 /* Wallpaper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3FD865C09D4CE6C4025020 /* Wallpaper.swift */; };
 		42AF0F91E2BE36A155243433 /* LockScreenManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E4377C1CA7A41D21A10FC40 /* LockScreenManager.swift */; };
+		4BC3BA52E3938E15E6BC7AAA /* Log.swift in Sources */ = {isa = PBXBuildFile; fileRef = F62ADB679C576DF4637BA6C9 /* Log.swift */; };
 		4D244E609DA6FBD637CD7D8F /* WallneticApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D9A31C3562655D7C27A30B1 /* WallneticApp.swift */; };
 		4DC3D57FC37765D6CEABF304 /* ColorCategoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56F59C3C7AB56348DA1D9D45 /* ColorCategoryTests.swift */; };
 		51355B920BE931D2A9A3BE58 /* WallpaperCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8562F59693CF276239AD0905 /* WallpaperCollection.swift */; };
@@ -237,6 +238,7 @@
 		E0187521E8CC2C0BB29CE90D /* BatteryPromptService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatteryPromptService.swift; sourceTree = "<group>"; };
 		EA19F4DBD0636536454696F3 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		ED806BD7E0913BCDF1142604 /* MetalVideoRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetalVideoRenderer.swift; sourceTree = "<group>"; };
+		F62ADB679C576DF4637BA6C9 /* Log.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Log.swift; sourceTree = "<group>"; };
 		F9534BF578FB9EFE92050C52 /* TimeOfDayManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeOfDayManager.swift; sourceTree = "<group>"; };
 		F9960B917192178D2217E668 /* iCloudSyncManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iCloudSyncManager.swift; sourceTree = "<group>"; };
 		FA624026F461BCF47C3E39D5 /* UsageTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageTracker.swift; sourceTree = "<group>"; };
@@ -262,6 +264,7 @@
 			children = (
 				4C70B541C6297E485FF1E0AF /* ExceptionCatcher.h */,
 				AA91ACE8CEF6E8C6CC8A68B8 /* ExceptionCatcher.m */,
+				F62ADB679C576DF4637BA6C9 /* Log.swift */,
 				585BFEEC0C8B2AF4168BD91A /* Wallnetic-Bridging-Header.h */,
 			);
 			path = Utils;
@@ -691,6 +694,7 @@
 				131EDF3DA15DA0EEA84918A4 /* HomeView.swift in Sources */,
 				1CA1504E421EAE5C547DF122 /* KeychainManager.swift in Sources */,
 				42AF0F91E2BE36A155243433 /* LockScreenManager.swift in Sources */,
+				4BC3BA52E3938E15E6BC7AAA /* Log.swift in Sources */,
 				EA0AA7318BCBE3C944FF48ED /* MLWDecryptor.swift in Sources */,
 				61B1EC0DBC85801311FA1F2F /* MenuBarView.swift in Sources */,
 				71B0E8B741F75A6147C62611 /* MetalVideoRenderer.swift in Sources */,


### PR DESCRIPTION
## Summary

Closes #169 — replaces all 93 `print`/`NSLog` calls across 34 files with a
centralized `Log` enum at `Utils/Log.swift` wrapping `os.log` Logger
instances per category.

## Why

`print`/`NSLog`:
- Run in Release builds, polluting the system log.
- No subsystem/category filtering in Console.app.
- No privacy-level annotations.

`os.log` Logger (the new approach):
- Strips `.debug` entries from Release builds automatically.
- Lets users filter Console.app by `subsystem == com.wallnetic.app` and category.
- Marks emails `.private`, system events `.public` — proper privacy hygiene.

## Categories registered

| Category | Files using it |
|---|---|
| `app` | AppDelegate, SettingsSubViews |
| `ai` | AIService |
| `analytics` | AnalyticsManager |
| `auth` | AuthManager |
| `browser` | DiscoverView |
| `cloud` | CloudSyncManager |
| `deepLink` | DeepLinkHandler |
| `download` | DownloadManager |
| `history` | GenerationHistory |
| `icloud` | iCloudSyncManager |
| `keychain` | KeychainManager |
| `lockScreen` | LockScreenManager |
| `mlw` | MLWDecryptor |
| `music` | MusicReactiveManager |
| `notification` | NotificationManager |
| `power` | PowerManager |
| `scheduler` | SchedulerService |
| `screenSaver` | ScreenSaverBridge |
| `shared` | SharedDataManager |
| `space` | SpaceWallpaperManager |
| `store` | WallpaperStoreManager |
| `supabase` | SupabaseClient |
| `thumbnail` | ThumbnailCache |
| `timeOfDay` | TimeOfDayManager |
| `ui` | ContentView, DynamicIslandView |
| `update` | UpdateChecker |
| `usage` | UsageTracker |
| `video` | VideoRenderer |
| `visualizer` | AudioVisualizerManager |
| `weather` | WeatherWallpaperManager |
| `window` | DesktopWindowController |

## Severity mapping

- `.error` — caught exceptions / failure paths (always shown in Release).
- `.info` — state transitions, lifecycle events.
- `.debug` — diagnostics, Release-stripped automatically.

`#if DEBUG` wrappers around the converted calls were removed — the
.debug level handles release-time filtering on its own.

## Build

- Debug: ✓
- Release: ✓

## Test plan

- [ ] Launch app, open Console.app, filter `subsystem == com.wallnetic.app`.
- [ ] Switch power source — `category == Power` shows transitions.
- [ ] Trigger a download in Discover — `category == Browser` shows the WKDownload lifecycle.
- [ ] Sign in/out — `category == Auth` masks the email as `<private>`.
- [ ] Confirm Release build does not emit any `category == Power | Video | UI` debug lines (filter by level).