### PR TITLE
Wire up Collections rename dialog (#181)

### DIFF
--- a/src/Wallnetic/Views/Collections/CollectionDetailView.swift
+++ b/src/Wallnetic/Views/Collections/CollectionDetailView.swift
@@ -193,14 +193,32 @@ struct RenameCollectionSheet: View {
     @ObservedObject private var collectionManager = CollectionManager.shared
 
     @State private var name: String = ""
+    @FocusState private var nameFieldFocused: Bool
+
+    private var trimmedName: String {
+        name.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var canRename: Bool {
+        !trimmedName.isEmpty && trimmedName != collection.name
+    }
 
     var body: some View {
         VStack(spacing: 16) {
             Text("Rename Collection")
                 .font(.headline)
 
-            TextField("Collection name", text: $name)
-                .textFieldStyle(.roundedBorder)
+            HStack(spacing: 12) {
+                Image(systemName: collection.icon)
+                    .font(.title2)
+                    .foregroundColor(.accentColor)
+                    .frame(width: 32)
+
+                TextField("Collection name", text: $name)
+                    .textFieldStyle(.roundedBorder)
+                    .focused($nameFieldFocused)
+                    .onSubmit { commit() }
+            }
 
             HStack {
                 Button("Cancel") {
@@ -211,19 +229,25 @@ struct RenameCollectionSheet: View {
                 Spacer()
 
                 Button("Save") {
-                    collectionManager.renameCollection(collection, to: name)
-                    dismiss()
+                    commit()
                 }
                 .buttonStyle(.borderedProminent)
-                .disabled(name.isEmpty)
+                .disabled(!canRename)
                 .keyboardShortcut(.return)
             }
         }
         .padding()
-        .frame(width: 300)
+        .frame(width: 320)
         .onAppear {
             name = collection.name
+            nameFieldFocused = true
         }
+    }
+
+    private func commit() {
+        guard canRename else { return }
+        collectionManager.renameCollection(collection, to: trimmedName)
+        dismiss()
     }
 }
 

--- a/src/Wallnetic/Views/Collections/CollectionsView.swift
+++ b/src/Wallnetic/Views/Collections/CollectionsView.swift
@@ -4,6 +4,7 @@ struct CollectionsView: View {
     @ObservedObject private var collectionManager = CollectionManager.shared
     @State private var showingCreateSheet = false
     @State private var selectedCollection: WallpaperCollection?
+    @State private var collectionToRename: WallpaperCollection?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -54,7 +55,7 @@ struct CollectionsView: View {
                             .tag(collection)
                             .contextMenu {
                                 Button("Rename") {
-                                    // Implementation tracked in #181.
+                                    collectionToRename = collection
                                 }
 
                                 Button("Delete", role: .destructive) {
@@ -68,6 +69,9 @@ struct CollectionsView: View {
         }
         .sheet(isPresented: $showingCreateSheet) {
             CreateCollectionSheet()
+        }
+        .sheet(item: $collectionToRename) { collection in
+            RenameCollectionSheet(collection: collection)
         }
     }
 }


### PR DESCRIPTION
## Summary
- Replaces `// TODO: Show rename dialog` in CollectionsView contextMenu with a presented sheet.
- Reuses existing `RenameCollectionSheet`; tightens its validation so the Save button is disabled when the trimmed name is empty *or* unchanged.
- Adds auto-focus, submit-to-save, and shows the collection icon in the sheet header.

## Test plan
- [x] Debug build SUCCEEDED
- [x] All 57 unit tests pass
- [ ] Manual: right-click a collection → Rename → edit name → Save / Cancel / submit-key

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)