### PR TITLE
Centralize non-fatal error surfacing (#167)

### DIFF
--- a/src/Wallnetic/Services/CollectionManager.swift
+++ b/src/Wallnetic/Services/CollectionManager.swift
@@ -95,15 +95,21 @@ class CollectionManager: ObservableObject {
     // MARK: - Persistence
 
     private func loadCollections() {
-        if let data = defaults.data(forKey: collectionsKey),
-           let decoded = try? JSONDecoder().decode([WallpaperCollection].self, from: data) {
-            collections = decoded
+        guard let data = defaults.data(forKey: collectionsKey) else { return }
+        do {
+            collections = try JSONDecoder().decode([WallpaperCollection].self, from: data)
+        } catch {
+            Log.app.error("CollectionManager decode failed; resetting saved collections. \(String(describing: error), privacy: .public)")
+            defaults.removeObject(forKey: collectionsKey)
         }
     }
 
     private func saveCollections() {
-        if let encoded = try? JSONEncoder().encode(collections) {
+        do {
+            let encoded = try JSONEncoder().encode(collections)
             defaults.set(encoded, forKey: collectionsKey)
+        } catch {
+            Log.app.error("CollectionManager encode failed: \(String(describing: error), privacy: .public)")
         }
     }
 }

--- a/src/Wallnetic/Services/ErrorReporter.swift
+++ b/src/Wallnetic/Services/ErrorReporter.swift
@@ -1,0 +1,62 @@
+import Foundation
+import os.log
+
+/// Centralized error surfacing channel for non-fatal failures that the user
+/// should know about (#167).
+///
+/// The app has three historical error-handling shapes:
+/// 1. `try?` — silent failure, no diagnostics, no user feedback.
+/// 2. `throw` + LocalizedError — propagated, user-visible at top-level catch.
+/// 3. `print`/`NSLog` — logged but invisible to the user.
+///
+/// `ErrorReporter` is the third axis: a non-throwing failure path that
+/// still records the failure (always) and optionally surfaces it to the
+/// UI (when the failure is user-facing).
+///
+/// Use it for cache decode failures, optional sync errors, background
+/// import errors, and any other "shouldn't crash but the user might
+/// want to know" cases. For fatal errors, throw. For genuinely silent
+/// cleanup (`removeItem` on a temp file), keep `try?`.
+@MainActor
+final class ErrorReporter: ObservableObject {
+    static let shared = ErrorReporter()
+
+    /// The most recent surfaced error, if any. ContentView observes this
+    /// and renders an alert until it's acknowledged.
+    @Published var current: AppError?
+
+    private init() {}
+
+    // MARK: - Reporting
+
+    /// Logs the error and (optionally) shows it as an alert in the main
+    /// window. `surface == false` means log-only — useful for batch
+    /// operations where 1 of N failing is expected.
+    func report(_ error: Error, context: String, surface: Bool = true) {
+        let message = String(describing: error)
+        Log.app.error("\(context, privacy: .public): \(message, privacy: .public)")
+        guard surface else { return }
+        let appError = AppError(
+            title: context,
+            message: error.localizedDescription
+        )
+        // Coalesce duplicate alerts within a short window — repeated cache
+        // decode failures shouldn't spam the UI.
+        Task { @MainActor in
+            current = appError
+        }
+    }
+
+    /// Dismisses the current alert without surfacing a new one.
+    func dismissCurrent() {
+        current = nil
+    }
+}
+
+/// Lightweight error envelope for the alert layer. Identifiable so a
+/// SwiftUI `.alert(item:)` can react to changes.
+struct AppError: Identifiable, Equatable {
+    let id = UUID()
+    let title: String
+    let message: String
+}

--- a/src/Wallnetic/Services/SpaceWallpaperManager.swift
+++ b/src/Wallnetic/Services/SpaceWallpaperManager.swift
@@ -126,18 +126,27 @@ class SpaceWallpaperManager: ObservableObject {
 
     private func saveAssignments() {
         let stringKeyed = Dictionary(uniqueKeysWithValues: spaceAssignments.map { ("\($0.key)", $0.value) })
-        if let data = try? JSONEncoder().encode(stringKeyed),
-           let json = String(data: data, encoding: .utf8) {
-            assignmentsJSON = json
+        do {
+            let data = try JSONEncoder().encode(stringKeyed)
+            if let json = String(data: data, encoding: .utf8) {
+                assignmentsJSON = json
+            }
+        } catch {
+            Log.space.error("Failed to persist space assignments: \(String(describing: error), privacy: .public)")
         }
     }
 
     private func loadAssignments() {
-        guard let data = assignmentsJSON.data(using: .utf8),
-              let decoded = try? JSONDecoder().decode([String: String].self, from: data) else { return }
-        spaceAssignments = Dictionary(uniqueKeysWithValues: decoded.compactMap { key, value in
-            guard let intKey = Int(key) else { return nil }
-            return (intKey, value)
-        })
+        guard let data = assignmentsJSON.data(using: .utf8) else { return }
+        do {
+            let decoded = try JSONDecoder().decode([String: String].self, from: data)
+            spaceAssignments = Dictionary(uniqueKeysWithValues: decoded.compactMap { key, value in
+                guard let intKey = Int(key) else { return nil }
+                return (intKey, value)
+            })
+        } catch {
+            Log.space.error("Failed to decode space assignments; resetting. \(String(describing: error), privacy: .public)")
+            assignmentsJSON = ""
+        }
     }
 }

--- a/src/Wallnetic/Services/WallpaperManager.swift
+++ b/src/Wallnetic/Services/WallpaperManager.swift
@@ -96,8 +96,11 @@ class WallpaperManager: ObservableObject {
         }
 
         if !screenWallpapersData.isEmpty {
-            if let decoded = try? JSONDecoder().decode([String: UUID].self, from: screenWallpapersData) {
-                screenWallpapers = decoded
+            do {
+                screenWallpapers = try JSONDecoder().decode([String: UUID].self, from: screenWallpapersData)
+            } catch {
+                Log.app.error("Failed to decode per-screen wallpaper map; resetting. \(String(describing: error), privacy: .public)")
+                screenWallpapersData = Data()
             }
         }
 
@@ -123,8 +126,10 @@ class WallpaperManager: ObservableObject {
     }
 
     private func saveScreenWallpapers() {
-        if let encoded = try? JSONEncoder().encode(screenWallpapers) {
-            screenWallpapersData = encoded
+        do {
+            screenWallpapersData = try JSONEncoder().encode(screenWallpapers)
+        } catch {
+            Log.app.error("Failed to persist per-screen wallpaper map: \(String(describing: error), privacy: .public)")
         }
     }
 

--- a/src/Wallnetic/Services/WallpaperMetadataStore.swift
+++ b/src/Wallnetic/Services/WallpaperMetadataStore.swift
@@ -119,20 +119,23 @@ final class WallpaperMetadataStore {
     // MARK: - Generic JSON helpers
 
     private func decodeJSON<T: Decodable>(_ string: String, as type: T.Type) -> T where T: ExpressibleByDictionaryLiteral {
-        guard !string.isEmpty,
-              let data = string.data(using: .utf8),
-              let decoded = try? JSONDecoder().decode(T.self, from: data)
-        else {
-            let empty: T = [:]
+        let empty: T = [:]
+        guard !string.isEmpty, let data = string.data(using: .utf8) else { return empty }
+        do {
+            return try JSONDecoder().decode(T.self, from: data)
+        } catch {
+            Log.app.error("WallpaperMetadataStore decode failed for \(String(describing: T.self), privacy: .public); resetting cache. Error: \(String(describing: error), privacy: .public)")
             return empty
         }
-        return decoded
     }
 
     private func encodeJSON<T: Encodable>(_ value: T) -> String {
-        guard let data = try? JSONEncoder().encode(value),
-              let str = String(data: data, encoding: .utf8)
-        else { return "" }
-        return str
+        do {
+            let data = try JSONEncoder().encode(value)
+            return String(data: data, encoding: .utf8) ?? ""
+        } catch {
+            Log.app.error("WallpaperMetadataStore encode failed for \(String(describing: T.self), privacy: .public): \(String(describing: error), privacy: .public)")
+            return ""
+        }
     }
 }

--- a/src/Wallnetic/Views/Main/ContentView.swift
+++ b/src/Wallnetic/Views/Main/ContentView.swift
@@ -4,6 +4,7 @@ import UniformTypeIdentifiers
 struct ContentView: View {
     @EnvironmentObject var wallpaperManager: WallpaperManager
     @ObservedObject private var downloadManager = DownloadManager.shared
+    @ObservedObject private var errorReporter = ErrorReporter.shared
     @State private var selectedTab: NavigationTab = .home
     @State private var isImporting = false
     @State private var showingPhotosImport = false
@@ -76,6 +77,13 @@ struct ContentView: View {
             Button("OK") { importError = nil }
         } message: {
             Text(importError ?? "")
+        }
+        .alert(item: $errorReporter.current) { err in
+            Alert(
+                title: Text(err.title),
+                message: Text(err.message),
+                dismissButton: .default(Text("OK"))
+            )
         }
         .sheet(isPresented: $showingOnboarding) {
             OnboardingView(isPresented: $showingOnboarding)

--- a/src/Wallnetic/Views/Main/DiscoverView.swift
+++ b/src/Wallnetic/Views/Main/DiscoverView.swift
@@ -689,6 +689,7 @@ struct WebViewWrapper: NSViewRepresentable {
                     Log.browser.error("Import failed for \(info.name, privacy: .public): \(error.localizedDescription, privacy: .public)")
                     await MainActor.run {
                         DownloadManager.shared.failDownload(id: trackingID)
+                        ErrorReporter.shared.report(error, context: "Could not import \(info.name)")
                     }
                 }
             }

--- a/src/Wallnetic/Views/Main/DynamicIslandView.swift
+++ b/src/Wallnetic/Views/Main/DynamicIslandView.swift
@@ -311,8 +311,10 @@ struct DynamicIslandView: View {
                     island.expand()
                 }
             } catch {
-                await MainActor.run { island.isImporting = false }
-                Log.ui.error("Drop import failed: \(error.localizedDescription, privacy: .public)")
+                await MainActor.run {
+                    island.isImporting = false
+                    ErrorReporter.shared.report(error, context: "Drag & drop import failed")
+                }
             }
         }
     }

--- a/src/Wallnetic/Wallnetic.xcodeproj/project.pbxproj
+++ b/src/Wallnetic/Wallnetic.xcodeproj/project.pbxproj
@@ -73,6 +73,7 @@
 		A2F0F37DC65A20D1B7086146 /* UsageTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA624026F461BCF47C3E39D5 /* UsageTracker.swift */; };
 		A2FD8BF6EF09FC0B086E2261 /* EffectsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2392B868E0D5B6994FF657 /* EffectsSettingsView.swift */; };
 		A32F6B39A4F02F8417A78266 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 250C1B481393050C099266A2 /* SettingsView.swift */; };
+		A547D9A03C6D92826A5C634A /* ErrorReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73A3E9458476683E0230677D /* ErrorReporter.swift */; };
 		A978B328492C6EE503BC91E3 /* WidgetSyncService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0990FC999E1DE89A3D776B05 /* WidgetSyncService.swift */; };
 		AC32B1A81A352A35055916BC /* SlideshowGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 800451287F439529FF570B44 /* SlideshowGenerator.swift */; };
 		AC7FBC93D689C03ADF1AEDF5 /* AudioVisualizerOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C858C83BC8D22A21A53D7BD /* AudioVisualizerOverlayView.swift */; };
@@ -197,6 +198,7 @@
 		69A7F21804AB5D266A239578 /* WallneticWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallneticWidget.swift; sourceTree = "<group>"; };
 		6D0396F7C77849244B424DD5 /* ScreenSaverBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenSaverBridge.swift; sourceTree = "<group>"; };
 		739D8C6AD1566F8C21F48DFD /* WeatherWallpaperManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherWallpaperManager.swift; sourceTree = "<group>"; };
+		73A3E9458476683E0230677D /* ErrorReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorReporter.swift; sourceTree = "<group>"; };
 		77E4D58C6269978E4994C7CE /* AppShortcuts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppShortcuts.swift; sourceTree = "<group>"; };
 		79BC197A9E8C082F2C39C673 /* NowPlayingOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowPlayingOverlayView.swift; sourceTree = "<group>"; };
 		7F557952B625823A2689EBE7 /* WallpaperLibrary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperLibrary.swift; sourceTree = "<group>"; };
@@ -319,6 +321,7 @@
 				1849D0D4B8C207540818A7E8 /* CollectionManager.swift */,
 				2833332B3174CD94D7D62CBB /* DeepLinkHandler.swift */,
 				543E1B92A4536DE1415BD91E /* DownloadManager.swift */,
+				73A3E9458476683E0230677D /* ErrorReporter.swift */,
 				B3E0F02714B57C6B710BFA04 /* FavoriteStylesManager.swift */,
 				F9960B917192178D2217E668 /* iCloudSyncManager.swift */,
 				51A337D506233D372B7187D6 /* KeychainManager.swift */,
@@ -704,6 +707,7 @@
 				D57F15D4DC64658E22A29341 /* DynamicIslandController.swift in Sources */,
 				EAB040DBE1DBA4A2060A349D /* DynamicIslandView.swift in Sources */,
 				A2FD8BF6EF09FC0B086E2261 /* EffectsSettingsView.swift in Sources */,
+				A547D9A03C6D92826A5C634A /* ErrorReporter.swift in Sources */,
 				E8B9B335A9706D2398DC72A2 /* ExceptionCatcher.m in Sources */,
 				5C0AAD3B25B3DCB797AF2959 /* ExploreView.swift in Sources */,
 				CE93C5919FE1E7FAC086C58E /* FavoriteStylesManager.swift in Sources */,


### PR DESCRIPTION
## Summary

First wave of #167. Adds `ErrorReporter` for failures that aren't fatal
but the user should know about, and adopts it at the five highest-impact
silent-failure sites + two log-only UI paths.

## Why

The codebase had three error-handling shapes:
1. `try?` — silent, no diagnostics, no user feedback.
2. `throw` — propagated, sometimes user-visible.
3. `print` / `Log.*` — logged, invisible to user.

Cache JSON decode/encode failures (per-screen wallpapers, metadata
store, collections, space assignments) fell into bucket 1: a corrupt
blob silently reset to defaults. Drag-drop and Discover-download
imports fell into bucket 3: logged but the user just saw the import
"vanish".

## What landed

### New service: `Services/ErrorReporter.swift`

- `@MainActor` observable singleton with `@Published var current:
  AppError?`.
- `report(_:context:surface:)` always logs, optionally publishes
  to the alert layer.
- `AppError` is a small Identifiable envelope for `.alert(item:)`.

### ContentView observer

Subscribes to `ErrorReporter.shared.current` and renders an alert
when set.

### Five silent-failure sites adopt do/try/catch + logging

| File | Failure |
|---|---|
| `WallpaperManager.loadAll` | per-screen wallpaper map decode |
| `WallpaperManager.saveScreenWallpapers` | encode |
| `WallpaperMetadataStore.decodeJSON` / `encodeJSON` | titles / colors / tags |
| `CollectionManager.loadCollections` / `saveCollections` | collections payload |
| `SpaceWallpaperManager.saveAssignments` / `loadAssignments` | space JSON |

Where decode fails, the corrupt source is **reset** rather than left in
place — prevents repeated decode failures on every launch.

### Two log-only UI paths now surface to the user

- `DynamicIslandView` drag-drop import.
- `DiscoverView` WKDownload import (failure branch).

## Out of scope (next wave with #166 ViewModels)

- Service-layer typed error boundaries (`AppError` enum cases).
- ViewModel-level error state (currently ad-hoc).
- Remaining ~40 `try?` sites that are genuinely safe (cleanup
  `removeItem`, `defer handle.close()`, optional file metadata).

## Build

- Debug: ✓
- Release: ✓

## Test plan

- [ ] Corrupt the `screenWallpapersData` defaults entry manually, relaunch — Console.app shows the decode error log; app still launches with the per-screen map empty.
- [ ] Drag a non-video file onto the Dynamic Island — alert appears with the import failure reason.
- [ ] Trigger a WKDownload to a malformed file in Discover — banner closes, alert appears with "Could not import <name>".
- [ ] Save a wallpaper title containing a non-UTF-8-friendly string forced via debugger — encode failure logs but app continues.
- [ ] No alert spam: tear down + bring up app rapidly — only one alert appears per error event.