### PR TITLE
3D perspective wallpaper carousel (#127)

### DIFF
--- a/src/Wallnetic/Views/Main/Carousel3DGallery.swift
+++ b/src/Wallnetic/Views/Main/Carousel3DGallery.swift
@@ -1,0 +1,64 @@
+import SwiftUI
+
+/// 3D perspektif yatay carousel (#127). Ortadaki kart düz, kenarlardakiler
+/// y-ekseninde dönerek küçülür ve solar. Container'ın gerçek genişliğine göre
+/// hesaplandığı için pencere boyutuna ve ekrana bağımsız çalışır.
+struct Carousel3DGallery: View {
+    let wallpapers: [Wallpaper]
+    var onTap: ((Wallpaper) -> Void)? = nil
+
+    private let cardWidth: CGFloat = 280
+    private let cardHeight: CGFloat = 200
+    private let spacing: CGFloat = -40       // overlap so depth illusion holds
+    private let maxAngle: Double = 38
+    private let maxScaleLoss: Double = 0.22
+    private let minOpacity: Double = 0.35
+    private let coordSpace = "carousel3d"
+
+    var body: some View {
+        GeometryReader { container in
+            let centerX = container.size.width / 2
+            let leadingPad = max(centerX - cardWidth / 2, 16)
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                LazyHStack(spacing: spacing) {
+                    ForEach(wallpapers, id: \.id) { wallpaper in
+                        card(for: wallpaper, centerX: centerX)
+                    }
+                }
+                .padding(.horizontal, leadingPad)
+                .padding(.vertical, 24)
+            }
+            .coordinateSpace(name: coordSpace)
+        }
+        .frame(height: cardHeight + 48)
+    }
+
+    @ViewBuilder
+    private func card(for wallpaper: Wallpaper, centerX: CGFloat) -> some View {
+        GeometryReader { card in
+            let cardCenter = card.frame(in: .named(coordSpace)).midX
+            let raw = (cardCenter - centerX) / 320
+            let clamped = max(-1.4, min(1.4, raw))
+            let angle = clamped * maxAngle
+            let scale = max(0.66, 1.0 - abs(clamped) * maxScaleLoss)
+            let opacity = max(minOpacity, 1.0 - abs(clamped) * 0.55)
+            let z = 1.0 - abs(clamped)
+
+            CarouselCard(wallpaper: wallpaper)
+                .frame(width: cardWidth, height: cardHeight)
+                .scaleEffect(scale)
+                .rotation3DEffect(
+                    .degrees(-angle),
+                    axis: (x: 0, y: 1, z: 0),
+                    perspective: 0.6
+                )
+                .opacity(opacity)
+                .zIndex(z)
+                .onTapGesture {
+                    onTap?(wallpaper)
+                }
+        }
+        .frame(width: cardWidth, height: cardHeight)
+    }
+}

--- a/src/Wallnetic/Views/Main/ExploreView.swift
+++ b/src/Wallnetic/Views/Main/ExploreView.swift
@@ -11,7 +11,7 @@ struct ExploreView: View {
     @State private var selectedColor: ColorCategory?
 
     enum ViewMode: String {
-        case grid, list
+        case grid, list, carousel3D
     }
 
     private let categories = ["All", "Favorites", "Recent", "Long", "Short", "HD", "4K"]
@@ -133,14 +133,16 @@ struct ExploreView: View {
                 HStack(spacing: 4) {
                     viewModeButton(icon: "square.grid.2x2", mode: .grid)
                     viewModeButton(icon: "list.bullet", mode: .list)
+                    viewModeButton(icon: "rectangle.stack", mode: .carousel3D)
                 }
             }
             .padding(.horizontal, 20)
             .padding(.vertical, 8)
 
-            // Content — grid or list
-            ScrollView {
-                if viewMode == .grid {
+            // Content — grid, list, or 3D carousel
+            switch viewMode {
+            case .grid:
+                ScrollView {
                     LazyVGrid(columns: columns, spacing: 14) {
                         ForEach(Array(filteredWallpapers.enumerated()), id: \.element.id) { index, wallpaper in
                             ExploreCard(wallpaper: wallpaper, index: index)
@@ -149,7 +151,9 @@ struct ExploreView: View {
                     .padding(.horizontal, 20)
                     .padding(.top, 4)
                     .padding(.bottom, 20)
-                } else {
+                }
+            case .list:
+                ScrollView {
                     LazyVStack(spacing: 8) {
                         ForEach(Array(filteredWallpapers.enumerated()), id: \.element.id) { index, wallpaper in
                             ExploreListRow(wallpaper: wallpaper)
@@ -160,6 +164,13 @@ struct ExploreView: View {
                     .padding(.top, 4)
                     .padding(.bottom, 20)
                 }
+            case .carousel3D:
+                Carousel3DGallery(wallpapers: filteredWallpapers) { wallpaper in
+                    wallpaperManager.setWallpaper(wallpaper)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.top, 20)
+                Spacer()
             }
         }
         .background(Color.clear)

--- a/src/Wallnetic/Views/Main/HomeView.swift
+++ b/src/Wallnetic/Views/Main/HomeView.swift
@@ -311,63 +311,6 @@ struct CarouselSection: View {
     }
 }
 
-// MARK: - 3D Perspective Carousel
-
-struct Carousel3DSection: View {
-    let title: String
-    let icon: String
-    let iconColor: Color
-    let wallpapers: [Wallpaper]
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            HStack(spacing: 8) {
-                Image(systemName: icon)
-                    .font(.system(size: 12))
-                    .foregroundColor(iconColor)
-                    .neonGlow(iconColor, isActive: true, radius: 4)
-
-                Text(title)
-                    .font(.system(size: 16, weight: .bold))
-                    .foregroundColor(.white)
-
-                Text("\(wallpapers.count)")
-                    .font(.system(size: 11, weight: .medium, design: .monospaced))
-                    .foregroundColor(.white.opacity(0.3))
-            }
-            .padding(.horizontal, 48)
-
-            ScrollView(.horizontal, showsIndicators: false) {
-                LazyHStack(spacing: 0) {
-                    ForEach(Array(wallpapers.enumerated()), id: \.element.id) { index, wallpaper in
-                        GeometryReader { geo in
-                            let midX = geo.frame(in: .global).midX
-                            let screenMidX = NSScreen.main?.frame.midX ?? 600
-                            let distance = (midX - screenMidX) / 300
-                            let angle = Double(distance) * 25
-                            let scale = max(0.75, 1.0 - abs(distance) * 0.15)
-                            let opacity = max(0.5, 1.0 - abs(distance) * 0.3)
-
-                            CarouselCard(wallpaper: wallpaper)
-                                .scaleEffect(scale)
-                                .rotation3DEffect(
-                                    .degrees(-angle),
-                                    axis: (x: 0, y: 1, z: 0),
-                                    perspective: 0.5
-                                )
-                                .opacity(opacity)
-                                .animation(.easeOut(duration: 0.15), value: angle)
-                        }
-                        .frame(width: 260, height: 185)
-                    }
-                }
-                .padding(.horizontal, 48)
-                .padding(.vertical, 12)
-            }
-        }
-    }
-}
-
 // MARK: - Carousel Card with Glow
 
 struct CarouselCard: View {

--- a/src/Wallnetic/Wallnetic.xcodeproj/project.pbxproj
+++ b/src/Wallnetic/Wallnetic.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		131EDF3DA15DA0EEA84918A4 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43A9F2E051E3DDAA18ACAC9D /* HomeView.swift */; };
 		147CC96E7447673896138CA7 /* UpdateChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48513382BB8B61A6DD8431DC /* UpdateChecker.swift */; };
 		15138957B8762022576E764B /* AudioVisualizerOverlayController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C649839F5BB66D43BA4A499A /* AudioVisualizerOverlayController.swift */; };
+		18744CBDB0BD9D39124BA5BA /* Carousel3DGallery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92B6AD451254AF3C55F4100E /* Carousel3DGallery.swift */; };
 		1A4240EA14F4261CBA1F1E54 /* SettingsSubViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02604286446C78C5C8935E45 /* SettingsSubViews.swift */; };
 		1ACE67A285A3AC235ECF7904 /* MLWDecryptorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35A70D71A1BFA621DE839CA5 /* MLWDecryptorTests.swift */; };
 		1AEF59FC27860B386A6D7049 /* ErrorReporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BB04CF2E27DC75B29EE8A67 /* ErrorReporterTests.swift */; };
@@ -229,6 +230,7 @@
 		8F02815851C30DCFA0A4ACA3 /* DynamicIslandController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicIslandController.swift; sourceTree = "<group>"; };
 		9065D39D45D04ED947D1507D /* Wallnetic.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Wallnetic.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		91B502C8C68ABF2CD503030E /* AIGenerateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIGenerateView.swift; sourceTree = "<group>"; };
+		92B6AD451254AF3C55F4100E /* Carousel3DGallery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Carousel3DGallery.swift; sourceTree = "<group>"; };
 		9A160A29BBDB078330BD0CA4 /* URLImporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLImporter.swift; sourceTree = "<group>"; };
 		9E4377C1CA7A41D21A10FC40 /* LockScreenManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockScreenManager.swift; sourceTree = "<group>"; };
 		9E4C04ED28406292407FFBD0 /* PowerManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PowerManager.swift; sourceTree = "<group>"; };
@@ -421,6 +423,7 @@
 				91B502C8C68ABF2CD503030E /* AIGenerateView.swift */,
 				3C858C83BC8D22A21A53D7BD /* AudioVisualizerOverlayView.swift */,
 				3791DDB3169C35687B40D5CA /* BrowserWebView.swift */,
+				92B6AD451254AF3C55F4100E /* Carousel3DGallery.swift */,
 				EA19F4DBD0636536454696F3 /* ContentView.swift */,
 				BB036BA69CC6D00731C1D273 /* DiscoverView.swift */,
 				DDB1C25115998357CDFF95EB /* DynamicIslandView.swift */,
@@ -731,6 +734,7 @@
 				B34E2B3843447164873423D8 /* AuthManager.swift in Sources */,
 				61773D343F4EBEEB12FF8AFB /* BatteryPromptService.swift in Sources */,
 				F7D599673F52C74E4EF244EE /* BrowserWebView.swift in Sources */,
+				18744CBDB0BD9D39124BA5BA /* Carousel3DGallery.swift in Sources */,
 				B4147A0425D06A4CAD8EDE77 /* CloudSyncManager.swift in Sources */,
 				559304CF4E8C6C1F05A97B59 /* CollectionDetailView.swift in Sources */,
 				73849203691B6B9B27EF0384 /* CollectionManager.swift in Sources */,


### PR DESCRIPTION
## Summary
- Adds a third ViewMode (`carousel3D`) to ExploreView next to grid and list.
- New reusable component **Carousel3DGallery** (Views/Main/Carousel3DGallery.swift) — each card maps its distance from the container's center to a y-axis rotation (max 38°), scale (down to 0.66×), opacity (down to 0.35) and z-index. Math uses the scroll container's local coordinate space, so it is independent of window size, screen, or where it is embedded.
- Color filter toolbar mentioned in the issue is already present on ExploreView (dominant-color swatches + 11 ColorCategory cases).
- Tap on any card applies the wallpaper.

## Cleanup
- Removed the unused first attempt of \`Carousel3DSection\` from HomeView (it relied on \`NSScreen.main.frame.midX\` and was never referenced).

## Test plan
- [x] Debug build SUCCEEDED
- [x] All 57 unit tests pass
- [ ] Manual: Explore tab → click 3rd view-mode icon → scroll horizontally, cards rotate/scale/fade with depth; tap to apply
- [ ] Manual: works at different window widths (no NSScreen dependency)

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)