### PR TITLE
Security hardening — address all /security-scan findings

### DIFF
--- a/src/Wallnetic/Resources/Wallnetic.entitlements
+++ b/src/Wallnetic/Resources/Wallnetic.entitlements
@@ -3,12 +3,27 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.security.app-sandbox</key>
-	<false/>
+	<true/>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.com.wallnetic.shared</string>
 	</array>
+	<key>com.apple.security.network.client</key>
+	<true/>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
+	<key>com.apple.security.files.downloads.read-write</key>
+	<true/>
 	<key>com.apple.security.device.audio-input</key>
 	<true/>
+	<key>com.apple.security.personal-information.photos-library</key>
+	<true/>
+	<key>com.apple.security.scripting-targets</key>
+	<dict>
+		<key>com.apple.Music</key>
+		<array>
+			<string>com.apple.Music.read</string>
+		</array>
+	</dict>
 </dict>
 </plist>

--- a/src/Wallnetic/Services/AIService.swift
+++ b/src/Wallnetic/Services/AIService.swift
@@ -107,7 +107,8 @@ class AIService {
         // Parse queue response
         guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
               let requestId = json["request_id"] as? String else {
-            Log.ai.error("Failed to parse queue response: \(String(data: data, encoding: .utf8) ?? "nil", privacy: .public)")
+            // Body may contain echoed prompt or user-provided context — keep private.
+            Log.ai.error("Failed to parse queue response (body redacted): \(String(data: data, encoding: .utf8) ?? "nil", privacy: .private)")
             throw AIServiceError.invalidResponse
         }
 

--- a/src/Wallnetic/Services/DeepLinkHandler.swift
+++ b/src/Wallnetic/Services/DeepLinkHandler.swift
@@ -1,6 +1,13 @@
 import Foundation
+import AppKit
 
-/// Handles wallnetic:// URL scheme deep links
+/// Handles `wallnetic://` URL scheme deep links.
+///
+/// Security model: deep links are reachable from any process or web page
+/// that can spawn a `wallnetic://` URL — anyone the user clicks. State-
+/// changing actions (especially `import` which downloads + imports a
+/// remote file) require **explicit user confirmation** and limit the
+/// allowed schemes to HTTPS to prevent `file://` exfiltration.
 class DeepLinkHandler {
     static let shared = DeepLinkHandler()
 
@@ -18,7 +25,11 @@ class DeepLinkHandler {
             }
         )
 
-        Log.deepLink.info("\(url.absoluteString, privacy: .public)")
+        // Log only host + path. Query string can contain tokens / credentials
+        // from external referrers and should not be public-level diagnostic.
+        let safe = "\(url.scheme ?? "")://\(url.host ?? "")\(url.path)"
+        let queryLen = url.query?.count ?? 0
+        Log.deepLink.info("\(safe, privacy: .public) [+\(queryLen) query chars]")
 
         switch host {
         case "playPause":
@@ -55,15 +66,72 @@ class DeepLinkHandler {
             }
 
         case "import":
-            if let urlString = params["url"] {
-                Task {
-                    let downloaded = try await URLImporter.shared.downloadAndImport(from: urlString)
-                    _ = try await WallpaperManager.shared.importVideo(from: downloaded)
-                }
-            }
+            handleImportAction(params: params)
 
         default:
             Log.deepLink.info("Unknown action: \(host, privacy: .public)")
+        }
+    }
+
+    // MARK: - Import (sensitive — gated behind confirmation + HTTPS-only)
+
+    private func handleImportAction(params: [String: String]) {
+        guard let urlString = params["url"],
+              let importURL = URL(string: urlString) else {
+            Log.deepLink.error("import action with invalid URL")
+            return
+        }
+
+        // Only allow HTTPS — `file://`, `ftp://`, custom schemes are denied
+        // outright. URL scheme can be lower- or upper-case.
+        guard importURL.scheme?.lowercased() == "https" else {
+            Log.deepLink.error("import refused — non-HTTPS scheme: \(importURL.scheme ?? "nil", privacy: .public)")
+            DispatchQueue.main.async {
+                ErrorReporter.shared.report(
+                    DeepLinkError.invalidScheme,
+                    context: "Import refused: only HTTPS URLs are accepted from deep links."
+                )
+            }
+            return
+        }
+
+        let host = importURL.host ?? "unknown source"
+
+        DispatchQueue.main.async {
+            let alert = NSAlert()
+            alert.messageText = "Download wallpaper from \(host)?"
+            alert.informativeText = "Wallnetic was asked to import a video from this URL:\n\n\(importURL.absoluteString)\n\nOnly proceed if you started this action."
+            alert.alertStyle = .warning
+            alert.addButton(withTitle: "Download & Import")
+            alert.addButton(withTitle: "Cancel")
+            NSApp.activate(ignoringOtherApps: true)
+
+            let response = alert.runModal()
+            guard response == .alertFirstButtonReturn else {
+                Log.deepLink.info("import cancelled by user")
+                return
+            }
+
+            Task {
+                do {
+                    let downloaded = try await URLImporter.shared.downloadAndImport(from: urlString)
+                    _ = try await WallpaperManager.shared.importVideo(from: downloaded)
+                } catch {
+                    await MainActor.run {
+                        ErrorReporter.shared.report(error, context: "Import from deep link failed")
+                    }
+                }
+            }
+        }
+    }
+}
+
+private enum DeepLinkError: LocalizedError {
+    case invalidScheme
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidScheme: return "Only HTTPS URLs are accepted from deep links."
         }
     }
 }

--- a/src/Wallnetic/Services/URLImporter.swift
+++ b/src/Wallnetic/Services/URLImporter.swift
@@ -22,10 +22,16 @@ class URLImporter: ObservableObject {
         return videoExtensions.contains(url.pathExtension.lowercased())
     }
 
-    /// Downloads a video from URL and imports it
+    /// Downloads a video from URL and imports it. HTTPS-only and verifies
+    /// the response Content-Type against a video-format allowlist before
+    /// returning the saved file.
     func downloadAndImport(from urlString: String) async throws -> URL {
         guard let url = URL(string: urlString) else {
             throw URLImportError.invalidURL
+        }
+
+        guard url.scheme?.lowercased() == "https" else {
+            throw URLImportError.invalidScheme
         }
 
         isDownloading = true
@@ -44,6 +50,24 @@ class URLImporter: ObservableObject {
                   httpResponse.statusCode == 200 else {
                 isDownloading = false
                 throw URLImportError.downloadFailed
+            }
+
+            // Verify Content-Type matches an expected video MIME so a
+            // mislabelled `.mp4`-suffixed payload (HTML, executable) is
+            // rejected before being imported.
+            let mime = (httpResponse.value(forHTTPHeaderField: "Content-Type") ?? "")
+                .lowercased()
+                .components(separatedBy: ";").first
+                .map { $0.trimmingCharacters(in: .whitespaces) } ?? ""
+            let allowedMimes: Set<String> = [
+                "video/mp4", "video/quicktime", "video/x-m4v",
+                "video/webm", "video/x-matroska", "image/gif",
+                "image/webp", "application/octet-stream"
+            ]
+            if !allowedMimes.contains(mime) {
+                try? FileManager.default.removeItem(at: tempURL)
+                isDownloading = false
+                throw URLImportError.unsupportedContentType(mime)
             }
 
             // Move to stable location
@@ -79,12 +103,17 @@ class URLImporter: ObservableObject {
 
 enum URLImportError: LocalizedError {
     case invalidURL
+    case invalidScheme
     case downloadFailed
+    case unsupportedContentType(String)
 
     var errorDescription: String? {
         switch self {
         case .invalidURL: return "Invalid URL"
+        case .invalidScheme: return "Only HTTPS URLs are accepted."
         case .downloadFailed: return "Download failed"
+        case .unsupportedContentType(let mime):
+            return "Server returned unsupported content type: \(mime.isEmpty ? "(none)" : mime)"
         }
     }
 }

--- a/src/Wallnetic/Services/VideoFormatConverter.swift
+++ b/src/Wallnetic/Services/VideoFormatConverter.swift
@@ -184,13 +184,19 @@ class VideoFormatConverter {
             "-y",           // Overwrite
             outputURL.path
         ]
+        // Capture stderr so a conversion failure leaves a diagnostic trail
+        // instead of just an opaque "ffmpegFailed".
+        let stderrPipe = Pipe()
         process.standardOutput = FileHandle.nullDevice
-        process.standardError = FileHandle.nullDevice
+        process.standardError = stderrPipe
 
         try process.run()
         process.waitUntilExit()
 
         guard process.terminationStatus == 0 else {
+            let errorData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+            let tail = String(data: errorData, encoding: .utf8)?.suffix(500) ?? ""
+            Log.video.error("ffmpeg WebM conversion failed (exit \(process.terminationStatus)): \(String(tail), privacy: .public)")
             throw ConversionError.ffmpegFailed
         }
 

--- a/src/Wallnetic/Views/Main/DiscoverView.swift
+++ b/src/Wallnetic/Views/Main/DiscoverView.swift
@@ -491,7 +491,10 @@ struct WebViewWrapper: NSViewRepresentable {
     func makeNSView(context: Context) -> WKWebView {
         let config = WKWebViewConfiguration()
         config.allowsAirPlayForMediaPlayback = false
-        config.preferences.javaScriptCanOpenWindowsAutomatically = true
+        // Refuse JavaScript-driven `window.open()` without a user gesture —
+        // common popup spam / drive-by-download vector when the user
+        // browses untrusted sites in Discover.
+        config.preferences.javaScriptCanOpenWindowsAutomatically = false
         let webView = WKWebView(frame: .zero, configuration: config)
         webView.navigationDelegate = context.coordinator
         webView.uiDelegate = context.coordinator
@@ -501,7 +504,12 @@ struct WebViewWrapper: NSViewRepresentable {
 
         DispatchQueue.main.async { self.webViewRef = webView }
 
-        if let url = URL(string: urlString) {
+        // HTTPS/HTTP only. Reject `file://`, `javascript:`, custom schemes
+        // — prevents local-file disclosure and JS execution against the
+        // WebView origin via crafted address bar input.
+        if let url = URL(string: urlString),
+           let scheme = url.scheme?.lowercased(),
+           scheme == "https" || scheme == "http" {
             webView.load(URLRequest(url: url))
         }
         return webView


### PR DESCRIPTION
## Summary

Addresses all 12 findings from today's `/security-scan` pass. Three of
them are merge-blockers for App Store submission and arbitrary-URL
abuse defence; the rest tighten the rough edges.

## High

| # | Fix | File |
|---|---|---|
| 1 | Deep link `import` requires HTTPS + user confirmation alert. | `DeepLinkHandler.swift` |
| 2+7 | App sandbox enabled. Matching capability entitlements added (network, files, photos, Music scripting target). | `Wallnetic.entitlements` |
| 3 | WKWebView refuses JS-driven popups; URL load gated on `https?` scheme. | `DiscoverView.swift` |

## Medium

| # | Fix | File |
|---|---|---|
| 4 | Deep link log strips query string (only scheme/host/path public). | `DeepLinkHandler.swift` |
| 5 | URLImporter rejects non-HTTPS schemes. | `URLImporter.swift` |
| 6 | URLImporter validates response Content-Type against video MIME allowlist. | `URLImporter.swift` |
| 8 | AIService response body log flipped from `.public` to `.private`. | `AIService.swift` |

## Low

| # | Fix | File |
|---|---|---|
| 10 | VideoFormatConverter ffmpeg stderr now captured to `Log.video.error`. | `VideoFormatConverter.swift` |

## Defense-in-depth (no code change)

- **#9** NowPlayingManager AppleScript: hardcoded source, no injection
  vector. Sandbox now requires the `scripting-targets` entitlement
  for `com.apple.Music` which is in this commit.
- **#11** KeychainManager `kSecAttrAccessibleWhenUnlocked`:
  appropriate macOS default.
- **#12** Ad-hoc `try? removeItem` cleanups: residual symlink attack
  surface neutralised by sandbox.

## ⚠ Sandbox interaction

The WebM-via-ffmpeg path in `VideoFormatConverter` will fail
gracefully with `ConversionError.ffmpegNotFound` in sandboxed builds
(the sandbox blocks `Process` spawning `/usr/local/bin/ffmpeg`). GIF +
animated WebP via ImageIO/AVFoundation are unaffected. Most users
don't have ffmpeg installed anyway, so the user-visible behaviour is
"still doesn't convert WebM" rather than a regression.

## ⚠ Validation gap — must test before ship

Sandbox is enforced only when the app is properly signed. The
pre-commit hook strips `DEVELOPMENT_TEAM` and ad-hoc signing (which
this repo's CI uses) doesn't apply the entitlements blob. So Debug ✓
+ Release ✓ here only confirms compile-correctness.

Before next App Store submission please archive with a real signing
identity and exercise:

- [ ] Audio visualizer system-audio (ScreenCaptureKit).
- [ ] Microphone visualizer source.
- [ ] File picker import (`Cmd+I`).
- [ ] Drag-and-drop import on Dynamic Island.
- [ ] Photos slideshow end-to-end.
- [ ] WKDownload import in Discover.
- [ ] Music.app artwork fallback (`fetchMusicArtwork`).
- [ ] Deep links — `wallnetic://playPause`, `wallnetic://random`,
      `wallnetic://import?url=…` (confirmation alert appears).

Any of these failing in a signed build means the entitlement set
needs adjustment before submission.

## Build

- Debug: ✓
- Release: ✓ (compile-only — see validation gap above).