### PR TITLE
Address /review findings: slideshow timing, off-main render, cancellation

### DIFF
--- a/src/Wallnetic/Models/GenerationHistory.swift
+++ b/src/Wallnetic/Models/GenerationHistory.swift
@@ -121,7 +121,8 @@ class GenerationHistoryManager: ObservableObject {
             // Sort by date, newest first
             items.sort { $0.createdAt > $1.createdAt }
         } catch {
-            Log.history.error("Failed to load history: \(error.localizedDescription, privacy: .public)")
+            let errDesc = String(describing: error)
+            Log.history.error("Failed to load history: \(errDesc, privacy: .public)")
             items = []
         }
     }
@@ -136,7 +137,8 @@ class GenerationHistoryManager: ObservableObject {
             let data = try encoder.encode(items)
             try data.write(to: fileURL)
         } catch {
-            Log.history.error("Failed to save history: \(error.localizedDescription, privacy: .public)")
+            let errDesc = String(describing: error)
+            Log.history.error("Failed to save history: \(errDesc, privacy: .public)")
         }
     }
 
@@ -163,7 +165,8 @@ class GenerationHistoryManager: ObservableObject {
         do {
             try FileManager.default.copyItem(at: videoURL, to: destVideoURL)
         } catch {
-            Log.history.error("Failed to copy video: \(error.localizedDescription, privacy: .public)")
+            let errDesc = String(describing: error)
+            Log.history.error("Failed to copy video: \(errDesc, privacy: .public)")
             return
         }
 
@@ -256,7 +259,8 @@ class GenerationHistoryManager: ObservableObject {
                 try jpegData.write(to: thumbnailURL)
             }
         } catch {
-            Log.history.error("Failed to generate thumbnail: \(error.localizedDescription, privacy: .public)")
+            let errDesc = String(describing: error)
+            Log.history.error("Failed to generate thumbnail: \(errDesc, privacy: .public)")
         }
     }
 }

--- a/src/Wallnetic/Services/PhotosLibraryService.swift
+++ b/src/Wallnetic/Services/PhotosLibraryService.swift
@@ -94,7 +94,9 @@ final class PhotosLibraryService: ObservableObject {
 
     /// Loads a square thumbnail for the asset at the requested point size
     /// (the manager scales by display scale internally). The completion is
-    /// always invoked on the main queue.
+    /// always invoked on the main queue exactly once with the final
+    /// (non-degraded) image — the opportunistic low-res placeholder is
+    /// skipped to avoid grid flicker.
     func requestThumbnail(for asset: PHAsset, targetSize: CGSize, completion: @escaping (NSImage?) -> Void) {
         let options = PHImageRequestOptions()
         options.deliveryMode = .opportunistic
@@ -106,9 +108,18 @@ final class PhotosLibraryService: ObservableObject {
             targetSize: targetSize,
             contentMode: .aspectFill,
             options: options
-        ) { image, _ in
+        ) { image, info in
+            // Skip the low-res preview pass; only deliver the final image.
+            if let isDegraded = info?[PHImageResultIsDegradedKey] as? Bool, isDegraded {
+                return
+            }
             DispatchQueue.main.async { completion(image) }
         }
+    }
+
+    /// Drops every cached thumbnail. Call when the photo grid disappears.
+    func flushThumbnailCache() {
+        imageManager.stopCachingImagesForAllAssets()
     }
 
     /// Loads a full-size image for slideshow rendering.

--- a/src/Wallnetic/Services/SlideshowGenerator.swift
+++ b/src/Wallnetic/Services/SlideshowGenerator.swift
@@ -2,19 +2,21 @@ import Foundation
 import AVFoundation
 import Photos
 import AppKit
-import CoreImage
 
 /// Generates an MP4 slideshow from a list of `PHAsset`s with optional
 /// Ken Burns pan/zoom and crossfade transitions (#137).
 ///
 /// Render strategy:
 /// 1. Load each PHAsset as a high-quality `NSImage`.
-/// 2. Build an offscreen CGContext at the target resolution, render each
-///    frame into it with the Ken Burns transform applied, and pipe pixel
-///    buffers into an `AVAssetWriter` configured for H.264.
-/// 3. Crossfades are realised by overlapping the last `transitionDuration`
-///    seconds of frame N with the first frame of N+1, blending alpha.
-@MainActor
+/// 2. Compute total output frames `N*d − (N−1)*T` and walk a single
+///    timeline. For each frame, decide which 1–2 photos are visible
+///    and render with their Ken Burns transforms + alpha blend.
+/// 3. Pixel buffers go through `AVAssetWriterInputPixelBufferAdaptor`
+///    to an H.264 `AVAssetWriter`.
+///
+/// Not main-actor isolated — the render loop is heavy and would freeze
+/// the UI if forced onto main. Cancellation is cooperative via Swift
+/// `Task.checkCancellation()`.
 final class SlideshowGenerator {
     enum Resolution {
         case hd1080, qhd1440, uhd4k
@@ -59,11 +61,16 @@ final class SlideshowGenerator {
             switch self {
             case .noAssets: return "No photos selected."
             case .writerFailed(let m): return "Video writer failed: \(m)"
-            case .imageLoadFailed: return "Could not load one of the selected photos."
+            case .imageLoadFailed: return "Could not load any of the selected photos."
             case .cancelled: return "Slideshow generation was cancelled."
             }
         }
     }
+
+    /// Cover-fit oversampling so Ken Burns pan never exposes black
+    /// edges at the minimum scale. `panRange = intensity * 80px` at the
+    /// canvas, `coverPad` keeps a safety margin around the cropped area.
+    private let coverPad: CGFloat = 1.12
 
     private let library: PhotosLibraryService
 
@@ -76,21 +83,24 @@ final class SlideshowGenerator {
     /// Generates the slideshow and writes it to a temporary file. The
     /// returned URL points at a `.mp4` ready to be imported via the
     /// `WallpaperManager` import flow.
+    ///
+    /// Cancel by cancelling the parent `Task` — the loop checks
+    /// `Task.checkCancellation()` per frame and throws `cancelled`.
     func generate(
         assets: [PHAsset],
         settings: Settings,
-        progress: @escaping (Double) -> Void
+        progress: @Sendable @escaping (Double) -> Void
     ) async throws -> URL {
         guard !assets.isEmpty else { throw GeneratorError.noAssets }
 
         let outputURL = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("Wallnetic-Slideshow-\(UUID().uuidString).mp4")
 
-        // Load all images upfront. For 30+ photos this is heavy, but slideshow
-        // counts realistically stay under 50 — the bottleneck is rendering, not
-        // load. Skip nil images so a single bad asset doesn't fail the whole job.
+        // Load all images upfront. Slideshow counts realistically stay under 50.
+        // Skip nil images so a single bad asset doesn't fail the whole job.
         var images: [NSImage] = []
         for (idx, asset) in assets.enumerated() {
+            try Task.checkCancellation()
             if let img = await library.requestFullImage(for: asset) {
                 images.append(img)
             }
@@ -98,12 +108,20 @@ final class SlideshowGenerator {
         }
         guard !images.isEmpty else { throw GeneratorError.imageLoadFailed }
 
-        try await renderToFile(
-            images: images,
-            settings: settings,
-            outputURL: outputURL,
-            progress: { progress(0.2 + $0 * 0.8) }
-        )
+        do {
+            try await renderToFile(
+                images: images,
+                settings: settings,
+                outputURL: outputURL,
+                progress: { progress(0.2 + $0 * 0.8) }
+            )
+        } catch is CancellationError {
+            try? FileManager.default.removeItem(at: outputURL)
+            throw GeneratorError.cancelled
+        } catch {
+            try? FileManager.default.removeItem(at: outputURL)
+            throw error
+        }
 
         return outputURL
     }
@@ -114,7 +132,7 @@ final class SlideshowGenerator {
         images: [NSImage],
         settings: Settings,
         outputURL: URL,
-        progress: @escaping (Double) -> Void
+        progress: @Sendable @escaping (Double) -> Void
     ) async throws {
         try? FileManager.default.removeItem(at: outputURL)
 
@@ -173,89 +191,95 @@ final class SlideshowGenerator {
         }
     }
 
-    /// Generates each frame and submits it to the adaptor. Caller has already
-    /// configured the writer + input.
+    /// Frame-by-frame timeline walker. Computes which 1–2 photos are
+    /// visible at each output frame and renders accordingly.
     private func renderFrames(
         images: [NSImage],
         settings: Settings,
         adaptor: AVAssetWriterInputPixelBufferAdaptor,
         writerInput: AVAssetWriterInput,
         outputSize: CGSize,
-        progress: @escaping (Double) -> Void
+        progress: @Sendable @escaping (Double) -> Void
     ) async throws {
         let fps = settings.fps
         let frameDuration = CMTime(value: 1, timescale: fps)
         let framesPerImage = Int(settings.perPhotoDuration * Double(fps))
         let transitionFrames = settings.transition == .crossfade
-            ? Int(settings.transitionDuration * Double(fps))
+            ? min(Int(settings.transitionDuration * Double(fps)), framesPerImage / 2)
             : 0
-        let totalFrames = images.count * framesPerImage - transitionFrames * (images.count - 1)
+        // Stride between successive photo starts. `framesPerImage − transitionFrames`
+        // because adjacent photos overlap during their transition.
+        let stride = framesPerImage - transitionFrames
+        let imageCount = images.count
+        let totalFrames = imageCount * framesPerImage - transitionFrames * (imageCount - 1)
 
-        var frameIndex: Int = 0
-        let kenBurns = generateKenBurnsTransforms(count: images.count, intensity: settings.kenBurns ? 0.18 : 0)
+        let kenBurns = generateKenBurnsTransforms(
+            count: imageCount,
+            intensity: settings.kenBurns ? 0.18 : 0
+        )
 
-        let pool = adaptor.pixelBufferPool
-        let ciContext = CIContext(options: [.useSoftwareRenderer: false])
+        for f in 0..<totalFrames {
+            try Task.checkCancellation()
 
-        for imgIdx in 0..<images.count {
-            let isLast = imgIdx == images.count - 1
-            let blendInFrames = (imgIdx > 0 && transitionFrames > 0) ? transitionFrames : 0
-            let blendOutFrames = (!isLast && transitionFrames > 0) ? transitionFrames : 0
-            let solidFrames = framesPerImage - blendOutFrames
-
-            let frames = blendInFrames + solidFrames
-
-            for f in 0..<frames {
-                while !writerInput.isReadyForMoreMediaData {
-                    try await Task.sleep(nanoseconds: 5_000_000)
-                }
-
-                let progressInImage = Double(blendInFrames + f) / Double(framesPerImage)
-                let kbA = kenBurns[imgIdx].apply(progress: progressInImage)
-
-                guard let pool = pool, let buffer = makePixelBuffer(pool: pool) else {
-                    throw GeneratorError.writerFailed("could not allocate pixel buffer")
-                }
-
-                let alphaA: CGFloat
-                let alphaB: CGFloat
-                let prevImage: NSImage?
-                let prevTransform: CGAffineTransform?
-
-                if f < blendInFrames, imgIdx > 0 {
-                    // Crossfade-in from previous image
-                    let t = CGFloat(f) / CGFloat(max(blendInFrames, 1))
-                    alphaA = t
-                    alphaB = 1 - t
-                    prevImage = images[imgIdx - 1]
-                    let prevProgress = 1.0 - Double(blendInFrames - f) / Double(framesPerImage)
-                    prevTransform = kenBurns[imgIdx - 1].apply(progress: prevProgress)
-                } else {
-                    alphaA = 1
-                    alphaB = 0
-                    prevImage = nil
-                    prevTransform = nil
-                }
-
-                drawFrame(
-                    into: buffer,
-                    outputSize: outputSize,
-                    primary: images[imgIdx],
-                    primaryTransform: kbA,
-                    primaryAlpha: alphaA,
-                    secondary: prevImage,
-                    secondaryTransform: prevTransform,
-                    secondaryAlpha: alphaB,
-                    ciContext: ciContext
-                )
-
-                let pts = CMTimeMultiply(frameDuration, multiplier: Int32(frameIndex))
-                if !adaptor.append(buffer, withPresentationTime: pts) {
-                    throw GeneratorError.writerFailed("append failed at frame \(frameIndex)")
-                }
-                frameIndex += 1
-                progress(Double(frameIndex) / Double(totalFrames))
+            // Wait for adaptor to be ready without blocking main.
+            while !writerInput.isReadyForMoreMediaData {
+                try await Task.sleep(nanoseconds: 5_000_000)
+                try Task.checkCancellation()
             }
+
+            // Determine which photo(s) are visible at this frame.
+            // Photo i runs frames [i*stride, i*stride + framesPerImage).
+            let primaryIdx = min(f / max(stride, 1), imageCount - 1)
+            let frameInPrimary = f - primaryIdx * stride
+
+            // Crossfade region: first `transitionFrames` frames of any non-first photo.
+            let inOverlap = primaryIdx > 0 && transitionFrames > 0 && frameInPrimary < transitionFrames
+
+            let primaryProgress = Double(frameInPrimary) / Double(max(framesPerImage, 1))
+            let primaryTransform = kenBurns[primaryIdx].apply(progress: primaryProgress)
+
+            let primaryAlpha: CGFloat
+            let secondaryImage: NSImage?
+            let secondaryTransform: CGAffineTransform?
+            let secondaryAlpha: CGFloat
+
+            if inOverlap {
+                let t = CGFloat(frameInPrimary) / CGFloat(transitionFrames)
+                primaryAlpha = t
+                secondaryAlpha = 1 - t
+                secondaryImage = images[primaryIdx - 1]
+                let secondaryFrameInImage = stride + frameInPrimary
+                let secProgress = Double(secondaryFrameInImage) / Double(max(framesPerImage, 1))
+                secondaryTransform = kenBurns[primaryIdx - 1].apply(progress: secProgress)
+            } else {
+                primaryAlpha = 1
+                secondaryImage = nil
+                secondaryTransform = nil
+                secondaryAlpha = 0
+            }
+
+            guard let pool = adaptor.pixelBufferPool,
+                  let buffer = makePixelBuffer(pool: pool) else {
+                throw GeneratorError.writerFailed("could not allocate pixel buffer")
+            }
+
+            drawFrame(
+                into: buffer,
+                outputSize: outputSize,
+                primary: images[primaryIdx],
+                primaryTransform: primaryTransform,
+                primaryAlpha: primaryAlpha,
+                secondary: secondaryImage,
+                secondaryTransform: secondaryTransform,
+                secondaryAlpha: secondaryAlpha
+            )
+
+            let pts = CMTimeMultiply(frameDuration, multiplier: Int32(f))
+            if !adaptor.append(buffer, withPresentationTime: pts) {
+                throw GeneratorError.writerFailed("append failed at frame \(f)")
+            }
+
+            progress(Double(f + 1) / Double(totalFrames))
         }
     }
 
@@ -283,6 +307,8 @@ final class SlideshowGenerator {
         var seed = SystemRandomNumberGenerator()
         return (0..<count).map { _ in
             let zoomIn = Bool.random(using: &seed)
+            // Always start ≥ 1.0 — combined with `coverPad` oversampling in
+            // drawImage this prevents black edges from pan + scale.
             let startScale: CGFloat = zoomIn ? 1.0 : 1.0 + intensity
             let endScale: CGFloat = zoomIn ? 1.0 + intensity : 1.0
             let panRange = intensity * 80
@@ -315,8 +341,7 @@ final class SlideshowGenerator {
         primaryAlpha: CGFloat,
         secondary: NSImage?,
         secondaryTransform: CGAffineTransform?,
-        secondaryAlpha: CGFloat,
-        ciContext: CIContext
+        secondaryAlpha: CGFloat
     ) {
         CVPixelBufferLockBaseAddress(buffer, [])
         defer { CVPixelBufferUnlockBaseAddress(buffer, []) }
@@ -356,25 +381,21 @@ final class SlideshowGenerator {
         var rect = CGRect(origin: .zero, size: outputSize)
         guard let cgImage = image.cgImage(forProposedRect: &rect, context: nil, hints: nil) else { return }
 
-        let imageSize = CGSize(width: cgImage.width, height: cgImage.height)
-        let imageAspect = imageSize.width / imageSize.height
+        let imageAspect = CGFloat(cgImage.width) / CGFloat(cgImage.height)
         let outAspect = outputSize.width / outputSize.height
 
-        // aspect-fit: contain inside the output, then ken-burns scales/offsets
-        var drawSize = outputSize
-        if imageAspect > outAspect {
-            drawSize.height = outputSize.width / imageAspect
-        } else {
-            drawSize.width = outputSize.height * imageAspect
-        }
-
-        // Cover instead of fit — we want full-frame look when ken-burns crops in.
+        // Cover-fit so the image fills the output rect.
         var coverSize = outputSize
         if imageAspect > outAspect {
             coverSize.width = outputSize.height * imageAspect
         } else {
             coverSize.height = outputSize.width / imageAspect
         }
+
+        // Oversample so Ken Burns pan never exposes black edges around
+        // the canvas border at minimum scale (1.0).
+        coverSize.width *= coverPad
+        coverSize.height *= coverPad
 
         let drawOrigin = CGPoint(
             x: (outputSize.width - coverSize.width) / 2,

--- a/src/Wallnetic/Views/Photos/CreateFromPhotosView.swift
+++ b/src/Wallnetic/Views/Photos/CreateFromPhotosView.swift
@@ -23,6 +23,12 @@ struct CreateFromPhotosView: View {
     @State private var generationProgress: Double = 0
     @State private var generationError: String?
     @State private var showingSuccess = false
+    @State private var generationTask: Task<Void, Never>?
+
+    /// Hard cap on selected photos. With 50 photos × 5s/each + 4K Ken Burns
+    /// the output is already ~4 minutes / a few GB — going higher risks
+    /// running out of memory and producing a wallpaper too long to loop.
+    private static let maxSelection = 50
 
     private let columns = [GridItem(.adaptive(minimum: 90, maximum: 110), spacing: 6)]
 
@@ -49,6 +55,10 @@ struct CreateFromPhotosView: View {
             if photos.isAuthorized {
                 loadAlbums()
             }
+        }
+        .onDisappear {
+            generationTask?.cancel()
+            photos.flushThumbnailCache()
         }
         .alert("Slideshow Error", isPresented: Binding(
             get: { generationError != nil },
@@ -184,9 +194,16 @@ struct CreateFromPhotosView: View {
             Divider()
             HStack(alignment: .top, spacing: 24) {
                 VStack(alignment: .leading, spacing: 8) {
-                    Text("\(selectedAssets.count) photo\(selectedAssets.count == 1 ? "" : "s") selected")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
+                    HStack(spacing: 6) {
+                        Text("\(selectedAssets.count) of max \(Self.maxSelection) photo\(selectedAssets.count == 1 ? "" : "s") selected")
+                            .font(.caption)
+                            .foregroundColor(selectedAssets.count >= Self.maxSelection ? .orange : .secondary)
+                        if selectedAssets.count >= Self.maxSelection {
+                            Image(systemName: "exclamationmark.circle")
+                                .foregroundColor(.orange)
+                                .font(.caption)
+                        }
+                    }
 
                     HStack(spacing: 12) {
                         VStack(alignment: .leading, spacing: 2) {
@@ -227,7 +244,7 @@ struct CreateFromPhotosView: View {
                 Spacer()
 
                 Button {
-                    Task { await generate() }
+                    startGeneration()
                 } label: {
                     Text("Create Wallpaper")
                         .padding(.horizontal, 8)
@@ -243,11 +260,17 @@ struct CreateFromPhotosView: View {
     private var generatingFooter: some View {
         VStack(spacing: 0) {
             Divider()
-            VStack(alignment: .leading, spacing: 6) {
-                Text("Generating slideshow…")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                ProgressView(value: generationProgress)
+            HStack(alignment: .top, spacing: 16) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Generating slideshow…")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    ProgressView(value: generationProgress)
+                }
+                Button("Cancel") {
+                    generationTask?.cancel()
+                }
+                .keyboardShortcut(.escape, modifiers: [])
             }
             .padding()
         }
@@ -271,18 +294,16 @@ struct CreateFromPhotosView: View {
     private func toggleSelection(_ asset: PHAsset) {
         if selectedAssets.contains(asset.localIdentifier) {
             selectedAssets.remove(asset.localIdentifier)
-        } else {
+        } else if selectedAssets.count < Self.maxSelection {
             selectedAssets.insert(asset.localIdentifier)
         }
+        // At cap, additional taps are ignored. The footer label flips to
+        // orange to surface the limit.
     }
 
-    private func generate() async {
+    private func startGeneration() {
         let chosen = assets.filter { selectedAssets.contains($0.localIdentifier) }
         guard chosen.count >= 2 else { return }
-
-        isGenerating = true
-        generationProgress = 0
-        defer { isGenerating = false }
 
         let settings = SlideshowGenerator.Settings(
             perPhotoDuration: perPhotoDuration,
@@ -291,18 +312,35 @@ struct CreateFromPhotosView: View {
             resolution: resolution
         )
 
-        do {
-            let url = try await SlideshowGenerator().generate(
-                assets: chosen,
-                settings: settings
-            ) { progress in
-                Task { @MainActor in self.generationProgress = progress }
+        isGenerating = true
+        generationProgress = 0
+
+        generationTask = Task {
+            defer {
+                Task { @MainActor in
+                    isGenerating = false
+                    generationTask = nil
+                }
             }
-            _ = try await wallpaperManager.importVideo(from: url)
-            try? FileManager.default.removeItem(at: url)
-            showingSuccess = true
-        } catch {
-            generationError = error.localizedDescription
+            do {
+                let url = try await SlideshowGenerator().generate(
+                    assets: chosen,
+                    settings: settings
+                ) { progress in
+                    Task { @MainActor in self.generationProgress = progress }
+                }
+                _ = try await wallpaperManager.importVideo(from: url)
+                try? FileManager.default.removeItem(at: url)
+                await MainActor.run { showingSuccess = true }
+            } catch is CancellationError {
+                // User cancelled — silent close, no alert.
+            } catch SlideshowGenerator.GeneratorError.cancelled {
+                // Same — generator surfaced the cancellation as its own type.
+            } catch {
+                await MainActor.run {
+                    generationError = error.localizedDescription
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes all 10 findings from the post-merge `/review` pass on the v1.3
work that landed today (#174, #175, #176).

## High

| # | Finding | Fix |
|---|---------|-----|
| 1 | Slideshow video was `(N−1)*T/fps` seconds longer than intended; progress bar exceeded 100% mid-render. | Rewrote `renderFrames` as a single-frame timeline walker over `0..<totalFrames`. For each frame computes primary photo via stride-divide, decides overlap, blends. |
| 2 | `SlideshowGenerator` was `@MainActor` so the entire render loop blocked the UI. | Dropped `@MainActor`. Render now runs on a non-main task; `PhotosLibraryService` remains main-actor so PHImageManager dispatch is still correct. |

## Medium

| # | Finding | Fix |
|---|---------|-----|
| 3 | Photo grid flickered because the `.opportunistic` thumbnail callback fired twice. | Filter on `PHImageResultIsDegradedKey` and only emit the final image. |
| 4 | Ken Burns pan exposed thin black edges at scale = 1.0. | Cover region oversampled by `coverPad = 1.12`. |
| 5 | Generation could not be cancelled. | View holds the generation `Task`; Cancel button + sheet `.onDisappear` call `task.cancel()`. Loop calls `Task.checkCancellation()` per frame. Cancellation cleans up the partial file and exits silently. |

## Low

| # | Finding | Fix |
|---|---------|-----|
| 6 | `drawSize` computed and never used. | Removed. |
| 7 | `ciContext` parameter unused. | Removed from `drawFrame` signature. |
| 8 | `PHCachingImageManager` cache never flushed. | Added `flushThumbnailCache()`; sheet calls on disappear. |
| 9 | No upper bound on photo selection. | Capped at 50; over-cap taps no-op, footer label flips orange. |
| 10 | Centralized logging lost full Error description in `GenerationHistory`. | Use `String(describing: error)` instead of `.localizedDescription` for those four log sites. |

## Build

- Debug: ✓
- Release: ✓

## Test plan

- [ ] 3-photo slideshow at 5s/each + 0.6s crossfade runs 13.8s — verify with QuickTime / `ffprobe`.
- [ ] Progress bar advances to 100% at completion (no overshoot).
- [ ] During render, the photo grid stays scrollable and the Cancel button responds within ~0.1s.
- [ ] Cancel button: stops render, deletes temp file, sheet stays open with selections intact.
- [ ] Closing the sheet mid-render: render aborts cleanly, no orphan temp file in `~/Library/Containers/.../tmp`.
- [ ] Photo grid: no flicker between low-res preview and final image, even on iCloud-backed photos.
- [ ] Ken Burns at minimum scale: no black edges visible at any pan offset.
- [ ] Selecting a 51st photo: tap is ignored, label turns orange.
- [ ] `Log.history.error` entries in Console.app show full domain/code on a forced load failure.