### PR TITLE
Audio Visualizer customization (#159, #160, #161, #162)

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,8 @@ open Wallnetic.xcodeproj
 - [x] 37 unit tests for Wallpaper, URL helpers, async init (#140)
 - [x] Privacy Manifest (`PrivacyInfo.xcprivacy`) for App Store compliance (#164)
 - [x] MRMediaRemote private framework gated to `#if DEBUG` for store builds (#165)
+- [x] Centralized `os.log` logging — 93 `print`/`NSLog` → `Log.*` registry across 31 categories (#169)
+- [x] Audio Visualizer customization &mdash; sensitivity slider, 3 styles (Bars/Waveform/Dots), 6 corner positions, S/M/L sizes (#159, #160, #161, #162)
 
 ### v2.0 &mdash; Planned
 - [ ] AI video generation from text prompts

--- a/src/Wallnetic/Engine/AudioVisualizerOverlayController.swift
+++ b/src/Wallnetic/Engine/AudioVisualizerOverlayController.swift
@@ -12,6 +12,12 @@ final class AudioVisualizerOverlayController: ObservableObject {
     private var window: NSPanel?
 
     private init() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(layoutDidChange),
+            name: .audioVisualizerLayoutDidChange,
+            object: nil
+        )
         if isEnabled {
             DispatchQueue.main.async { [weak self] in self?.show() }
         }
@@ -33,16 +39,8 @@ final class AudioVisualizerOverlayController: ObservableObject {
             }
         }
 
-        let screen = NSScreen.main ?? NSScreen.screens.first
-        let screenFrame = screen?.visibleFrame ?? NSRect(x: 0, y: 0, width: 1440, height: 900)
-        let size = NSSize(width: 520, height: 180)
-        let origin = NSPoint(
-            x: screenFrame.maxX - size.width - 32,
-            y: screenFrame.minY + 32
-        )
-
         let panel = NSPanel(
-            contentRect: NSRect(origin: origin, size: size),
+            contentRect: NSRect(origin: .zero, size: AudioVisualizerManager.shared.sizePreset.dimensions),
             styleMask: [.borderless, .nonactivatingPanel],
             backing: .buffered,
             defer: true
@@ -58,10 +56,45 @@ final class AudioVisualizerOverlayController: ObservableObject {
             rootView: AudioVisualizerOverlayView()
                 .environmentObject(AudioVisualizerManager.shared)
         )
+
+        anchorPanel(panel)
         panel.orderFront(nil)
 
         window = panel
         isVisible = true
+    }
+
+    /// Computes the panel frame from the current size preset + corner anchor
+    /// (#161, #162) and applies it. Called both on `show` and after a layout
+    /// notification.
+    private func anchorPanel(_ panel: NSPanel) {
+        let screen = NSScreen.main ?? NSScreen.screens.first
+        let visible = screen?.visibleFrame ?? NSRect(x: 0, y: 0, width: 1440, height: 900)
+        let size = AudioVisualizerManager.shared.sizePreset.dimensions
+        let inset: CGFloat = 32
+
+        let origin: NSPoint
+        switch AudioVisualizerManager.shared.position {
+        case .bottomRight:
+            origin = NSPoint(x: visible.maxX - size.width - inset, y: visible.minY + inset)
+        case .bottomLeft:
+            origin = NSPoint(x: visible.minX + inset, y: visible.minY + inset)
+        case .topRight:
+            origin = NSPoint(x: visible.maxX - size.width - inset, y: visible.maxY - size.height - inset)
+        case .topLeft:
+            origin = NSPoint(x: visible.minX + inset, y: visible.maxY - size.height - inset)
+        case .bottomCenter:
+            origin = NSPoint(x: visible.midX - size.width / 2, y: visible.minY + inset)
+        case .topCenter:
+            origin = NSPoint(x: visible.midX - size.width / 2, y: visible.maxY - size.height - inset)
+        }
+
+        panel.setFrame(NSRect(origin: origin, size: size), display: true, animate: false)
+    }
+
+    @objc private func layoutDidChange() {
+        guard let panel = window else { return }
+        anchorPanel(panel)
     }
 
     func hide() {

--- a/src/Wallnetic/Services/AudioVisualizerManager.swift
+++ b/src/Wallnetic/Services/AudioVisualizerManager.swift
@@ -23,9 +23,65 @@ final class AudioVisualizerManager: NSObject, ObservableObject {
         }
     }
 
+    /// Rendering style for the overlay (#160). Implemented in
+    /// `AudioVisualizerOverlayView` — adding a case here requires a matching
+    /// branch in the view's draw routine.
+    enum Style: String, CaseIterable, Identifiable {
+        case bars      // Original 64-column burst (default)
+        case waveform  // Continuous mirrored waveform line
+        case dots      // Sparse circular dot grid
+        var id: String { rawValue }
+        var label: String {
+            switch self {
+            case .bars:     return "Bars"
+            case .waveform: return "Waveform"
+            case .dots:     return "Dots"
+            }
+        }
+    }
+
+    /// On-screen anchor point for the overlay panel (#161).
+    enum Position: String, CaseIterable, Identifiable {
+        case bottomRight, bottomLeft, topRight, topLeft, bottomCenter, topCenter
+        var id: String { rawValue }
+        var label: String {
+            switch self {
+            case .bottomRight:  return "Bottom Right"
+            case .bottomLeft:   return "Bottom Left"
+            case .topRight:     return "Top Right"
+            case .topLeft:      return "Top Left"
+            case .bottomCenter: return "Bottom Center"
+            case .topCenter:    return "Top Center"
+            }
+        }
+    }
+
+    /// Overlay panel size preset (#162).
+    enum Size: String, CaseIterable, Identifiable {
+        case small, medium, large
+        var id: String { rawValue }
+        var label: String {
+            switch self {
+            case .small:  return "Small"
+            case .medium: return "Medium"
+            case .large:  return "Large"
+            }
+        }
+        var dimensions: NSSize {
+            switch self {
+            case .small:  return NSSize(width: 380, height: 130)
+            case .medium: return NSSize(width: 520, height: 180)
+            case .large:  return NSSize(width: 720, height: 250)
+            }
+        }
+    }
+
     @AppStorage("audioVisualizer.enabled") var isEnabled: Bool = false
     @AppStorage("audioVisualizer.sensitivity") var sensitivity: Double = 1.0
     @AppStorage("audioVisualizer.source") private var sourceRaw: String = Source.system.rawValue
+    @AppStorage("audioVisualizer.style") private var styleRaw: String = Style.bars.rawValue
+    @AppStorage("audioVisualizer.position") private var positionRaw: String = Position.bottomRight.rawValue
+    @AppStorage("audioVisualizer.size") private var sizeRaw: String = Size.medium.rawValue
 
     @Published var bands: [Float] = Array(repeating: 0, count: bandCount)
     @Published var peaks: [Float] = Array(repeating: 0, count: bandCount)
@@ -42,6 +98,32 @@ final class AudioVisualizerManager: NSObject, ObservableObject {
                 stop()
                 start()
             }
+        }
+    }
+
+    var style: Style {
+        get { Style(rawValue: styleRaw) ?? .bars }
+        set {
+            styleRaw = newValue.rawValue
+            objectWillChange.send()
+        }
+    }
+
+    var position: Position {
+        get { Position(rawValue: positionRaw) ?? .bottomRight }
+        set {
+            positionRaw = newValue.rawValue
+            objectWillChange.send()
+            NotificationCenter.default.post(name: .audioVisualizerLayoutDidChange, object: nil)
+        }
+    }
+
+    var sizePreset: Size {
+        get { Size(rawValue: sizeRaw) ?? .medium }
+        set {
+            sizeRaw = newValue.rawValue
+            objectWillChange.send()
+            NotificationCenter.default.post(name: .audioVisualizerLayoutDidChange, object: nil)
         }
     }
 
@@ -411,4 +493,10 @@ extension AudioVisualizerManager: SCStreamOutput, SCStreamDelegate {
             self.scStream = nil
         }
     }
+}
+
+extension Notification.Name {
+    /// Fired when the user changes the visualizer's position or size preset
+    /// (#161 / #162) so the overlay panel can re-anchor / resize.
+    static let audioVisualizerLayoutDidChange = Notification.Name("audioVisualizerLayoutDidChange")
 }

--- a/src/Wallnetic/Views/Main/AudioVisualizerOverlayView.swift
+++ b/src/Wallnetic/Views/Main/AudioVisualizerOverlayView.swift
@@ -40,15 +40,107 @@ struct AudioVisualizerOverlayView: View {
 
         drawBackground(context: context, size: size, centerY: centerY, accent: accent, loudness: loud)
 
-        context.drawLayer { layer in
-            layer.addFilter(.blur(radius: 10))
-            layer.opacity = 0.55
-            drawBurst(context: layer, size: size, centerY: centerY, bands: bands, accent: accent)
+        switch manager.style {
+        case .bars:
+            context.drawLayer { layer in
+                layer.addFilter(.blur(radius: 10))
+                layer.opacity = 0.55
+                drawBurst(context: layer, size: size, centerY: centerY, bands: bands, accent: accent)
+            }
+            drawBurst(context: context, size: size, centerY: centerY, bands: bands, accent: accent)
+            drawCenterLine(context: context, size: size, centerY: centerY, accent: accent, loudness: loud)
+
+        case .waveform:
+            context.drawLayer { layer in
+                layer.addFilter(.blur(radius: 8))
+                layer.opacity = 0.6
+                drawWaveform(context: layer, size: size, centerY: centerY, bands: bands, accent: accent)
+            }
+            drawWaveform(context: context, size: size, centerY: centerY, bands: bands, accent: accent)
+
+        case .dots:
+            context.drawLayer { layer in
+                layer.addFilter(.blur(radius: 6))
+                layer.opacity = 0.5
+                drawDots(context: layer, size: size, centerY: centerY, bands: bands, accent: accent)
+            }
+            drawDots(context: context, size: size, centerY: centerY, bands: bands, accent: accent)
+        }
+    }
+
+    // MARK: - Style: Waveform — mirrored continuous line driven by band amplitudes
+
+    private func drawWaveform(context: GraphicsContext, size: CGSize, centerY: CGFloat, bands: [Float], accent: Color) {
+        let inset: CGFloat = 8
+        let usableWidth = size.width - inset * 2
+        let halfHeight = centerY - 6
+        let count = bands.count
+        guard count > 1 else { return }
+
+        var topPath = Path()
+        var bottomPath = Path()
+
+        for (i, value) in bands.enumerated() {
+            let x = inset + CGFloat(i) / CGFloat(count - 1) * usableWidth
+            let amplitude = max(0.0, CGFloat(value)) * halfHeight
+            let yTop = centerY - amplitude
+            let yBottom = centerY + amplitude
+
+            if i == 0 {
+                topPath.move(to: CGPoint(x: x, y: yTop))
+                bottomPath.move(to: CGPoint(x: x, y: yBottom))
+            } else {
+                topPath.addLine(to: CGPoint(x: x, y: yTop))
+                bottomPath.addLine(to: CGPoint(x: x, y: yBottom))
+            }
         }
 
-        drawBurst(context: context, size: size, centerY: centerY, bands: bands, accent: accent)
+        context.stroke(topPath, with: .color(accent.opacity(0.95)), lineWidth: 1.6)
+        context.stroke(bottomPath, with: .color(accent.opacity(0.95)), lineWidth: 1.6)
 
-        drawCenterLine(context: context, size: size, centerY: centerY, accent: accent, loudness: loud)
+        // Center line for context
+        let line = CGRect(x: inset, y: centerY - 0.5, width: usableWidth, height: 1)
+        context.fill(Path(roundedRect: line, cornerRadius: 0.5), with: .color(.white.opacity(0.35)))
+    }
+
+    // MARK: - Style: Dots — sparse circular dot grid lit by amplitude
+
+    private func drawDots(context: GraphicsContext, size: CGSize, centerY: CGFloat, bands: [Float], accent: Color) {
+        let inset: CGFloat = 10
+        let usableWidth = size.width - inset * 2
+        let halfHeight = centerY - 8
+        let dotRadius: CGFloat = 1.6
+        let dotPitch: CGFloat = 6
+        let maxDots = max(1, Int(halfHeight / dotPitch))
+
+        let acR = accentRGB.r
+        let acG = accentRGB.g
+        let acB = accentRGB.b
+
+        let count = bands.count
+        for (i, value) in bands.enumerated() {
+            let x = inset + CGFloat(i) / CGFloat(max(count - 1, 1)) * usableWidth
+            let amplitude = max(0.0, CGFloat(value))
+            let litDots = max(1, Int(round(amplitude * CGFloat(maxDots))))
+
+            for d in 0..<litDots {
+                let progress = Double(d) / Double(max(litDots - 1, 1))
+                let tipMix = progress * progress
+                let alpha = 0.85 - progress * 0.3
+                let r = acR + (1.0 - acR) * tipMix
+                let g = acG + (1.0 - acG) * tipMix
+                let b = acB + (1.0 - acB) * tipMix
+                let color = Color(red: r, green: g, blue: b, opacity: alpha)
+
+                let offset = CGFloat(d) * dotPitch + 4
+                let topY = centerY - offset
+                let bottomY = centerY + offset
+                let topRect = CGRect(x: x - dotRadius, y: topY - dotRadius, width: dotRadius * 2, height: dotRadius * 2)
+                let bottomRect = CGRect(x: x - dotRadius, y: bottomY - dotRadius, width: dotRadius * 2, height: dotRadius * 2)
+                context.fill(Path(ellipseIn: topRect), with: .color(color))
+                context.fill(Path(ellipseIn: bottomRect), with: .color(color))
+            }
+        }
     }
 
     // MARK: - Background

--- a/src/Wallnetic/Views/Settings/SettingsSubViews.swift
+++ b/src/Wallnetic/Views/Settings/SettingsSubViews.swift
@@ -184,6 +184,9 @@ struct GeneralSettingsView: View {
 private struct AudioVisualizerSourcePicker: View {
     @ObservedObject private var manager = AudioVisualizerManager.shared
     @State private var source: AudioVisualizerManager.Source = .system
+    @State private var style: AudioVisualizerManager.Style = .bars
+    @State private var position: AudioVisualizerManager.Position = .bottomRight
+    @State private var sizePreset: AudioVisualizerManager.Size = .medium
 
     var body: some View {
         Picker("Audio source", selection: $source) {
@@ -192,8 +195,51 @@ private struct AudioVisualizerSourcePicker: View {
             }
         }
         .pickerStyle(.segmented)
-        .onAppear { source = manager.source }
+        .onAppear {
+            source = manager.source
+            style = manager.style
+            position = manager.position
+            sizePreset = manager.sizePreset
+        }
         .onChange(of: source) { newValue in manager.source = newValue }
+
+        // #159 — sensitivity slider
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text("Sensitivity")
+                Spacer()
+                Text(String(format: "%.1fx", manager.sensitivity))
+                    .foregroundColor(.secondary)
+                    .monospacedDigit()
+            }
+            Slider(value: $manager.sensitivity, in: 0.3...3.0, step: 0.1)
+        }
+
+        // #160 — visual style
+        Picker("Style", selection: $style) {
+            ForEach(AudioVisualizerManager.Style.allCases) { s in
+                Text(s.label).tag(s)
+            }
+        }
+        .pickerStyle(.segmented)
+        .onChange(of: style) { newValue in manager.style = newValue }
+
+        // #162 — size preset
+        Picker("Size", selection: $sizePreset) {
+            ForEach(AudioVisualizerManager.Size.allCases) { s in
+                Text(s.label).tag(s)
+            }
+        }
+        .pickerStyle(.segmented)
+        .onChange(of: sizePreset) { newValue in manager.sizePreset = newValue }
+
+        // #161 — corner anchor
+        Picker("Position", selection: $position) {
+            ForEach(AudioVisualizerManager.Position.allCases) { p in
+                Text(p.label).tag(p)
+            }
+        }
+        .onChange(of: position) { newValue in manager.position = newValue }
 
         if let error = manager.lastError {
             Label(error, systemImage: "exclamationmark.triangle.fill")


### PR DESCRIPTION
## Summary

Closes #159, #160, #161, #162 — four customization options for the
audio visualizer overlay. All live in Settings → General → Audio
Visualizer.

## Surface

| # | Control | UI |
|---|---------|----|
| #159 | Sensitivity | Slider (0.3x–3.0x, 0.1 step). Bound to the existing `audioVisualizer.sensitivity` AppStorage. |
| #160 | Style | Segmented picker — Bars (default), Waveform, Dots. |
| #161 | Position | Picker — Bottom Right (default), Bottom Left, Top Right, Top Left, Bottom Center, Top Center. |
| #162 | Size | Segmented picker — Small (380×130), Medium (520×180, default), Large (720×250). |

## Engine changes

- `AudioVisualizerManager` gains `Style`, `Position`, `Size` enums plus
  three new `@AppStorage`-backed rawValue properties.
- New `Notification.Name.audioVisualizerLayoutDidChange` lets the
  controller re-anchor / resize the panel in place when position or
  size changes.

## Render changes

- `AudioVisualizerOverlayView.draw(...)` switches on `manager.style`
  and dispatches to `drawBurst` (existing, kept), `drawWaveform`, or
  `drawDots`.
- Each style has its own blur+layering pass for the soft-glow look.

## Build

- Debug: ✓
- Release: ✓

## Test plan

- [ ] Open Settings while the overlay is visible.
- [ ] Drag sensitivity slider — bar amplitude responds in real time
      without restarting the overlay.
- [ ] Cycle styles — overlay re-renders without flicker.
- [ ] Cycle positions — panel jumps to the new corner immediately.
- [ ] Cycle sizes — panel resizes in place at the chosen corner.
- [ ] Restart app — last-selected sensitivity/style/position/size
      persist (AppStorage).
- [ ] With the overlay disabled, all four controls remain hidden
      (existing behavior — they live inside the source picker view
      which is gated on the master toggle).