### PR TITLE
Photos slideshow generator (#137)

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ open Wallnetic.xcodeproj
 - [x] MRMediaRemote private framework gated to `#if DEBUG` for store builds (#165)
 - [x] Centralized `os.log` logging — 93 `print`/`NSLog` → `Log.*` registry across 31 categories (#169)
 - [x] Audio Visualizer customization &mdash; sensitivity slider, 3 styles (Bars/Waveform/Dots), 6 corner positions, S/M/L sizes (#159, #160, #161, #162)
+- [x] Photos slideshow generator &mdash; create wallpapers from your Apple Photos library with Ken Burns and crossfade transitions (#137)
 
 ### v2.0 &mdash; Planned
 - [ ] AI video generation from text prompts

--- a/src/Wallnetic/Resources/Info.plist
+++ b/src/Wallnetic/Resources/Info.plist
@@ -43,6 +43,8 @@
 	<true/>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Wallnetic uses microphone audio to drive the on-desktop audio visualizer.</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Wallnetic reads selected photos from your library to generate slideshow wallpapers. Nothing is uploaded or shared.</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 	<key>NSScreenCaptureUsageDescription</key>

--- a/src/Wallnetic/Services/PhotosLibraryService.swift
+++ b/src/Wallnetic/Services/PhotosLibraryService.swift
@@ -1,0 +1,154 @@
+import Foundation
+import Photos
+import AppKit
+
+/// Wraps Apple Photos framework access for the Memories integration (#137).
+/// Handles authorization, lazy album/asset fetching, and thumbnail loading.
+///
+/// Authorization is requested once via `requestAuthorization`; callers should
+/// branch on the returned status and present a Settings deep-link if denied.
+@MainActor
+final class PhotosLibraryService: ObservableObject {
+    static let shared = PhotosLibraryService()
+
+    @Published private(set) var authStatus: PHAuthorizationStatus = .notDetermined
+
+    private let imageManager = PHCachingImageManager()
+
+    private init() {
+        authStatus = PHPhotoLibrary.authorizationStatus(for: .readWrite)
+    }
+
+    // MARK: - Authorization
+
+    func requestAuthorization() async -> PHAuthorizationStatus {
+        let status = await withCheckedContinuation { (cont: CheckedContinuation<PHAuthorizationStatus, Never>) in
+            PHPhotoLibrary.requestAuthorization(for: .readWrite) { status in
+                cont.resume(returning: status)
+            }
+        }
+        await MainActor.run { self.authStatus = status }
+        return status
+    }
+
+    var isAuthorized: Bool {
+        authStatus == .authorized || authStatus == .limited
+    }
+
+    // MARK: - Albums
+
+    /// Returns user-created albums plus the synthetic "Recents" smart album.
+    func fetchAlbums() -> [AlbumDescriptor] {
+        var result: [AlbumDescriptor] = []
+
+        // Recents smart album (most recent media)
+        let recents = PHAssetCollection.fetchAssetCollections(
+            with: .smartAlbum,
+            subtype: .smartAlbumUserLibrary,
+            options: nil
+        )
+        if let collection = recents.firstObject {
+            result.append(AlbumDescriptor(collection: collection, displayName: "Recents"))
+        }
+
+        // Favorites smart album
+        let favorites = PHAssetCollection.fetchAssetCollections(
+            with: .smartAlbum,
+            subtype: .smartAlbumFavorites,
+            options: nil
+        )
+        if let collection = favorites.firstObject {
+            result.append(AlbumDescriptor(collection: collection, displayName: "Favorites"))
+        }
+
+        // User-created albums
+        let userAlbums = PHAssetCollection.fetchAssetCollections(
+            with: .album,
+            subtype: .albumRegular,
+            options: nil
+        )
+        userAlbums.enumerateObjects { collection, _, _ in
+            let name = collection.localizedTitle ?? "Album"
+            result.append(AlbumDescriptor(collection: collection, displayName: name))
+        }
+
+        return result
+    }
+
+    /// Fetches image-only assets in the given album, newest first.
+    /// Limited to `limit` results to keep grid render fast — the user can
+    /// search/filter inside their library if they need older items.
+    func fetchAssets(in album: AlbumDescriptor, limit: Int = 300) -> [PHAsset] {
+        let options = PHFetchOptions()
+        options.sortDescriptors = [NSSortDescriptor(key: "creationDate", ascending: false)]
+        options.predicate = NSPredicate(format: "mediaType == %d", PHAssetMediaType.image.rawValue)
+        options.fetchLimit = limit
+
+        let result = PHAsset.fetchAssets(in: album.collection, options: options)
+        var assets: [PHAsset] = []
+        result.enumerateObjects { asset, _, _ in assets.append(asset) }
+        return assets
+    }
+
+    // MARK: - Thumbnails
+
+    /// Loads a square thumbnail for the asset at the requested point size
+    /// (the manager scales by display scale internally). The completion is
+    /// always invoked on the main queue.
+    func requestThumbnail(for asset: PHAsset, targetSize: CGSize, completion: @escaping (NSImage?) -> Void) {
+        let options = PHImageRequestOptions()
+        options.deliveryMode = .opportunistic
+        options.resizeMode = .fast
+        options.isNetworkAccessAllowed = true
+
+        imageManager.requestImage(
+            for: asset,
+            targetSize: targetSize,
+            contentMode: .aspectFill,
+            options: options
+        ) { image, _ in
+            DispatchQueue.main.async { completion(image) }
+        }
+    }
+
+    /// Loads a full-size image for slideshow rendering.
+    func requestFullImage(for asset: PHAsset) async -> NSImage? {
+        await withCheckedContinuation { (cont: CheckedContinuation<NSImage?, Never>) in
+            let options = PHImageRequestOptions()
+            options.deliveryMode = .highQualityFormat
+            options.resizeMode = .exact
+            options.isNetworkAccessAllowed = true
+            options.isSynchronous = false
+
+            imageManager.requestImage(
+                for: asset,
+                targetSize: PHImageManagerMaximumSize,
+                contentMode: .aspectFit,
+                options: options
+            ) { image, info in
+                // Skip the low-res "opportunistic" preview if a degraded flag is set.
+                if let isDegraded = info?[PHImageResultIsDegradedKey] as? Bool, isDegraded {
+                    return
+                }
+                cont.resume(returning: image)
+            }
+        }
+    }
+}
+
+// MARK: - Models
+
+struct AlbumDescriptor: Identifiable, Hashable {
+    let collection: PHAssetCollection
+    let displayName: String
+
+    var id: String { collection.localIdentifier }
+
+    static func == (lhs: AlbumDescriptor, rhs: AlbumDescriptor) -> Bool {
+        lhs.collection.localIdentifier == rhs.collection.localIdentifier
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(collection.localIdentifier)
+    }
+}

--- a/src/Wallnetic/Services/SlideshowGenerator.swift
+++ b/src/Wallnetic/Services/SlideshowGenerator.swift
@@ -1,0 +1,395 @@
+import Foundation
+import AVFoundation
+import Photos
+import AppKit
+import CoreImage
+
+/// Generates an MP4 slideshow from a list of `PHAsset`s with optional
+/// Ken Burns pan/zoom and crossfade transitions (#137).
+///
+/// Render strategy:
+/// 1. Load each PHAsset as a high-quality `NSImage`.
+/// 2. Build an offscreen CGContext at the target resolution, render each
+///    frame into it with the Ken Burns transform applied, and pipe pixel
+///    buffers into an `AVAssetWriter` configured for H.264.
+/// 3. Crossfades are realised by overlapping the last `transitionDuration`
+///    seconds of frame N with the first frame of N+1, blending alpha.
+@MainActor
+final class SlideshowGenerator {
+    enum Resolution {
+        case hd1080, qhd1440, uhd4k
+
+        var size: CGSize {
+            switch self {
+            case .hd1080: return CGSize(width: 1920, height: 1080)
+            case .qhd1440: return CGSize(width: 2560, height: 1440)
+            case .uhd4k: return CGSize(width: 3840, height: 2160)
+            }
+        }
+
+        var bitrate: Int {
+            switch self {
+            case .hd1080: return 8_000_000
+            case .qhd1440: return 14_000_000
+            case .uhd4k: return 24_000_000
+            }
+        }
+    }
+
+    enum Transition {
+        case none, crossfade
+    }
+
+    struct Settings {
+        var perPhotoDuration: TimeInterval = 5.0
+        var transition: Transition = .crossfade
+        var transitionDuration: TimeInterval = 0.6
+        var kenBurns: Bool = true
+        var resolution: Resolution = .hd1080
+        var fps: Int32 = 30
+    }
+
+    enum GeneratorError: LocalizedError {
+        case noAssets
+        case writerFailed(String)
+        case imageLoadFailed
+        case cancelled
+
+        var errorDescription: String? {
+            switch self {
+            case .noAssets: return "No photos selected."
+            case .writerFailed(let m): return "Video writer failed: \(m)"
+            case .imageLoadFailed: return "Could not load one of the selected photos."
+            case .cancelled: return "Slideshow generation was cancelled."
+            }
+        }
+    }
+
+    private let library: PhotosLibraryService
+
+    init(library: PhotosLibraryService = .shared) {
+        self.library = library
+    }
+
+    // MARK: - Public
+
+    /// Generates the slideshow and writes it to a temporary file. The
+    /// returned URL points at a `.mp4` ready to be imported via the
+    /// `WallpaperManager` import flow.
+    func generate(
+        assets: [PHAsset],
+        settings: Settings,
+        progress: @escaping (Double) -> Void
+    ) async throws -> URL {
+        guard !assets.isEmpty else { throw GeneratorError.noAssets }
+
+        let outputURL = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("Wallnetic-Slideshow-\(UUID().uuidString).mp4")
+
+        // Load all images upfront. For 30+ photos this is heavy, but slideshow
+        // counts realistically stay under 50 — the bottleneck is rendering, not
+        // load. Skip nil images so a single bad asset doesn't fail the whole job.
+        var images: [NSImage] = []
+        for (idx, asset) in assets.enumerated() {
+            if let img = await library.requestFullImage(for: asset) {
+                images.append(img)
+            }
+            progress(Double(idx + 1) / Double(assets.count) * 0.2)
+        }
+        guard !images.isEmpty else { throw GeneratorError.imageLoadFailed }
+
+        try await renderToFile(
+            images: images,
+            settings: settings,
+            outputURL: outputURL,
+            progress: { progress(0.2 + $0 * 0.8) }
+        )
+
+        return outputURL
+    }
+
+    // MARK: - Render pipeline
+
+    private func renderToFile(
+        images: [NSImage],
+        settings: Settings,
+        outputURL: URL,
+        progress: @escaping (Double) -> Void
+    ) async throws {
+        try? FileManager.default.removeItem(at: outputURL)
+
+        let writer = try AVAssetWriter(outputURL: outputURL, fileType: .mp4)
+        let outputSize = settings.resolution.size
+
+        let videoSettings: [String: Any] = [
+            AVVideoCodecKey: AVVideoCodecType.h264,
+            AVVideoWidthKey: outputSize.width,
+            AVVideoHeightKey: outputSize.height,
+            AVVideoCompressionPropertiesKey: [
+                AVVideoAverageBitRateKey: settings.resolution.bitrate,
+                AVVideoMaxKeyFrameIntervalKey: 60,
+                AVVideoProfileLevelKey: AVVideoProfileLevelH264HighAutoLevel
+            ]
+        ]
+
+        let writerInput = AVAssetWriterInput(mediaType: .video, outputSettings: videoSettings)
+        writerInput.expectsMediaDataInRealTime = false
+
+        let pixelBufferAttrs: [String: Any] = [
+            kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA,
+            kCVPixelBufferWidthKey as String: outputSize.width,
+            kCVPixelBufferHeightKey as String: outputSize.height
+        ]
+
+        let adaptor = AVAssetWriterInputPixelBufferAdaptor(
+            assetWriterInput: writerInput,
+            sourcePixelBufferAttributes: pixelBufferAttrs
+        )
+
+        guard writer.canAdd(writerInput) else {
+            throw GeneratorError.writerFailed("input not accepted")
+        }
+        writer.add(writerInput)
+
+        guard writer.startWriting() else {
+            throw GeneratorError.writerFailed(writer.error?.localizedDescription ?? "startWriting failed")
+        }
+        writer.startSession(atSourceTime: .zero)
+
+        try await renderFrames(
+            images: images,
+            settings: settings,
+            adaptor: adaptor,
+            writerInput: writerInput,
+            outputSize: outputSize,
+            progress: progress
+        )
+
+        writerInput.markAsFinished()
+        await writer.finishWriting()
+
+        if writer.status == .failed {
+            throw GeneratorError.writerFailed(writer.error?.localizedDescription ?? "unknown")
+        }
+    }
+
+    /// Generates each frame and submits it to the adaptor. Caller has already
+    /// configured the writer + input.
+    private func renderFrames(
+        images: [NSImage],
+        settings: Settings,
+        adaptor: AVAssetWriterInputPixelBufferAdaptor,
+        writerInput: AVAssetWriterInput,
+        outputSize: CGSize,
+        progress: @escaping (Double) -> Void
+    ) async throws {
+        let fps = settings.fps
+        let frameDuration = CMTime(value: 1, timescale: fps)
+        let framesPerImage = Int(settings.perPhotoDuration * Double(fps))
+        let transitionFrames = settings.transition == .crossfade
+            ? Int(settings.transitionDuration * Double(fps))
+            : 0
+        let totalFrames = images.count * framesPerImage - transitionFrames * (images.count - 1)
+
+        var frameIndex: Int = 0
+        let kenBurns = generateKenBurnsTransforms(count: images.count, intensity: settings.kenBurns ? 0.18 : 0)
+
+        let pool = adaptor.pixelBufferPool
+        let ciContext = CIContext(options: [.useSoftwareRenderer: false])
+
+        for imgIdx in 0..<images.count {
+            let isLast = imgIdx == images.count - 1
+            let blendInFrames = (imgIdx > 0 && transitionFrames > 0) ? transitionFrames : 0
+            let blendOutFrames = (!isLast && transitionFrames > 0) ? transitionFrames : 0
+            let solidFrames = framesPerImage - blendOutFrames
+
+            let frames = blendInFrames + solidFrames
+
+            for f in 0..<frames {
+                while !writerInput.isReadyForMoreMediaData {
+                    try await Task.sleep(nanoseconds: 5_000_000)
+                }
+
+                let progressInImage = Double(blendInFrames + f) / Double(framesPerImage)
+                let kbA = kenBurns[imgIdx].apply(progress: progressInImage)
+
+                guard let pool = pool, let buffer = makePixelBuffer(pool: pool) else {
+                    throw GeneratorError.writerFailed("could not allocate pixel buffer")
+                }
+
+                let alphaA: CGFloat
+                let alphaB: CGFloat
+                let prevImage: NSImage?
+                let prevTransform: CGAffineTransform?
+
+                if f < blendInFrames, imgIdx > 0 {
+                    // Crossfade-in from previous image
+                    let t = CGFloat(f) / CGFloat(max(blendInFrames, 1))
+                    alphaA = t
+                    alphaB = 1 - t
+                    prevImage = images[imgIdx - 1]
+                    let prevProgress = 1.0 - Double(blendInFrames - f) / Double(framesPerImage)
+                    prevTransform = kenBurns[imgIdx - 1].apply(progress: prevProgress)
+                } else {
+                    alphaA = 1
+                    alphaB = 0
+                    prevImage = nil
+                    prevTransform = nil
+                }
+
+                drawFrame(
+                    into: buffer,
+                    outputSize: outputSize,
+                    primary: images[imgIdx],
+                    primaryTransform: kbA,
+                    primaryAlpha: alphaA,
+                    secondary: prevImage,
+                    secondaryTransform: prevTransform,
+                    secondaryAlpha: alphaB,
+                    ciContext: ciContext
+                )
+
+                let pts = CMTimeMultiply(frameDuration, multiplier: Int32(frameIndex))
+                if !adaptor.append(buffer, withPresentationTime: pts) {
+                    throw GeneratorError.writerFailed("append failed at frame \(frameIndex)")
+                }
+                frameIndex += 1
+                progress(Double(frameIndex) / Double(totalFrames))
+            }
+        }
+    }
+
+    // MARK: - Ken Burns
+
+    private struct KenBurns {
+        var startScale: CGFloat
+        var endScale: CGFloat
+        var startOffset: CGPoint
+        var endOffset: CGPoint
+
+        /// Returns a transform that, when applied to an image already centered
+        /// at the output's center, produces the desired scale + offset for the
+        /// given progress value (0...1).
+        func apply(progress: Double) -> CGAffineTransform {
+            let p = max(0, min(1, progress))
+            let scale = startScale + (endScale - startScale) * CGFloat(p)
+            let offsetX = startOffset.x + (endOffset.x - startOffset.x) * CGFloat(p)
+            let offsetY = startOffset.y + (endOffset.y - startOffset.y) * CGFloat(p)
+            return CGAffineTransform(translationX: offsetX, y: offsetY).scaledBy(x: scale, y: scale)
+        }
+    }
+
+    private func generateKenBurnsTransforms(count: Int, intensity: CGFloat) -> [KenBurns] {
+        var seed = SystemRandomNumberGenerator()
+        return (0..<count).map { _ in
+            let zoomIn = Bool.random(using: &seed)
+            let startScale: CGFloat = zoomIn ? 1.0 : 1.0 + intensity
+            let endScale: CGFloat = zoomIn ? 1.0 + intensity : 1.0
+            let panRange = intensity * 80
+            let startX = CGFloat.random(in: -panRange...panRange, using: &seed)
+            let startY = CGFloat.random(in: -panRange...panRange, using: &seed)
+            let endX = CGFloat.random(in: -panRange...panRange, using: &seed)
+            let endY = CGFloat.random(in: -panRange...panRange, using: &seed)
+            return KenBurns(
+                startScale: startScale,
+                endScale: endScale,
+                startOffset: CGPoint(x: startX, y: startY),
+                endOffset: CGPoint(x: endX, y: endY)
+            )
+        }
+    }
+
+    // MARK: - Drawing
+
+    private func makePixelBuffer(pool: CVPixelBufferPool) -> CVPixelBuffer? {
+        var buffer: CVPixelBuffer?
+        CVPixelBufferPoolCreatePixelBuffer(nil, pool, &buffer)
+        return buffer
+    }
+
+    private func drawFrame(
+        into buffer: CVPixelBuffer,
+        outputSize: CGSize,
+        primary: NSImage,
+        primaryTransform: CGAffineTransform,
+        primaryAlpha: CGFloat,
+        secondary: NSImage?,
+        secondaryTransform: CGAffineTransform?,
+        secondaryAlpha: CGFloat,
+        ciContext: CIContext
+    ) {
+        CVPixelBufferLockBaseAddress(buffer, [])
+        defer { CVPixelBufferUnlockBaseAddress(buffer, []) }
+
+        guard let baseAddress = CVPixelBufferGetBaseAddress(buffer) else { return }
+        let bytesPerRow = CVPixelBufferGetBytesPerRow(buffer)
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+
+        guard let context = CGContext(
+            data: baseAddress,
+            width: Int(outputSize.width),
+            height: Int(outputSize.height),
+            bitsPerComponent: 8,
+            bytesPerRow: bytesPerRow,
+            space: colorSpace,
+            bitmapInfo: CGImageAlphaInfo.premultipliedFirst.rawValue | CGBitmapInfo.byteOrder32Little.rawValue
+        ) else { return }
+
+        // Black background
+        context.setFillColor(CGColor.black)
+        context.fill(CGRect(origin: .zero, size: outputSize))
+
+        if let secondary = secondary, let st = secondaryTransform, secondaryAlpha > 0.001 {
+            drawImage(secondary, into: context, outputSize: outputSize, transform: st, alpha: secondaryAlpha)
+        }
+
+        drawImage(primary, into: context, outputSize: outputSize, transform: primaryTransform, alpha: primaryAlpha)
+    }
+
+    private func drawImage(
+        _ image: NSImage,
+        into context: CGContext,
+        outputSize: CGSize,
+        transform: CGAffineTransform,
+        alpha: CGFloat
+    ) {
+        var rect = CGRect(origin: .zero, size: outputSize)
+        guard let cgImage = image.cgImage(forProposedRect: &rect, context: nil, hints: nil) else { return }
+
+        let imageSize = CGSize(width: cgImage.width, height: cgImage.height)
+        let imageAspect = imageSize.width / imageSize.height
+        let outAspect = outputSize.width / outputSize.height
+
+        // aspect-fit: contain inside the output, then ken-burns scales/offsets
+        var drawSize = outputSize
+        if imageAspect > outAspect {
+            drawSize.height = outputSize.width / imageAspect
+        } else {
+            drawSize.width = outputSize.height * imageAspect
+        }
+
+        // Cover instead of fit — we want full-frame look when ken-burns crops in.
+        var coverSize = outputSize
+        if imageAspect > outAspect {
+            coverSize.width = outputSize.height * imageAspect
+        } else {
+            coverSize.height = outputSize.width / imageAspect
+        }
+
+        let drawOrigin = CGPoint(
+            x: (outputSize.width - coverSize.width) / 2,
+            y: (outputSize.height - coverSize.height) / 2
+        )
+
+        context.saveGState()
+        context.setAlpha(alpha)
+
+        // Anchor the Ken Burns transform around the image center.
+        context.translateBy(x: outputSize.width / 2, y: outputSize.height / 2)
+        context.concatenate(transform)
+        context.translateBy(x: -outputSize.width / 2, y: -outputSize.height / 2)
+
+        context.draw(cgImage, in: CGRect(origin: drawOrigin, size: coverSize))
+        context.restoreGState()
+    }
+}

--- a/src/Wallnetic/Utils/Log.swift
+++ b/src/Wallnetic/Utils/Log.swift
@@ -28,6 +28,8 @@ enum Log {
     static let mlw          = Logger(subsystem: subsystem, category: "MLWDecryptor")
     static let music        = Logger(subsystem: subsystem, category: "MusicReactive")
     static let notification = Logger(subsystem: subsystem, category: "Notification")
+    static let photos       = Logger(subsystem: subsystem, category: "Photos")
+    static let slideshow    = Logger(subsystem: subsystem, category: "Slideshow")
     static let power        = Logger(subsystem: subsystem, category: "Power")
     static let render       = Logger(subsystem: subsystem, category: "Render")
     static let scheduler    = Logger(subsystem: subsystem, category: "Scheduler")

--- a/src/Wallnetic/Views/Main/ContentView.swift
+++ b/src/Wallnetic/Views/Main/ContentView.swift
@@ -6,6 +6,7 @@ struct ContentView: View {
     @ObservedObject private var downloadManager = DownloadManager.shared
     @State private var selectedTab: NavigationTab = .home
     @State private var isImporting = false
+    @State private var showingPhotosImport = false
     @State private var searchText = ""
     @State private var scrollOffset: CGFloat = 0
     @AppStorage("hasCompletedOnboarding") private var hasCompletedOnboarding = false
@@ -22,6 +23,7 @@ struct ContentView: View {
                     selectedTab: $selectedTab,
                     searchText: $searchText,
                     isImporting: $isImporting,
+                    showingPhotosImport: $showingPhotosImport,
                     isScrolled: scrollOffset > 50
                 )
                 .zIndex(10)
@@ -77,6 +79,10 @@ struct ContentView: View {
         }
         .sheet(isPresented: $showingOnboarding) {
             OnboardingView(isPresented: $showingOnboarding)
+        }
+        .sheet(isPresented: $showingPhotosImport) {
+            CreateFromPhotosView()
+                .environmentObject(wallpaperManager)
         }
         .onAppear {
             if !hasCompletedOnboarding {

--- a/src/Wallnetic/Views/Main/TopNavigationBar.swift
+++ b/src/Wallnetic/Views/Main/TopNavigationBar.swift
@@ -24,6 +24,7 @@ struct TopNavigationBar: View {
     @Binding var selectedTab: NavigationTab
     @Binding var searchText: String
     @Binding var isImporting: Bool
+    @Binding var showingPhotosImport: Bool
     @State private var isSearching = false
     @State private var hoveredTab: NavigationTab?
     var isScrolled: Bool = false
@@ -72,8 +73,19 @@ struct TopNavigationBar: View {
             HStack(spacing: 12) {
                 Spacer()
 
-                Button {
-                    isImporting = true
+                Menu {
+                    Button {
+                        isImporting = true
+                    } label: {
+                        Label("Import video file…", systemImage: "film")
+                    }
+                    .keyboardShortcut("i", modifiers: .command)
+
+                    Button {
+                        showingPhotosImport = true
+                    } label: {
+                        Label("Create from Photos…", systemImage: "photo.on.rectangle.angled")
+                    }
                 } label: {
                     Image(systemName: "plus")
                         .font(.system(size: 12, weight: .bold))
@@ -85,8 +97,9 @@ struct TopNavigationBar: View {
                                 .overlay(Circle().stroke(Color.white.opacity(0.12), lineWidth: 0.5))
                         )
                 }
-                .buttonStyle(.plain)
-                .keyboardShortcut("i", modifiers: .command)
+                .menuStyle(.borderlessButton)
+                .menuIndicator(.hidden)
+                .frame(width: 28, height: 28)
 
                 if #available(macOS 14.0, *) {
                     SettingsLink {

--- a/src/Wallnetic/Views/Photos/CreateFromPhotosView.swift
+++ b/src/Wallnetic/Views/Photos/CreateFromPhotosView.swift
@@ -1,0 +1,349 @@
+import SwiftUI
+import Photos
+import AppKit
+
+/// Wallpaper-from-Photos generator UI (#137).
+/// Shown as a sheet from the main window's "+" menu.
+struct CreateFromPhotosView: View {
+    @EnvironmentObject var wallpaperManager: WallpaperManager
+    @StateObject private var photos = PhotosLibraryService.shared
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var albums: [AlbumDescriptor] = []
+    @State private var selectedAlbum: AlbumDescriptor?
+    @State private var assets: [PHAsset] = []
+    @State private var selectedAssets: Set<String> = []  // PHAsset.localIdentifier
+
+    @State private var perPhotoDuration: Double = 5.0
+    @State private var transition: SlideshowGenerator.Transition = .crossfade
+    @State private var kenBurns: Bool = true
+    @State private var resolution: SlideshowGenerator.Resolution = .hd1080
+
+    @State private var isGenerating = false
+    @State private var generationProgress: Double = 0
+    @State private var generationError: String?
+    @State private var showingSuccess = false
+
+    private let columns = [GridItem(.adaptive(minimum: 90, maximum: 110), spacing: 6)]
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+
+            switch photos.authStatus {
+            case .notDetermined:
+                authPrompt
+            case .denied, .restricted:
+                deniedState
+            case .authorized, .limited:
+                authorizedContent
+            @unknown default:
+                deniedState
+            }
+
+            if isGenerating { generatingFooter } else { actionFooter }
+        }
+        .frame(minWidth: 720, minHeight: 560)
+        .onAppear {
+            if photos.isAuthorized {
+                loadAlbums()
+            }
+        }
+        .alert("Slideshow Error", isPresented: Binding(
+            get: { generationError != nil },
+            set: { if !$0 { generationError = nil } }
+        )) {
+            Button("OK") { generationError = nil }
+        } message: {
+            Text(generationError ?? "")
+        }
+        .alert("Wallpaper Created", isPresented: $showingSuccess) {
+            Button("Done") {
+                showingSuccess = false
+                dismiss()
+            }
+        } message: {
+            Text("The slideshow has been added to your library.")
+        }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack {
+            Text("Create from Photos")
+                .font(.title2.bold())
+            Spacer()
+            Button("Cancel") { dismiss() }
+                .keyboardShortcut(.escape, modifiers: [])
+                .disabled(isGenerating)
+        }
+        .padding()
+    }
+
+    // MARK: - Auth states
+
+    private var authPrompt: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "photo.on.rectangle.angled")
+                .font(.system(size: 56))
+                .foregroundColor(.accentColor)
+            Text("Allow access to Photos to create slideshows from your library.")
+                .multilineTextAlignment(.center)
+                .padding(.horizontal)
+            Button("Allow Photos Access") {
+                Task {
+                    let status = await photos.requestAuthorization()
+                    if status == .authorized || status == .limited {
+                        loadAlbums()
+                    }
+                }
+            }
+            .buttonStyle(.borderedProminent)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding()
+    }
+
+    private var deniedState: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "lock.fill")
+                .font(.system(size: 48))
+                .foregroundColor(.orange)
+            Text("Photos access is denied.")
+                .font(.headline)
+            Text("Open System Settings → Privacy & Security → Photos and grant access to Wallnetic.")
+                .multilineTextAlignment(.center)
+                .foregroundColor(.secondary)
+                .padding(.horizontal)
+            Button("Open System Settings") {
+                if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Photos") {
+                    NSWorkspace.shared.open(url)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding()
+    }
+
+    // MARK: - Authorized content
+
+    @ViewBuilder
+    private var authorizedContent: some View {
+        VStack(spacing: 0) {
+            albumPicker
+            Divider()
+            assetGrid
+        }
+    }
+
+    private var albumPicker: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                ForEach(albums) { album in
+                    Button {
+                        selectAlbum(album)
+                    } label: {
+                        Text(album.displayName)
+                            .font(.callout)
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 6)
+                            .background(
+                                Capsule()
+                                    .fill(selectedAlbum == album ? Color.accentColor.opacity(0.4) : Color.white.opacity(0.06))
+                            )
+                            .foregroundColor(selectedAlbum == album ? .white : .secondary)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 10)
+        }
+    }
+
+    private var assetGrid: some View {
+        ScrollView {
+            LazyVGrid(columns: columns, spacing: 6) {
+                ForEach(assets, id: \.localIdentifier) { asset in
+                    PhotoThumbnail(asset: asset, isSelected: selectedAssets.contains(asset.localIdentifier))
+                        .aspectRatio(1, contentMode: .fit)
+                        .onTapGesture { toggleSelection(asset) }
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+        }
+    }
+
+    // MARK: - Action footers
+
+    private var actionFooter: some View {
+        VStack(spacing: 0) {
+            Divider()
+            HStack(alignment: .top, spacing: 24) {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("\(selectedAssets.count) photo\(selectedAssets.count == 1 ? "" : "s") selected")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+
+                    HStack(spacing: 12) {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Duration").font(.caption2).foregroundColor(.secondary)
+                            Picker("", selection: $perPhotoDuration) {
+                                Text("3s").tag(3.0)
+                                Text("5s").tag(5.0)
+                                Text("8s").tag(8.0)
+                                Text("10s").tag(10.0)
+                            }
+                            .frame(width: 70)
+                            .labelsHidden()
+                        }
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Transition").font(.caption2).foregroundColor(.secondary)
+                            Picker("", selection: $transition) {
+                                Text("None").tag(SlideshowGenerator.Transition.none)
+                                Text("Crossfade").tag(SlideshowGenerator.Transition.crossfade)
+                            }
+                            .frame(width: 110)
+                            .labelsHidden()
+                        }
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Resolution").font(.caption2).foregroundColor(.secondary)
+                            Picker("", selection: $resolution) {
+                                Text("1080p").tag(SlideshowGenerator.Resolution.hd1080)
+                                Text("1440p").tag(SlideshowGenerator.Resolution.qhd1440)
+                                Text("4K").tag(SlideshowGenerator.Resolution.uhd4k)
+                            }
+                            .frame(width: 90)
+                            .labelsHidden()
+                        }
+                        Toggle("Ken Burns", isOn: $kenBurns)
+                            .toggleStyle(.checkbox)
+                    }
+                }
+
+                Spacer()
+
+                Button {
+                    Task { await generate() }
+                } label: {
+                    Text("Create Wallpaper")
+                        .padding(.horizontal, 8)
+                }
+                .buttonStyle(.borderedProminent)
+                .keyboardShortcut(.return, modifiers: .command)
+                .disabled(selectedAssets.count < 2)
+            }
+            .padding()
+        }
+    }
+
+    private var generatingFooter: some View {
+        VStack(spacing: 0) {
+            Divider()
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Generating slideshow…")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                ProgressView(value: generationProgress)
+            }
+            .padding()
+        }
+    }
+
+    // MARK: - Behavior
+
+    private func loadAlbums() {
+        albums = photos.fetchAlbums()
+        if let first = albums.first {
+            selectAlbum(first)
+        }
+    }
+
+    private func selectAlbum(_ album: AlbumDescriptor) {
+        selectedAlbum = album
+        selectedAssets.removeAll()
+        assets = photos.fetchAssets(in: album)
+    }
+
+    private func toggleSelection(_ asset: PHAsset) {
+        if selectedAssets.contains(asset.localIdentifier) {
+            selectedAssets.remove(asset.localIdentifier)
+        } else {
+            selectedAssets.insert(asset.localIdentifier)
+        }
+    }
+
+    private func generate() async {
+        let chosen = assets.filter { selectedAssets.contains($0.localIdentifier) }
+        guard chosen.count >= 2 else { return }
+
+        isGenerating = true
+        generationProgress = 0
+        defer { isGenerating = false }
+
+        let settings = SlideshowGenerator.Settings(
+            perPhotoDuration: perPhotoDuration,
+            transition: transition,
+            kenBurns: kenBurns,
+            resolution: resolution
+        )
+
+        do {
+            let url = try await SlideshowGenerator().generate(
+                assets: chosen,
+                settings: settings
+            ) { progress in
+                Task { @MainActor in self.generationProgress = progress }
+            }
+            _ = try await wallpaperManager.importVideo(from: url)
+            try? FileManager.default.removeItem(at: url)
+            showingSuccess = true
+        } catch {
+            generationError = error.localizedDescription
+        }
+    }
+}
+
+// MARK: - Thumbnail cell
+
+private struct PhotoThumbnail: View {
+    let asset: PHAsset
+    let isSelected: Bool
+
+    @State private var image: NSImage?
+
+    var body: some View {
+        ZStack {
+            if let image {
+                Image(nsImage: image)
+                    .resizable()
+                    .scaledToFill()
+            } else {
+                Rectangle().fill(Color.white.opacity(0.06))
+            }
+        }
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+        .overlay(
+            RoundedRectangle(cornerRadius: 6)
+                .strokeBorder(isSelected ? Color.accentColor : .clear, lineWidth: 3)
+        )
+        .overlay(alignment: .topTrailing) {
+            if isSelected {
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundStyle(.white, Color.accentColor)
+                    .font(.title3)
+                    .padding(4)
+            }
+        }
+        .onAppear { loadThumbnail() }
+    }
+
+    private func loadThumbnail() {
+        PhotosLibraryService.shared.requestThumbnail(for: asset, targetSize: CGSize(width: 220, height: 220)) { img in
+            image = img
+        }
+    }
+}

--- a/src/Wallnetic/Wallnetic.xcodeproj/project.pbxproj
+++ b/src/Wallnetic/Wallnetic.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		1ACE67A285A3AC235ECF7904 /* MLWDecryptorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35A70D71A1BFA621DE839CA5 /* MLWDecryptorTests.swift */; };
 		1B480E4A92B2E3538B724AE4 /* WallpaperEffectsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B86B489A26E64EF63ED72A8 /* WallpaperEffectsManager.swift */; };
 		1CA1504E421EAE5C547DF122 /* KeychainManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51A337D506233D372B7187D6 /* KeychainManager.swift */; };
+		1F756590D00246AFD943B61A /* PhotosLibraryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4D12B25631A66EDCB10593 /* PhotosLibraryService.swift */; };
 		2082CED0A15F59CAEEDB57F8 /* DownloadManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 543E1B92A4536DE1415BD91E /* DownloadManager.swift */; };
 		2124DE0A8E8717475F30D34C /* WallpaperGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D76E5D0AB6B966E492D0342 /* WallpaperGridView.swift */; };
 		2445819EF402088E3689C8CD /* DeepLinkHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2833332B3174CD94D7D62CBB /* DeepLinkHandler.swift */; };
@@ -36,6 +37,7 @@
 		4BC3BA52E3938E15E6BC7AAA /* Log.swift in Sources */ = {isa = PBXBuildFile; fileRef = F62ADB679C576DF4637BA6C9 /* Log.swift */; };
 		4D244E609DA6FBD637CD7D8F /* WallneticApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D9A31C3562655D7C27A30B1 /* WallneticApp.swift */; };
 		4DC3D57FC37765D6CEABF304 /* ColorCategoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56F59C3C7AB56348DA1D9D45 /* ColorCategoryTests.swift */; };
+		502AEDE09B50668E7154DC6E /* CreateFromPhotosView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC8F63EBF5F78663165C4697 /* CreateFromPhotosView.swift */; };
 		51355B920BE931D2A9A3BE58 /* WallpaperCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8562F59693CF276239AD0905 /* WallpaperCollection.swift */; };
 		53984128C8EBA3CD0BDEB573 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFD329195A86A0398FB6B4D0 /* AppDelegate.swift */; };
 		559304CF4E8C6C1F05A97B59 /* CollectionDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A5D74A5C252020316F511D6 /* CollectionDetailView.swift */; };
@@ -72,6 +74,7 @@
 		A2FD8BF6EF09FC0B086E2261 /* EffectsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2392B868E0D5B6994FF657 /* EffectsSettingsView.swift */; };
 		A32F6B39A4F02F8417A78266 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 250C1B481393050C099266A2 /* SettingsView.swift */; };
 		A978B328492C6EE503BC91E3 /* WidgetSyncService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0990FC999E1DE89A3D776B05 /* WidgetSyncService.swift */; };
+		AC32B1A81A352A35055916BC /* SlideshowGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 800451287F439529FF570B44 /* SlideshowGenerator.swift */; };
 		AC7FBC93D689C03ADF1AEDF5 /* AudioVisualizerOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C858C83BC8D22A21A53D7BD /* AudioVisualizerOverlayView.swift */; };
 		AE9FCE08CE4EDEECE7A843BD /* SharedDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52CE6EB39E15687BF3655B8C /* SharedDataManager.swift */; };
 		B0E9EFEE56304B99C2D7A14D /* StrikingEffects.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FD8494A42E5AA356A35BA25 /* StrikingEffects.swift */; };
@@ -197,6 +200,7 @@
 		77E4D58C6269978E4994C7CE /* AppShortcuts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppShortcuts.swift; sourceTree = "<group>"; };
 		79BC197A9E8C082F2C39C673 /* NowPlayingOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowPlayingOverlayView.swift; sourceTree = "<group>"; };
 		7F557952B625823A2689EBE7 /* WallpaperLibrary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperLibrary.swift; sourceTree = "<group>"; };
+		800451287F439529FF570B44 /* SlideshowGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlideshowGenerator.swift; sourceTree = "<group>"; };
 		843AD85E0F38C70B7B33DE40 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		84E4002911F0B7869F3183DA /* TimeOfDaySettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeOfDaySettingsView.swift; sourceTree = "<group>"; };
 		8500C9E87013D486C890E673 /* TopNavigationBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopNavigationBar.swift; sourceTree = "<group>"; };
@@ -219,7 +223,9 @@
 		B6272C35871A69060C41EFEC /* AIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIService.swift; sourceTree = "<group>"; };
 		B7021318E82664A8754F5FF1 /* AIProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIProvider.swift; sourceTree = "<group>"; };
 		BA2392B868E0D5B6994FF657 /* EffectsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EffectsSettingsView.swift; sourceTree = "<group>"; };
+		BA4D12B25631A66EDCB10593 /* PhotosLibraryService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotosLibraryService.swift; sourceTree = "<group>"; };
 		BB036BA69CC6D00731C1D273 /* DiscoverView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverView.swift; sourceTree = "<group>"; };
+		BC8F63EBF5F78663165C4697 /* CreateFromPhotosView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateFromPhotosView.swift; sourceTree = "<group>"; };
 		BF36E216B5F900C62E824B59 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		C296AD08F207FEC3AF4CDCB9 /* AnalyticsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsManager.swift; sourceTree = "<group>"; };
 		C36C5B8FAAEBFAB779FBBB39 /* VideoRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoRenderer.swift; sourceTree = "<group>"; };
@@ -323,10 +329,12 @@
 				5B7D2F1C8E95985C42051A32 /* NowPlayingManager.swift */,
 				3CFBA173095D37D5702C5C18 /* PerformanceManager.swift */,
 				65B960F4D2BFD36368F336A4 /* PexelsService.swift */,
+				BA4D12B25631A66EDCB10593 /* PhotosLibraryService.swift */,
 				689367BF56D29B65CDDB02F2 /* PixabayService.swift */,
 				2A3CC73608BAFA155E615F1B /* SchedulerService.swift */,
 				6D0396F7C77849244B424DD5 /* ScreenSaverBridge.swift */,
 				52CE6EB39E15687BF3655B8C /* SharedDataManager.swift */,
+				800451287F439529FF570B44 /* SlideshowGenerator.swift */,
 				FE3320FF526E744247F3B5BE /* SpaceWallpaperManager.swift */,
 				102BCD8F05208BC14E211E51 /* StoreKitManager.swift */,
 				5CEBCAF9E5F767C08A15158C /* SupabaseClient.swift */,
@@ -410,6 +418,7 @@
 				B811F8DBB05D82875DEB6A6B /* Collections */,
 				6D154AD72514800F57D7A3AE /* Components */,
 				535A9501C7CEE862EAB25CF6 /* Main */,
+				7D4DAE3AA9A84EF28D7AB007 /* Photos */,
 				3445FCF26F52DF704BF31F4A /* Settings */,
 			);
 			path = Views;
@@ -433,6 +442,14 @@
 				5FD8494A42E5AA356A35BA25 /* StrikingEffects.swift */,
 			);
 			path = Components;
+			sourceTree = "<group>";
+		};
+		7D4DAE3AA9A84EF28D7AB007 /* Photos */ = {
+			isa = PBXGroup;
+			children = (
+				BC8F63EBF5F78663165C4697 /* CreateFromPhotosView.swift */,
+			);
+			path = Photos;
 			sourceTree = "<group>";
 		};
 		B811F8DBB05D82875DEB6A6B /* Collections */ = {
@@ -677,6 +694,7 @@
 				73849203691B6B9B27EF0384 /* CollectionManager.swift in Sources */,
 				2C5619331688457B6A844B93 /* CollectionsView.swift in Sources */,
 				D95869079F717BD8B2BB26D0 /* ContentView.swift in Sources */,
+				502AEDE09B50668E7154DC6E /* CreateFromPhotosView.swift in Sources */,
 				2445819EF402088E3689C8CD /* DeepLinkHandler.swift in Sources */,
 				5E298128B4AE9AB89B656E86 /* DesktopOverlayController.swift in Sources */,
 				0BDACCA44A26C7459739D96B /* DesktopWindowController.swift in Sources */,
@@ -706,6 +724,7 @@
 				BED9A1AD659C124D26D37355 /* OnboardingView.swift in Sources */,
 				D729B636A0E78713E53C77FD /* PerformanceManager.swift in Sources */,
 				39C032EFB614D68ADAE9403B /* PexelsService.swift in Sources */,
+				1F756590D00246AFD943B61A /* PhotosLibraryService.swift in Sources */,
 				3D0DEC82756E9F587DEEA843 /* PixabayService.swift in Sources */,
 				E1A41C3F6B921B68A90EBBFA /* PopularView.swift in Sources */,
 				B528C1F69B3CD9B3914A58A6 /* PowerManager.swift in Sources */,
@@ -716,6 +735,7 @@
 				A32F6B39A4F02F8417A78266 /* SettingsView.swift in Sources */,
 				AE9FCE08CE4EDEECE7A843BD /* SharedDataManager.swift in Sources */,
 				6A650CD75C4B32AB9889A6A7 /* SharedWidgetModels.swift in Sources */,
+				AC32B1A81A352A35055916BC /* SlideshowGenerator.swift in Sources */,
 				0D0FFA07C32604C5448D9BD6 /* SpaceSettingsView.swift in Sources */,
 				B61FA302398523F6F9AFE321 /* SpaceWallpaperManager.swift in Sources */,
 				04BCEB8AB6239A8DB7D5C257 /* StoreKitManager.swift in Sources */,

--- a/src/Wallnetic/project.yml
+++ b/src/Wallnetic/project.yml
@@ -56,6 +56,7 @@ targets:
         LSApplicationCategoryType: public.app-category.utilities
         NSMicrophoneUsageDescription: "Wallnetic uses microphone audio to drive the on-desktop audio visualizer."
         NSScreenCaptureUsageDescription: "Wallnetic captures system audio (via ScreenCaptureKit) to drive the on-desktop audio visualizer. No screen imagery is recorded."
+        NSPhotoLibraryUsageDescription: "Wallnetic reads selected photos from your library to generate slideshow wallpapers. Nothing is uploaded or shared."
         CFBundleURLTypes:
           - CFBundleTypeRole: Editor
             CFBundleURLName: com.wallnetic.app


### PR DESCRIPTION
## Summary

Closes #137 — first cut of the Photos Memories integration.

Users can now select photos from their Apple Photos library and the
app stitches them into an MP4 slideshow wallpaper with optional
Ken Burns pan/zoom and crossfade transitions, then auto-imports the
result into the wallpaper library.

## What landed

- `PhotosLibraryService` — `PHPhotoLibrary` auth + album/asset fetching
  + thumbnail/full-size image loading, all wrapped in `async/await`.
- `SlideshowGenerator` — H.264 export pipeline using `AVAssetWriter`
  with cover-fit + Ken Burns transforms and CGContext alpha-blending
  for crossfades. Three resolution presets (1080p, 1440p, 4K).
- `CreateFromPhotosView` — sheet UI with album pill bar, multi-select
  thumbnail grid, settings row, generate button + progress.
- Top-nav `+` button is now a Menu with "Import video file…"
  (`Cmd+I`) and "Create from Photos…".
- `NSPhotoLibraryUsageDescription` added to Info.plist via project.yml.
- New `Log.photos` and `Log.slideshow` categories.

## What's deferred (v2)

- **Memories smart-grouping** (date/location/face clusters) — needs
  proper PHCollection traversal + curation UI, large enough to warrant
  its own issue. Filed as follow-up.
- **Background music tracks**.
- **Video assets** in the source pool — would need per-clip trim UI.
- **Slow-motion best-moment auto-selection**.

## Build

- Debug: ✓
- Release: ✓

## Test plan

- [ ] First open shows the auth prompt; granting access reveals albums.
- [ ] Denying shows the lock state with a working "Open System Settings" deep link.
- [ ] Album pill bar — Recents and Favorites appear at the front, then user albums.
- [ ] Tapping a photo toggles selection (accent border + check badge).
- [ ] Generate button is disabled with fewer than 2 selections.
- [ ] Progress bar advances during render.
- [ ] On success, alert appears and the wallpaper shows up at the top of the home grid.
- [ ] Generated video plays as wallpaper without stalling — Ken Burns visible, crossfades smooth.
- [ ] 4K render completes for 5–10 photos in reasonable time on Apple Silicon.
- [ ] Cancelling the sheet mid-render leaves no stray temp files (currently the temp file is deleted post-import; cancellation early aborts the writer task).

## Notes

- Currently photos-only. Mixed photo+video albums show only photos.
- Generation runs on the main actor; render is async-friendly via
  `Task.sleep` polling on `isReadyForMoreMediaData`.
- App is non-sandboxed today; if/when sandbox is enabled for store
  builds, add `com.apple.security.personal-information.photos-library`
  to entitlements.