### PR TITLE
ViewModel layer (#166) — establish pattern + extract AI generation

### DIFF
--- a/src/Wallnetic/ViewModels/AIGenerateViewModel.swift
+++ b/src/Wallnetic/ViewModels/AIGenerateViewModel.swift
@@ -1,0 +1,162 @@
+import Foundation
+import AppKit
+
+/// Owns the AI video generation state and pipeline so `AIGenerateView`
+/// stays purely declarative (#166).
+///
+/// The view keeps its own UI-only state — image picker selection,
+/// drag-hover flag, prompt text — but anything that survives a
+/// re-render or talks to a service lives here.
+@MainActor
+final class AIGenerateViewModel: ObservableObject {
+    // MARK: - Published state
+
+    @Published var isGenerating = false
+    @Published var generationProgress: Double = 0
+    @Published var generationStatus: String = ""
+    @Published var generatedVideoURL: URL?
+    @Published var estimatedTimeRemaining: String = ""
+    @Published var errorMessage: String?
+
+    // MARK: - Private state
+
+    private var generationTask: Task<Void, Never>?
+    private var generationStartTime: Date?
+
+    // MARK: - Dependencies (injectable for tests)
+
+    private let aiService: AIService
+    private let historyManager: GenerationHistoryManager
+
+    init(
+        aiService: AIService = .shared,
+        historyManager: GenerationHistoryManager = .shared
+    ) {
+        self.aiService = aiService
+        self.historyManager = historyManager
+    }
+
+    // MARK: - Generation
+
+    func startGeneration(
+        prompt: String,
+        model: VideoModel,
+        duration: Int,
+        aspectRatio: String,
+        sourceImage: NSImage?
+    ) {
+        isGenerating = true
+        generationProgress = 0
+        generationStatus = "Starting..."
+        generationStartTime = Date()
+        estimatedTimeRemaining = ""
+        errorMessage = nil
+
+        let request = VideoGenerationRequest(
+            prompt: prompt,
+            model: model,
+            duration: duration,
+            aspectRatio: aspectRatio,
+            sourceImage: sourceImage
+        )
+        let wasImg2Vid = sourceImage != nil
+
+        generationTask = Task { [weak self] in
+            do {
+                let result = try await self?.aiService.generateVideo(request: request) { progress, status in
+                    Task { @MainActor [weak self] in
+                        self?.generationProgress = progress
+                        self?.generationStatus = status
+                        self?.updateEstimatedTime(progress: progress)
+                    }
+                }
+
+                if Task.isCancelled { return }
+
+                if let result {
+                    self?.historyManager.addGeneration(
+                        from: result,
+                        wasImg2Vid: wasImg2Vid,
+                        aspectRatio: aspectRatio
+                    )
+
+                    await MainActor.run { [weak self] in
+                        self?.isGenerating = false
+                        self?.generationTask = nil
+                        self?.generatedVideoURL = result.localURL
+                    }
+                }
+            } catch {
+                if Task.isCancelled { return }
+
+                await MainActor.run { [weak self] in
+                    self?.isGenerating = false
+                    self?.generationTask = nil
+                    self?.errorMessage = error.localizedDescription
+                }
+            }
+        }
+    }
+
+    func cancelGeneration() {
+        generationTask?.cancel()
+        generationTask = nil
+        isGenerating = false
+        generationProgress = 0
+        generationStatus = ""
+        estimatedTimeRemaining = ""
+    }
+
+    private func updateEstimatedTime(progress: Double) {
+        guard progress > 0.1, let startTime = generationStartTime else {
+            estimatedTimeRemaining = ""
+            return
+        }
+
+        let elapsed = Date().timeIntervalSince(startTime)
+        let estimatedTotal = elapsed / progress
+        let remaining = estimatedTotal - elapsed
+
+        guard remaining > 0, remaining < 600 else {
+            estimatedTimeRemaining = ""
+            return
+        }
+
+        let seconds = Int(remaining)
+        if seconds >= 60 {
+            estimatedTimeRemaining = "~\(seconds / 60)m \(seconds % 60)s remaining"
+        } else {
+            estimatedTimeRemaining = "~\(seconds)s remaining"
+        }
+    }
+
+    // MARK: - Library import
+
+    /// Copies the generated video into the app's wallpaper library and
+    /// asks the manager to refresh. Returns `true` on success, in which
+    /// case the caller can clear its prompt / image state.
+    @discardableResult
+    func addToLibrary(_ videoURL: URL, wallpaperManager: WallpaperManager) -> Bool {
+        let libraryURL = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+            .appendingPathComponent("Wallnetic/Library")
+
+        do {
+            try FileManager.default.createDirectory(at: libraryURL, withIntermediateDirectories: true)
+
+            let filename = "AI_Video_\(Date().timeIntervalSince1970).mp4"
+            let destinationURL = libraryURL.appendingPathComponent(filename)
+            try FileManager.default.copyItem(at: videoURL, to: destinationURL)
+
+            wallpaperManager.loadWallpapers()
+            generatedVideoURL = nil
+            return true
+        } catch {
+            errorMessage = "Failed to add to library: \(error.localizedDescription)"
+            return false
+        }
+    }
+
+    func clearGeneratedVideo() {
+        generatedVideoURL = nil
+    }
+}

--- a/src/Wallnetic/ViewModels/README.md
+++ b/src/Wallnetic/ViewModels/README.md
@@ -1,0 +1,98 @@
+# ViewModels — pattern guide (#166)
+
+This directory holds `@MainActor`-isolated `ObservableObject` view-models
+that own each screen's business logic and async lifecycle. Views stay
+purely declarative — they bind to view-model `@Published` properties
+and call methods, rather than performing service calls inline.
+
+## When to add a ViewModel
+
+Add one when a view exhibits at least two of:
+
+- **Long-running async work** — network calls, video render, downloads.
+- **State that must outlive a re-render** — generation tasks,
+  cancellable jobs, paginated cursors.
+- **Logic the test suite should exercise without launching the UI**
+  — pipeline construction, error mapping, side-effect ordering.
+
+If a view is just composing existing services with simple bindings
+(e.g. `Settings → toggles`), a VM is overkill. Bind directly.
+
+## Conventions
+
+```swift
+@MainActor
+final class FooViewModel: ObservableObject {
+    // Published — drives the view.
+    @Published var isLoading = false
+    @Published var items: [Foo] = []
+    @Published var errorMessage: String?
+
+    // Private — internal lifecycle (cancellable tasks, timers).
+    private var fetchTask: Task<Void, Never>?
+
+    // Dependencies — accept defaults pointing at production singletons,
+    // override in tests via init.
+    private let service: FooService
+
+    init(service: FooService = .shared) {
+        self.service = service
+    }
+
+    func load() {
+        fetchTask?.cancel()
+        fetchTask = Task { [weak self] in
+            // … async work, update @Published on the main actor
+        }
+    }
+
+    func cancel() {
+        fetchTask?.cancel()
+        fetchTask = nil
+    }
+}
+```
+
+Views attach via `@StateObject` (when they own the VM lifetime) or
+`@ObservedObject` (when the VM is passed in):
+
+```swift
+struct FooView: View {
+    @StateObject private var vm = FooViewModel()
+
+    var body: some View {
+        if vm.isLoading {
+            ProgressView()
+        } else {
+            List(vm.items, id: \.id) { … }
+        }
+    }
+}
+```
+
+## Error surfacing
+
+VMs **do not** present alerts directly. Either:
+
+- Set `errorMessage` and let the view render an inline error state, OR
+- Call `ErrorReporter.shared.report(...)` (#167) to surface a global
+  alert via the `ContentView` observer.
+
+The split: VM error state for screen-local recovery flows (e.g. "Try
+Again" on a generation failure); `ErrorReporter` for "out of band"
+failures the user wasn't actively waiting on (drag-drop import
+glitches, sync errors, decode failures).
+
+## Cancellation
+
+Use Swift `Task` and `Task.checkCancellation()` for cooperative
+cancel. Hold `private var fooTask: Task<Void, Never>?` and provide
+both the start method and a `cancel()` method. Wire the view's
+"Cancel" button to `vm.cancel()` and `.onDisappear { vm.cancel() }`
+when the work shouldn't outlive the screen.
+
+## Examples in this directory
+
+- `AIGenerateViewModel` — fal.ai pipeline + history persistence + library
+  import. Complete extraction of generation lifecycle from
+  `AIGenerateView`. Use as the reference implementation.

--- a/src/Wallnetic/Views/Main/AIGenerateView.swift
+++ b/src/Wallnetic/Views/Main/AIGenerateView.swift
@@ -3,28 +3,20 @@ import UniformTypeIdentifiers
 
 struct AIGenerateView: View {
     @EnvironmentObject var wallpaperManager: WallpaperManager
+    @StateObject private var vm = AIGenerateViewModel()
     @AppStorage("selectedVideoModel") private var selectedModelRaw: String = VideoModel.klingStandard.rawValue
 
+    // UI-only state (file picker / drag-hover / image preview)
     @State private var selectedImage: NSImage?
     @State private var selectedImageURL: URL?
     @State private var isImporting = false
     @State private var isDragging = false
-    @State private var errorMessage: String?
     @State private var isValidImage = false
 
-    // Prompt state
+    // Prompt state — view-local because the input field binds to it directly.
     @State private var prompt: String = ""
     @State private var selectedDuration: Int = 5
     @State private var selectedAspectRatio: String = "16:9"
-
-    // Generation state
-    @State private var isGenerating = false
-    @State private var generationProgress: Double = 0
-    @State private var generationStatus: String = ""
-    @State private var generatedVideoURL: URL?
-    @State private var generationTask: Task<Void, Never>?
-    @State private var generationStartTime: Date?
-    @State private var estimatedTimeRemaining: String = ""
 
     private var selectedModel: VideoModel {
         VideoModel(rawValue: selectedModelRaw) ?? .klingStandard
@@ -41,11 +33,11 @@ struct AIGenerateView: View {
             Divider()
 
             // Main content
-            if isGenerating {
+            if vm.isGenerating {
                 generationProgressView
-            } else if let videoURL = generatedVideoURL {
+            } else if let videoURL = vm.generatedVideoURL {
                 generatedVideoView(videoURL)
-            } else if errorMessage != nil && !isValidImage && selectedImage != nil {
+            } else if vm.errorMessage != nil {
                 errorView
             } else {
                 promptInputView
@@ -324,7 +316,13 @@ struct AIGenerateView: View {
     private var generateButton: some View {
         VStack(spacing: 12) {
             Button {
-                startGeneration()
+                vm.startGeneration(
+                    prompt: prompt,
+                    model: selectedModel,
+                    duration: selectedDuration,
+                    aspectRatio: selectedAspectRatio,
+                    sourceImage: selectedImage
+                )
             } label: {
                 HStack {
                     Image(systemName: "wand.and.stars")
@@ -370,7 +368,7 @@ struct AIGenerateView: View {
                 Text("Generating Video...")
                     .font(.headline)
 
-                Text(generationStatus)
+                Text(vm.generationStatus)
                     .font(.subheadline)
                     .foregroundColor(.secondary)
 
@@ -381,20 +379,20 @@ struct AIGenerateView: View {
 
             // Progress bar
             VStack(spacing: 8) {
-                ProgressView(value: generationProgress)
+                ProgressView(value: vm.generationProgress)
                     .progressViewStyle(.linear)
                     .frame(maxWidth: 300)
 
                 HStack {
-                    Text("\(Int(generationProgress * 100))%")
+                    Text("\(Int(vm.generationProgress * 100))%")
                         .font(.caption)
                         .fontWeight(.medium)
                         .foregroundColor(.accentColor)
 
                     Spacer()
 
-                    if !estimatedTimeRemaining.isEmpty {
-                        Text(estimatedTimeRemaining)
+                    if !vm.estimatedTimeRemaining.isEmpty {
+                        Text(vm.estimatedTimeRemaining)
                             .font(.caption)
                             .foregroundColor(.secondary)
                     }
@@ -407,7 +405,7 @@ struct AIGenerateView: View {
                 .foregroundColor(.secondary)
 
             // Cancel button
-            Button(action: cancelGeneration) {
+            Button(action: vm.cancelGeneration) {
                 HStack {
                     Image(systemName: "xmark.circle")
                     Text("Cancel")
@@ -461,7 +459,10 @@ struct AIGenerateView: View {
             VStack(spacing: 12) {
                 HStack(spacing: 12) {
                     Button {
-                        addToLibrary(videoURL)
+                        if vm.addToLibrary(videoURL, wallpaperManager: wallpaperManager) {
+                            prompt = ""
+                            clearImage()
+                        }
                     } label: {
                         HStack {
                             Image(systemName: "square.and.arrow.down")
@@ -482,7 +483,7 @@ struct AIGenerateView: View {
                 }
 
                 Button("Generate Another") {
-                    generatedVideoURL = nil
+                    vm.clearGeneratedVideo()
                 }
                 .buttonStyle(.bordered)
                 .foregroundColor(.secondary)
@@ -504,7 +505,7 @@ struct AIGenerateView: View {
                 Text("Generation Failed")
                     .font(.headline)
 
-                Text(errorMessage ?? "An unknown error occurred")
+                Text(vm.errorMessage ?? "An unknown error occurred")
                     .font(.subheadline)
                     .foregroundColor(.secondary)
                     .multilineTextAlignment(.center)
@@ -513,13 +514,19 @@ struct AIGenerateView: View {
 
             HStack(spacing: 12) {
                 Button("Try Again") {
-                    errorMessage = nil
-                    startGeneration()
+                    vm.errorMessage = nil
+                    vm.startGeneration(
+                        prompt: prompt,
+                        model: selectedModel,
+                        duration: selectedDuration,
+                        aspectRatio: selectedAspectRatio,
+                        sourceImage: selectedImage
+                    )
                 }
                 .buttonStyle(.borderedProminent)
 
                 Button("Start Over") {
-                    errorMessage = nil
+                    vm.errorMessage = nil
                     clearImage()
                     prompt = ""
                 }
@@ -533,21 +540,16 @@ struct AIGenerateView: View {
     // MARK: - Image Handling
 
     private func handleImageImport(_ result: Result<[URL], Error>) {
-        errorMessage = nil
-
         switch result {
         case .success(let urls):
             guard let url = urls.first else { return }
             loadImage(from: url)
-
         case .failure(let error):
-            errorMessage = "Failed to open file: \(error.localizedDescription)"
+            ErrorReporter.shared.report(error, context: "Failed to open image file")
         }
     }
 
     private func handleDrop(_ providers: [NSItemProvider]) {
-        errorMessage = nil
-
         guard let provider = providers.first else { return }
 
         if provider.canLoadObject(ofClass: NSImage.self) {
@@ -558,18 +560,18 @@ struct AIGenerateView: View {
                         self.selectedImageURL = nil
                         self.validateImage(nsImage)
                     } else if let error = error {
-                        self.errorMessage = "Failed to load image: \(error.localizedDescription)"
+                        ErrorReporter.shared.report(error, context: "Failed to load dropped image")
                     }
                 }
             }
             return
         }
 
-        provider.loadItem(forTypeIdentifier: UTType.fileURL.identifier, options: nil) { item, error in
+        provider.loadItem(forTypeIdentifier: UTType.fileURL.identifier, options: nil) { item, _ in
             DispatchQueue.main.async {
                 guard let data = item as? Data,
                       let url = URL(dataRepresentation: data, relativeTo: nil) else {
-                    self.errorMessage = "Invalid file"
+                    ErrorReporter.shared.report(ImageError.invalidFile, context: "Drag and drop")
                     return
                 }
                 self.loadImage(from: url)
@@ -588,12 +590,12 @@ struct AIGenerateView: View {
         guard let typeIdentifier = try? url.resourceValues(forKeys: [.typeIdentifierKey]).typeIdentifier,
               let utType = UTType(typeIdentifier),
               supportedTypes.contains(where: { utType.conforms(to: $0) }) else {
-            errorMessage = "Unsupported file format. Please use JPEG, PNG, or HEIC."
+            ErrorReporter.shared.report(ImageError.unsupportedFormat, context: "Image import")
             return
         }
 
         guard let image = NSImage(contentsOf: url) else {
-            errorMessage = "Failed to load image from file"
+            ErrorReporter.shared.report(ImageError.loadFailed, context: "Image import")
             return
         }
 
@@ -604,136 +606,37 @@ struct AIGenerateView: View {
 
     private func validateImage(_ image: NSImage) {
         let minDimension: CGFloat = 256
-        let width = image.size.width
-        let height = image.size.height
-
-        if width < minDimension || height < minDimension {
-            errorMessage = "Image too small. Minimum size is \(Int(minDimension))×\(Int(minDimension)) pixels."
+        if image.size.width < minDimension || image.size.height < minDimension {
+            ErrorReporter.shared.report(ImageError.tooSmall(min: Int(minDimension)), context: "Image validation")
             isValidImage = false
             return
         }
-
         isValidImage = true
-        errorMessage = nil
     }
 
     private func clearImage() {
         selectedImage = nil
         selectedImageURL = nil
         isValidImage = false
-        errorMessage = nil
     }
 
-    // MARK: - Generation
+    // Generation, cancellation, and library import live in
+    // `AIGenerateViewModel` (#166).
+}
 
-    private func startGeneration() {
-        isGenerating = true
-        generationProgress = 0
-        generationStatus = "Starting..."
-        generationStartTime = Date()
-        estimatedTimeRemaining = ""
-        errorMessage = nil
+// Image-import errors surfaced via `ErrorReporter`.
+private enum ImageError: LocalizedError {
+    case invalidFile
+    case unsupportedFormat
+    case loadFailed
+    case tooSmall(min: Int)
 
-        let request = VideoGenerationRequest(
-            prompt: prompt,
-            model: selectedModel,
-            duration: selectedDuration,
-            aspectRatio: selectedAspectRatio,
-            sourceImage: selectedImage
-        )
-
-        generationTask = Task {
-            do {
-                let result = try await AIService.shared.generateVideo(
-                    request: request
-                ) { progress, status in
-                    Task { @MainActor in
-                        self.generationProgress = progress
-                        self.generationStatus = status
-                        self.updateEstimatedTime(progress: progress)
-                    }
-                }
-
-                if Task.isCancelled { return }
-
-                // Save to history
-                GenerationHistoryManager.shared.addGeneration(
-                    from: result,
-                    wasImg2Vid: selectedImage != nil,
-                    aspectRatio: selectedAspectRatio
-                )
-
-                await MainActor.run {
-                    isGenerating = false
-                    generationTask = nil
-                    generatedVideoURL = result.localURL
-                }
-            } catch {
-                if Task.isCancelled { return }
-
-                await MainActor.run {
-                    isGenerating = false
-                    generationTask = nil
-                    errorMessage = error.localizedDescription
-                }
-            }
-        }
-    }
-
-    private func cancelGeneration() {
-        generationTask?.cancel()
-        generationTask = nil
-        isGenerating = false
-        generationProgress = 0
-        generationStatus = ""
-        estimatedTimeRemaining = ""
-    }
-
-    private func updateEstimatedTime(progress: Double) {
-        guard progress > 0.1,
-              let startTime = generationStartTime else {
-            estimatedTimeRemaining = ""
-            return
-        }
-
-        let elapsed = Date().timeIntervalSince(startTime)
-        let estimatedTotal = elapsed / progress
-        let remaining = estimatedTotal - elapsed
-
-        if remaining > 0 && remaining < 600 {
-            let seconds = Int(remaining)
-            if seconds >= 60 {
-                let minutes = seconds / 60
-                let secs = seconds % 60
-                estimatedTimeRemaining = "~\(minutes)m \(secs)s remaining"
-            } else {
-                estimatedTimeRemaining = "~\(seconds)s remaining"
-            }
-        } else {
-            estimatedTimeRemaining = ""
-        }
-    }
-
-    // MARK: - Library
-
-    private func addToLibrary(_ videoURL: URL) {
-        let libraryURL = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-            .appendingPathComponent("Wallnetic/Library")
-
-        do {
-            try FileManager.default.createDirectory(at: libraryURL, withIntermediateDirectories: true)
-
-            let filename = "AI_Video_\(Date().timeIntervalSince1970).mp4"
-            let destinationURL = libraryURL.appendingPathComponent(filename)
-
-            try FileManager.default.copyItem(at: videoURL, to: destinationURL)
-
-            wallpaperManager.loadWallpapers()
-            generatedVideoURL = nil
-            prompt = ""
-            clearImage()
-        } catch {
-            errorMessage = "Failed to add to library: \(error.localizedDescription)"
+    var errorDescription: String? {
+        switch self {
+        case .invalidFile:           return "Invalid file"
+        case .unsupportedFormat:     return "Unsupported file format. Please use JPEG, PNG, or HEIC."
+        case .loadFailed:            return "Failed to load image from file"
+        case .tooSmall(let min):     return "Image too small. Minimum size is \(min)×\(min) pixels."
         }
     }
 }

--- a/src/Wallnetic/Wallnetic.xcodeproj/project.pbxproj
+++ b/src/Wallnetic/Wallnetic.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		82F024AE9E99C4A77098AD9B /* FuzzySearchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA18283F2FD8E99F3FFDC805 /* FuzzySearchTests.swift */; };
 		84ACCBC72C120B8B6E00A64F /* SupabaseClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CEBCAF9E5F767C08A15158C /* SupabaseClient.swift */; };
 		88C6A7F9AD19AA876CEEC465 /* iCloudSyncManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9960B917192178D2217E668 /* iCloudSyncManager.swift */; };
+		8AAE56E8D08264474270D889 /* AIGenerateViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B59109A0A0707AFA611D15A /* AIGenerateViewModel.swift */; };
 		8BED6ED6D599D3F3C32821D5 /* HistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A32AE3710192737ABA41FDA0 /* HistoryView.swift */; };
 		8EFAE3E67407537EC1B9A705 /* DiscoverView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB036BA69CC6D00731C1D273 /* DiscoverView.swift */; };
 		93BC58F85DF7EBC9B6D3970F /* SharedWidgetModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDFCAB2A636011BB543DD1B5 /* SharedWidgetModels.swift */; };
@@ -156,6 +157,7 @@
 		134AA54986991D7480CC4CD8 /* SmallWidgetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmallWidgetView.swift; sourceTree = "<group>"; };
 		140AE9B28FFA1BF12B3651C5 /* NotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManager.swift; sourceTree = "<group>"; };
 		1849D0D4B8C207540818A7E8 /* CollectionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionManager.swift; sourceTree = "<group>"; };
+		1B59109A0A0707AFA611D15A /* AIGenerateViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIGenerateViewModel.swift; sourceTree = "<group>"; };
 		22D4CC2AF93849AB8C429D52 /* NowPlayingOverlayController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowPlayingOverlayController.swift; sourceTree = "<group>"; };
 		250C1B481393050C099266A2 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		2833332B3174CD94D7D62CBB /* DeepLinkHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepLinkHandler.swift; sourceTree = "<group>"; };
@@ -304,6 +306,7 @@
 		28FBE419A416F64CC9C1E9AC /* ViewModels */ = {
 			isa = PBXGroup;
 			children = (
+				1B59109A0A0707AFA611D15A /* AIGenerateViewModel.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -681,6 +684,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				9D898F865EED9BB751EBF7EF /* AIGenerateView.swift in Sources */,
+				8AAE56E8D08264474270D889 /* AIGenerateViewModel.swift in Sources */,
 				72F4CF08714A41746B6A0258 /* AIProvider.swift in Sources */,
 				FF16323D780FDC2A4404D5BA /* AIService.swift in Sources */,
 				C703D713F68746183202C7DE /* AIStyle.swift in Sources */,


### PR DESCRIPTION
## Summary

Closes #166. Adds the long-empty `ViewModels/` directory with a
reference implementation, pattern doc, and extracts the heaviest
concrete piece of view-internal business logic — the AI generation
pipeline — out of `AIGenerateView`.

## What landed

### `ViewModels/AIGenerateViewModel.swift`

`@MainActor` ObservableObject that owns:
- Generation lifecycle (`startGeneration` / `cancelGeneration`).
- Progress + ETA computation.
- History persistence + library import.
- Cancellable `Task` lifecycle.

Dependencies are constructor-injected (`AIService`,
`GenerationHistoryManager`) — testable without singletons.

### `AIGenerateView.swift`

Generation `@State` deleted (lifted to VM). Body now binds to
`vm.isGenerating`, `vm.generationProgress`, `vm.generationStatus`,
`vm.estimatedTimeRemaining`, `vm.generatedVideoURL`,
`vm.errorMessage`.

Image-import error sites (`handleImageImport`, `handleDrop`,
`loadImage`, `validateImage`) now route through `ErrorReporter.shared`
(landed in #167). New `ImageError` enum supplies `LocalizedError`
titles.

View shrank 744 → 647 lines.

### `ViewModels/README.md`

Pattern guide:
- When to add a VM (vs binding directly).
- Conventions (constructor DI, cancellation, `@StateObject` vs
  `@ObservedObject`).
- Error surfacing split — VM-local for recovery flows,
  `ErrorReporter` for out-of-band failures.

## Scope cut (called out honestly)

The issue lists four VMs (Home / Discover / Settings / AIGenerate).
Only `AIGenerateViewModel` is in this PR.

| Proposed VM | Status | Rationale |
|---|---|---|
| `AIGenerateViewModel` | ✅ Landed | The heaviest extractable surface. ~50 lines of pipeline + helpers + lifecycle moved out of the view. |
| `HomeViewModel` | ⏭ Skipped | `HomeView`'s only non-UI state is a hero rotation timer — genuinely view-internal carousel state. |
| `DiscoverViewModel` | ⏭ Skipped | Heavy logic already lives in the `WKNavigationDelegate` / `WKDownloadDelegate` coordinator class outside the SwiftUI body. |
| `SettingsViewModel` | ⏭ Skipped | Settings bind directly to `WallpaperManager` / `ThemeManager` `@AppStorage`. A wrapper VM would be no-op indirection. |

Future PRs can add VMs case-by-case as views grow logic. The pattern
doc gives the next contributor a clear runway.

## Build

- Debug: ✓
- Release: ✓

## Test plan

- [ ] AI generation: prompt + Generate Video → progress fills, ETA updates, success view shows generated mp4.
- [ ] Cancel mid-render: progress view exits cleanly, no orphan task.
- [ ] "Try Again" after failure: re-runs generation with same params.
- [ ] "Add to Library" then "Generate Another": clears prompt + image, returns to input view.
- [ ] Drop a non-image file or undersized image: `ErrorReporter` alert appears with the right reason; app does not silently no-op.
- [ ] No regression in image picker or drag-drop behaviour.