### PR TITLE
SQLite metadata cache (#115)

### DIFF
--- a/src/Wallnetic/Services/WallpaperManager.swift
+++ b/src/Wallnetic/Services/WallpaperManager.swift
@@ -78,6 +78,7 @@ class WallpaperManager: ObservableObject {
     private let library = WallpaperLibrary.shared
     private let metadata = WallpaperMetadataStore.shared
     private let widgetSync = WidgetSyncService.shared
+    private let cache = WallpaperMetadataCache.shared
 
     // MARK: - Initialization
 
@@ -143,6 +144,8 @@ class WallpaperManager: ObservableObject {
         metadata.applySavedColors(to: &wallpapers)
         metadata.applySavedTags(to: &wallpapers)
 
+        cache.replaceAll(with: wallpapers)
+
         loadMetadataInBackground()
         extractMissingColors()
     }
@@ -164,6 +167,7 @@ class WallpaperManager: ObservableObject {
     }
 
     private func postImportProcess(_ wallpaper: Wallpaper) {
+        cache.upsert(wallpaper)
         Task {
             _ = await wallpaper.generateThumbnail(size: CGSize(width: 320, height: 180))
             _ = await wallpaper.generateThumbnail(size: CGSize(width: 160, height: 90))
@@ -175,6 +179,7 @@ class WallpaperManager: ObservableObject {
                         var colors = metadata.savedColors
                         colors[wallpaper.url.path] = hex
                         metadata.savedColors = colors
+                        cache.upsert(wallpapers[idx])
                     }
                 }
             }
@@ -188,6 +193,7 @@ class WallpaperManager: ObservableObject {
             currentWallpaper = nil
         }
         metadata.saveFavorites(from: wallpapers)
+        cache.delete(id: wallpaper.id)
         Task { await widgetSync.syncFavorites(wallpapers.filter { $0.isFavorite }) }
     }
 
@@ -196,6 +202,7 @@ class WallpaperManager: ObservableObject {
             let trimmed = newTitle.trimmingCharacters(in: .whitespacesAndNewlines)
             wallpapers[index].customTitle = trimmed.isEmpty ? nil : trimmed
             metadata.saveCustomTitles(from: wallpapers)
+            cache.upsert(wallpapers[index])
             if currentWallpaper?.id == wallpaper.id {
                 currentWallpaper = wallpapers[index]
                 Task { await widgetSync.syncCurrentWallpaper(currentWallpaper) }
@@ -210,6 +217,7 @@ class WallpaperManager: ObservableObject {
                 currentWallpaper = wallpapers[index]
             }
             metadata.saveFavorites(from: wallpapers)
+            cache.upsert(wallpapers[index])
             Task { await widgetSync.syncFavorites(wallpapers.filter { $0.isFavorite }) }
         }
     }
@@ -224,6 +232,7 @@ class WallpaperManager: ObservableObject {
         var all = metadata.savedTags
         all[wallpapers[index].url.path] = wallpapers[index].tags
         metadata.savedTags = all
+        cache.upsert(wallpapers[index])
     }
 
     func removeTag(_ tag: String, from wallpaper: Wallpaper) {
@@ -232,6 +241,7 @@ class WallpaperManager: ObservableObject {
         var all = metadata.savedTags
         all[wallpapers[index].url.path] = wallpapers[index].tags
         metadata.savedTags = all
+        cache.upsert(wallpapers[index])
     }
 
     var allTags: [String] {

--- a/src/Wallnetic/Services/WallpaperMetadataCache.swift
+++ b/src/Wallnetic/Services/WallpaperMetadataCache.swift
@@ -1,0 +1,381 @@
+import Foundation
+import AppKit
+import SQLite3
+
+/// SQLite metadata cache for fast wallpaper search & filtering (#115).
+///
+/// **Role:** secondary read-side index. The authoritative store is still
+/// `WallpaperMetadataStore` + the on-disk Library directory; this cache is a
+/// best-effort denormalised mirror that fuels search/filter queries. If the
+/// cache file is missing or corrupt we rebuild it from `WallpaperManager`
+/// on next launch — losing the cache is never user-visible data loss.
+///
+/// **Threading:** uses an internal serial queue so callers can fire writes
+/// from any thread without races. All sqlite3 calls happen on that queue.
+///
+/// **Failure policy:** every write is wrapped in do-or-log. If SQLite is in
+/// a bad state the in-memory `WallpaperManager.wallpapers` array still
+/// works; the next library reload will rebuild the cache.
+final class WallpaperMetadataCache {
+    static let shared = WallpaperMetadataCache()
+
+    private let queue = DispatchQueue(label: "com.wallnetic.metadata-cache", qos: .utility)
+    private var db: OpaquePointer?
+    private var isOpen: Bool { db != nil }
+
+    private init() {
+        queue.sync { open() }
+    }
+
+    deinit {
+        if let db { sqlite3_close(db) }
+    }
+
+    // MARK: - Lifecycle
+
+    private func open() {
+        let dbURL = applicationSupportURL()
+            .appendingPathComponent("Wallnetic", isDirectory: true)
+            .appendingPathComponent("metadata.sqlite")
+
+        do {
+            try FileManager.default.createDirectory(
+                at: dbURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+        } catch {
+            Log.cache.error("Failed to create cache dir: \(String(describing: error), privacy: .public)")
+            return
+        }
+
+        let path = dbURL.path
+        var handle: OpaquePointer?
+        let flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FULLMUTEX
+        guard sqlite3_open_v2(path, &handle, flags, nil) == SQLITE_OK, let handle else {
+            Log.cache.error("sqlite3_open_v2 failed for \(path, privacy: .public)")
+            if handle != nil { sqlite3_close(handle) }
+            return
+        }
+        db = handle
+
+        // WAL mode for concurrent reads + better crash resilience
+        exec("PRAGMA journal_mode=WAL;")
+        exec("PRAGMA synchronous=NORMAL;")
+        exec("PRAGMA foreign_keys=ON;")
+
+        applyMigrations()
+    }
+
+    private func applyMigrations() {
+        // Schema v1
+        let create = """
+        CREATE TABLE IF NOT EXISTS wallpapers (
+            key            TEXT PRIMARY KEY,
+            name           TEXT NOT NULL,
+            custom_title   TEXT,
+            path           TEXT NOT NULL UNIQUE,
+            type           TEXT NOT NULL DEFAULT 'video',
+            tags_json      TEXT NOT NULL DEFAULT '[]',
+            color_hex      TEXT,
+            hue            INTEGER,
+            saturation     INTEGER,
+            width          INTEGER,
+            height         INTEGER,
+            duration       REAL,
+            filesize       INTEGER NOT NULL DEFAULT 0,
+            favourite      INTEGER NOT NULL DEFAULT 0,
+            mtime          INTEGER NOT NULL DEFAULT 0,
+            date_added     REAL NOT NULL DEFAULT 0
+        );
+        """
+        exec(create)
+        exec("CREATE INDEX IF NOT EXISTS idx_wallpapers_favourite ON wallpapers(favourite);")
+        exec("CREATE INDEX IF NOT EXISTS idx_wallpapers_color    ON wallpapers(color_hex);")
+        exec("CREATE INDEX IF NOT EXISTS idx_wallpapers_name     ON wallpapers(name);")
+        exec("CREATE INDEX IF NOT EXISTS idx_wallpapers_mtime    ON wallpapers(mtime);")
+
+        // schema_version for future migrations
+        exec("CREATE TABLE IF NOT EXISTS schema (version INTEGER NOT NULL);")
+        exec("INSERT INTO schema (version) SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM schema);")
+    }
+
+    @discardableResult
+    private func exec(_ sql: String) -> Bool {
+        guard let db else { return false }
+        var errMsg: UnsafeMutablePointer<CChar>?
+        let rc = sqlite3_exec(db, sql, nil, nil, &errMsg)
+        if rc != SQLITE_OK {
+            let msg = errMsg.map { String(cString: $0) } ?? "unknown"
+            sqlite3_free(errMsg)
+            Log.cache.error("sqlite3_exec failed (\(rc, privacy: .public)): \(msg, privacy: .public)")
+            return false
+        }
+        return true
+    }
+
+    // MARK: - Public API (Writes)
+
+    /// Insert or update one wallpaper.
+    func upsert(_ wallpaper: Wallpaper) {
+        queue.async { [weak self] in
+            self?.unsafeUpsert(wallpaper)
+        }
+    }
+
+    /// Bulk replace — rebuilds the table to match an authoritative set.
+    /// Used after `WallpaperManager.loadWallpapers()` to drop stale rows.
+    func replaceAll(with wallpapers: [Wallpaper]) {
+        queue.async { [weak self] in
+            guard let self, self.isOpen else { return }
+            self.exec("BEGIN IMMEDIATE TRANSACTION;")
+            self.exec("DELETE FROM wallpapers;")
+            for wp in wallpapers {
+                self.unsafeUpsert(wp)
+            }
+            self.exec("COMMIT;")
+        }
+    }
+
+    /// Remove a wallpaper by id.
+    func delete(id: UUID) {
+        queue.async { [weak self] in
+            guard let self, let db = self.db else { return }
+            var stmt: OpaquePointer?
+            defer { sqlite3_finalize(stmt) }
+            guard sqlite3_prepare_v2(db, "DELETE FROM wallpapers WHERE key=?;", -1, &stmt, nil) == SQLITE_OK else {
+                Log.cache.error("prepare DELETE failed: \(self.lastError, privacy: .public)")
+                return
+            }
+            sqlite3_bind_text(stmt, 1, id.uuidString, -1, SQLITE_TRANSIENT)
+            if sqlite3_step(stmt) != SQLITE_DONE {
+                Log.cache.error("DELETE failed: \(self.lastError, privacy: .public)")
+            }
+        }
+    }
+
+    /// Drop rows whose `path` is not present in `currentPaths` — used after
+    /// a library rescan to discard rows for files that disappeared.
+    func pruneMissing(currentPaths: Set<String>) {
+        queue.async { [weak self] in
+            guard let self, let db = self.db else { return }
+            var stmt: OpaquePointer?
+            defer { sqlite3_finalize(stmt) }
+            guard sqlite3_prepare_v2(db, "SELECT path FROM wallpapers;", -1, &stmt, nil) == SQLITE_OK else { return }
+            var toDelete: [String] = []
+            while sqlite3_step(stmt) == SQLITE_ROW {
+                if let cstr = sqlite3_column_text(stmt, 0) {
+                    let path = String(cString: cstr)
+                    if !currentPaths.contains(path) { toDelete.append(path) }
+                }
+            }
+            for path in toDelete {
+                var d: OpaquePointer?
+                defer { sqlite3_finalize(d) }
+                if sqlite3_prepare_v2(db, "DELETE FROM wallpapers WHERE path=?;", -1, &d, nil) == SQLITE_OK {
+                    sqlite3_bind_text(d, 1, path, -1, SQLITE_TRANSIENT)
+                    _ = sqlite3_step(d)
+                }
+            }
+        }
+    }
+
+    // MARK: - Public API (Reads)
+
+    /// Returns wallpaper *ids* matching the search query in name/custom_title/tags.
+    /// Ordered by score (exact name match > contains > tag-contains > fuzzy).
+    /// Synchronous because callers display results inline.
+    func searchIds(query: String) -> [UUID] {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return [] }
+
+        return queue.sync {
+            guard let db = self.db else { return [] }
+            let like = "%\(trimmed.lowercased())%"
+            let sql = """
+            SELECT key,
+                   (CASE WHEN lower(coalesce(custom_title, name)) = ? THEN 100
+                         WHEN lower(coalesce(custom_title, name)) LIKE ? THEN 70
+                         ELSE 0 END) +
+                   (CASE WHEN lower(tags_json) LIKE ? THEN 50 ELSE 0 END) AS score
+              FROM wallpapers
+             WHERE score > 0
+             ORDER BY score DESC, name ASC;
+            """
+            var stmt: OpaquePointer?
+            defer { sqlite3_finalize(stmt) }
+            guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+                Log.cache.error("prepare SELECT search failed: \(self.lastError, privacy: .public)")
+                return []
+            }
+            let exact = trimmed.lowercased()
+            sqlite3_bind_text(stmt, 1, exact, -1, SQLITE_TRANSIENT)
+            sqlite3_bind_text(stmt, 2, like, -1, SQLITE_TRANSIENT)
+            sqlite3_bind_text(stmt, 3, like, -1, SQLITE_TRANSIENT)
+
+            var ids: [UUID] = []
+            while sqlite3_step(stmt) == SQLITE_ROW {
+                if let cstr = sqlite3_column_text(stmt, 0),
+                   let uuid = UUID(uuidString: String(cString: cstr)) {
+                    ids.append(uuid)
+                }
+            }
+            return ids
+        }
+    }
+
+    /// Returns ids of wallpapers in the given color category.
+    func idsByColorCategory(_ category: ColorCategory) -> [UUID] {
+        return queue.sync {
+            guard let db = self.db else { return [] }
+            var stmt: OpaquePointer?
+            defer { sqlite3_finalize(stmt) }
+            let sql = "SELECT key, color_hex FROM wallpapers WHERE color_hex IS NOT NULL;"
+            guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { return [] }
+
+            var ids: [UUID] = []
+            while sqlite3_step(stmt) == SQLITE_ROW {
+                guard
+                    let keyCstr = sqlite3_column_text(stmt, 0),
+                    let hexCstr = sqlite3_column_text(stmt, 1),
+                    let uuid = UUID(uuidString: String(cString: keyCstr))
+                else { continue }
+                let hex = String(cString: hexCstr)
+                if let color = NSColor(hex: hex), ColorCategory.from(color: color) == category {
+                    ids.append(uuid)
+                }
+            }
+            return ids
+        }
+    }
+
+    func count() -> Int {
+        return queue.sync {
+            guard let db = self.db else { return 0 }
+            var stmt: OpaquePointer?
+            defer { sqlite3_finalize(stmt) }
+            guard sqlite3_prepare_v2(db, "SELECT COUNT(*) FROM wallpapers;", -1, &stmt, nil) == SQLITE_OK,
+                  sqlite3_step(stmt) == SQLITE_ROW
+            else { return 0 }
+            return Int(sqlite3_column_int(stmt, 0))
+        }
+    }
+
+    // MARK: - Internals
+
+    /// Must run on `queue`.
+    private func unsafeUpsert(_ wallpaper: Wallpaper) {
+        guard let db else { return }
+
+        let mtime = (try? FileManager.default.attributesOfItem(atPath: wallpaper.url.path))?[.modificationDate] as? Date
+        let tagsJSON = (try? String(data: JSONEncoder().encode(wallpaper.tags), encoding: .utf8)) ?? "[]"
+
+        var hue: Int32 = -1
+        var sat: Int32 = -1
+        if let hex = wallpaper.dominantColorHex, let color = NSColor(hex: hex) {
+            let rgb = color.usingColorSpace(.sRGB) ?? color
+            var h: CGFloat = 0, s: CGFloat = 0, b: CGFloat = 0
+            rgb.getHue(&h, saturation: &s, brightness: &b, alpha: nil)
+            hue = Int32(h * 360)
+            sat = Int32(s * 100)
+        }
+
+        let sql = """
+        INSERT INTO wallpapers (key, name, custom_title, path, type, tags_json, color_hex, hue, saturation,
+                                width, height, duration, filesize, favourite, mtime, date_added)
+        VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+        ON CONFLICT(key) DO UPDATE SET
+            name=excluded.name,
+            custom_title=excluded.custom_title,
+            path=excluded.path,
+            tags_json=excluded.tags_json,
+            color_hex=excluded.color_hex,
+            hue=excluded.hue,
+            saturation=excluded.saturation,
+            width=excluded.width,
+            height=excluded.height,
+            duration=excluded.duration,
+            filesize=excluded.filesize,
+            favourite=excluded.favourite,
+            mtime=excluded.mtime;
+        """
+        var stmt: OpaquePointer?
+        defer { sqlite3_finalize(stmt) }
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            Log.cache.error("prepare UPSERT failed: \(self.lastError, privacy: .public)")
+            return
+        }
+
+        sqlite3_bind_text(stmt, 1, wallpaper.id.uuidString, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_text(stmt, 2, wallpaper.name, -1, SQLITE_TRANSIENT)
+        if let custom = wallpaper.customTitle {
+            sqlite3_bind_text(stmt, 3, custom, -1, SQLITE_TRANSIENT)
+        } else {
+            sqlite3_bind_null(stmt, 3)
+        }
+        sqlite3_bind_text(stmt, 4, wallpaper.url.path, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_text(stmt, 5, "video", -1, SQLITE_TRANSIENT)
+        sqlite3_bind_text(stmt, 6, tagsJSON, -1, SQLITE_TRANSIENT)
+        if let hex = wallpaper.dominantColorHex {
+            sqlite3_bind_text(stmt, 7, hex, -1, SQLITE_TRANSIENT)
+        } else {
+            sqlite3_bind_null(stmt, 7)
+        }
+        sqlite3_bind_int(stmt, 8, hue)
+        sqlite3_bind_int(stmt, 9, sat)
+
+        if let res = wallpaper.resolution {
+            sqlite3_bind_int(stmt, 10, Int32(res.width))
+            sqlite3_bind_int(stmt, 11, Int32(res.height))
+        } else {
+            sqlite3_bind_null(stmt, 10)
+            sqlite3_bind_null(stmt, 11)
+        }
+
+        if let dur = wallpaper.duration {
+            sqlite3_bind_double(stmt, 12, dur)
+        } else {
+            sqlite3_bind_null(stmt, 12)
+        }
+
+        sqlite3_bind_int64(stmt, 13, wallpaper.fileSize)
+        sqlite3_bind_int(stmt, 14, wallpaper.isFavorite ? 1 : 0)
+        sqlite3_bind_int64(stmt, 15, Int64(mtime?.timeIntervalSince1970 ?? 0))
+        sqlite3_bind_double(stmt, 16, wallpaper.dateAdded.timeIntervalSince1970)
+
+        if sqlite3_step(stmt) != SQLITE_DONE {
+            Log.cache.error("UPSERT step failed: \(self.lastError, privacy: .public)")
+        }
+    }
+
+    private var lastError: String {
+        guard let db else { return "no db" }
+        return String(cString: sqlite3_errmsg(db))
+    }
+
+    // MARK: - Test Support
+
+    #if DEBUG
+    /// In-memory database for unit tests. Not exposed in Release.
+    static func makeInMemoryForTesting() -> WallpaperMetadataCache {
+        let instance = WallpaperMetadataCache(inMemory: true)
+        return instance
+    }
+
+    private convenience init(inMemory: Bool) {
+        self.init()
+        guard inMemory else { return }
+        queue.sync {
+            if let db { sqlite3_close(db) }
+            self.db = nil
+            var handle: OpaquePointer?
+            if sqlite3_open(":memory:", &handle) == SQLITE_OK, let handle {
+                self.db = handle
+                applyMigrations()
+            }
+        }
+    }
+    #endif
+}
+
+// SQLITE_TRANSIENT helper — required for Swift bindings to copy strings.
+private let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)

--- a/src/Wallnetic/Tests/WallpaperMetadataCacheTests.swift
+++ b/src/Wallnetic/Tests/WallpaperMetadataCacheTests.swift
@@ -1,0 +1,108 @@
+import XCTest
+@testable import Wallnetic
+
+/// SQLite metadata cache (#115). Uses an in-memory database so tests do
+/// not touch the user's Application Support directory.
+final class WallpaperMetadataCacheTests: XCTestCase {
+    private var cache: WallpaperMetadataCache!
+
+    override func setUp() {
+        super.setUp()
+        cache = WallpaperMetadataCache.makeInMemoryForTesting()
+    }
+
+    override func tearDown() {
+        cache = nil
+        super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private func makeWallpaper(name: String, favorite: Bool = false, tags: [String] = [], color: String? = nil) -> Wallpaper {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wallpaper-cache-test-\(UUID().uuidString)-\(name).mp4")
+        try? Data().write(to: tmp)
+        var wp = Wallpaper(url: tmp, isFavorite: favorite)
+        wp.tags = tags
+        wp.dominantColorHex = color
+        return wp
+    }
+
+    // MARK: - Tests
+
+    func test_upsert_then_count_increments() {
+        let wp = makeWallpaper(name: "sunrise")
+        cache.upsert(wp)
+
+        // queue is async; flush by querying (search waits on the queue too)
+        _ = cache.searchIds(query: "sunrise")
+        XCTAssertEqual(cache.count(), 1)
+    }
+
+    func test_upsert_replaces_existing_row_on_same_id() {
+        let wp = makeWallpaper(name: "ocean", tags: ["blue"])
+        cache.upsert(wp)
+        cache.upsert(wp)
+        _ = cache.searchIds(query: "ocean")
+        XCTAssertEqual(cache.count(), 1, "Upserting the same wallpaper twice must not create duplicates.")
+    }
+
+    func test_search_matches_name_substring_and_tags() {
+        let a = makeWallpaper(name: "mountain-sunrise", tags: ["nature"])
+        let b = makeWallpaper(name: "city-skyline", tags: ["urban", "sunrise-special"])
+        let c = makeWallpaper(name: "ocean-depths", tags: ["nature"])
+        cache.upsert(a)
+        cache.upsert(b)
+        cache.upsert(c)
+
+        let hits = cache.searchIds(query: "sunrise")
+        XCTAssertTrue(hits.contains(a.id), "Name-substring hit expected.")
+        XCTAssertTrue(hits.contains(b.id), "Tag-substring hit expected.")
+        XCTAssertFalse(hits.contains(c.id), "Non-matching row must be excluded.")
+    }
+
+    func test_search_empty_query_returns_empty() {
+        cache.upsert(makeWallpaper(name: "anything"))
+        XCTAssertEqual(cache.searchIds(query: "  ").count, 0)
+        XCTAssertEqual(cache.searchIds(query: "").count, 0)
+    }
+
+    func test_delete_removes_row() {
+        let wp = makeWallpaper(name: "to-delete")
+        cache.upsert(wp)
+        _ = cache.searchIds(query: "to-delete")
+        XCTAssertEqual(cache.count(), 1)
+
+        cache.delete(id: wp.id)
+        _ = cache.searchIds(query: "to-delete")
+        XCTAssertEqual(cache.count(), 0)
+    }
+
+    func test_replaceAll_drops_stale_rows() {
+        let a = makeWallpaper(name: "old-a")
+        let b = makeWallpaper(name: "old-b")
+        cache.upsert(a)
+        cache.upsert(b)
+        _ = cache.searchIds(query: "old")
+        XCTAssertEqual(cache.count(), 2)
+
+        let c = makeWallpaper(name: "fresh-c")
+        cache.replaceAll(with: [c])
+        _ = cache.searchIds(query: "fresh")
+        XCTAssertEqual(cache.count(), 1)
+        XCTAssertEqual(cache.searchIds(query: "fresh"), [c.id])
+        XCTAssertEqual(cache.searchIds(query: "old"), [])
+    }
+
+    func test_idsByColorCategory_filters_by_dominant_color() {
+        let red = makeWallpaper(name: "red-one", color: "#E63946")
+        let blue = makeWallpaper(name: "blue-one", color: "#1D3557")
+        cache.upsert(red)
+        cache.upsert(blue)
+        _ = cache.searchIds(query: "one")
+
+        let reds = cache.idsByColorCategory(.red)
+        XCTAssertTrue(reds.contains(red.id))
+        XCTAssertFalse(reds.contains(blue.id))
+    }
+}

--- a/src/Wallnetic/Utils/Log.swift
+++ b/src/Wallnetic/Utils/Log.swift
@@ -47,6 +47,7 @@ enum Log {
     static let shared       = Logger(subsystem: subsystem, category: "SharedData")
     static let space        = Logger(subsystem: subsystem, category: "SpaceWallpaper")
     static let store        = Logger(subsystem: subsystem, category: "WallpaperStore")
+    static let cache        = Logger(subsystem: subsystem, category: "MetadataCache")
     static let supabase     = Logger(subsystem: subsystem, category: "Supabase")
     static let thumbnail    = Logger(subsystem: subsystem, category: "Thumbnail")
     static let timeOfDay    = Logger(subsystem: subsystem, category: "TimeOfDay")

--- a/src/Wallnetic/Wallnetic.xcodeproj/project.pbxproj
+++ b/src/Wallnetic/Wallnetic.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		61773D343F4EBEEB12FF8AFB /* BatteryPromptService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0187521E8CC2C0BB29CE90D /* BatteryPromptService.swift */; };
 		61B1EC0DBC85801311FA1F2F /* MenuBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B106464A071BF6E736C3272 /* MenuBarView.swift */; };
 		6A650CD75C4B32AB9889A6A7 /* SharedWidgetModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDFCAB2A636011BB543DD1B5 /* SharedWidgetModels.swift */; };
+		6ADBCB967C34EB7B36825043 /* WallpaperMetadataCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 941B25667F75E00393C7E895 /* WallpaperMetadataCacheTests.swift */; };
 		6B3FA8945F430A067CC4DB4D /* WallpaperLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F557952B625823A2689EBE7 /* WallpaperLibrary.swift */; };
 		6FDE90B9E751CC319C45BA54 /* MusicReactiveManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F48518E41B9C56DFE5EB099 /* MusicReactiveManager.swift */; };
 		71B0E8B741F75A6147C62611 /* MetalVideoRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED806BD7E0913BCDF1142604 /* MetalVideoRenderer.swift */; };
@@ -69,6 +70,7 @@
 		93BC58F85DF7EBC9B6D3970F /* SharedWidgetModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDFCAB2A636011BB543DD1B5 /* SharedWidgetModels.swift */; };
 		93CA4E731227254F983F6270 /* TimeOfDaySettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E4002911F0B7869F3183DA /* TimeOfDaySettingsView.swift */; };
 		9721B6140E12A2FA558584B8 /* NowPlayingOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79BC197A9E8C082F2C39C673 /* NowPlayingOverlayView.swift */; };
+		975BFD8CBA6DB402B4EFB2A5 /* WallpaperMetadataCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C5D6AF9B7CC270A5CB93E0 /* WallpaperMetadataCache.swift */; };
 		9C7206924D126AE38A11DD51 /* WallpaperStoreManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40A93EE0CF1D353315FEA25D /* WallpaperStoreManager.swift */; };
 		9D898F865EED9BB751EBF7EF /* AIGenerateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91B502C8C68ABF2CD503030E /* AIGenerateView.swift */; };
 		A0A7D57E670326EECB26D581 /* NotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 140AE9B28FFA1BF12B3651C5 /* NotificationManager.swift */; };
@@ -196,6 +198,7 @@
 		5391D519B2B4F2D898BEDB0F /* AuthManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthManager.swift; sourceTree = "<group>"; };
 		543E1B92A4536DE1415BD91E /* DownloadManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadManager.swift; sourceTree = "<group>"; };
 		56F59C3C7AB56348DA1D9D45 /* ColorCategoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorCategoryTests.swift; sourceTree = "<group>"; };
+		57C5D6AF9B7CC270A5CB93E0 /* WallpaperMetadataCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperMetadataCache.swift; sourceTree = "<group>"; };
 		585BFEEC0C8B2AF4168BD91A /* Wallnetic-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Wallnetic-Bridging-Header.h"; sourceTree = "<group>"; };
 		594B87C7E7B68A1E23F136C4 /* WallneticWidget.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = WallneticWidget.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		5B106464A071BF6E736C3272 /* MenuBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarView.swift; sourceTree = "<group>"; };
@@ -231,6 +234,7 @@
 		9065D39D45D04ED947D1507D /* Wallnetic.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Wallnetic.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		91B502C8C68ABF2CD503030E /* AIGenerateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIGenerateView.swift; sourceTree = "<group>"; };
 		92B6AD451254AF3C55F4100E /* Carousel3DGallery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Carousel3DGallery.swift; sourceTree = "<group>"; };
+		941B25667F75E00393C7E895 /* WallpaperMetadataCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperMetadataCacheTests.swift; sourceTree = "<group>"; };
 		9A160A29BBDB078330BD0CA4 /* URLImporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLImporter.swift; sourceTree = "<group>"; };
 		9E4377C1CA7A41D21A10FC40 /* LockScreenManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockScreenManager.swift; sourceTree = "<group>"; };
 		9E4C04ED28406292407FFBD0 /* PowerManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PowerManager.swift; sourceTree = "<group>"; };
@@ -377,6 +381,7 @@
 				7F557952B625823A2689EBE7 /* WallpaperLibrary.swift */,
 				532FE0E3069C64B6236A343C /* WallpaperManager.swift */,
 				251ADAE767CEEF99C8A61261 /* WallpaperManagerProtocols.swift */,
+				57C5D6AF9B7CC270A5CB93E0 /* WallpaperMetadataCache.swift */,
 				B0F9B4893FCEA17EEFC7550A /* WallpaperMetadataStore.swift */,
 				40A93EE0CF1D353315FEA25D /* WallpaperStoreManager.swift */,
 				739D8C6AD1566F8C21F48DFD /* WeatherWallpaperManager.swift */,
@@ -540,6 +545,7 @@
 				35A70D71A1BFA621DE839CA5 /* MLWDecryptorTests.swift */,
 				4C428B5A76D12B2D39EB866E /* SlideshowGeneratorTests.swift */,
 				A0AADE7F3045087811919B3C /* URLImporterTests.swift */,
+				941B25667F75E00393C7E895 /* WallpaperMetadataCacheTests.swift */,
 				CC1C9FEA53FC924608F4B3DC /* WallpaperMetadataStoreTests.swift */,
 				388D852D79939F22C5EF801C /* WallpaperModelTests.swift */,
 			);
@@ -711,6 +717,7 @@
 				1ACE67A285A3AC235ECF7904 /* MLWDecryptorTests.swift in Sources */,
 				D812BECBE0458A174EF2696E /* SlideshowGeneratorTests.swift in Sources */,
 				B03176CE3858D5C7915FA8BB /* URLImporterTests.swift in Sources */,
+				6ADBCB967C34EB7B36825043 /* WallpaperMetadataCacheTests.swift in Sources */,
 				C5C2637200252363B44EEBC3 /* WallpaperMetadataStoreTests.swift in Sources */,
 				725E4F9BF3A84F458A306BDF /* WallpaperModelTests.swift in Sources */,
 			);
@@ -808,6 +815,7 @@
 				6B3FA8945F430A067CC4DB4D /* WallpaperLibrary.swift in Sources */,
 				7B8DE2A0443E6DC55D750FCB /* WallpaperManager.swift in Sources */,
 				C7F8E15BC3BB122E6CC92634 /* WallpaperManagerProtocols.swift in Sources */,
+				975BFD8CBA6DB402B4EFB2A5 /* WallpaperMetadataCache.swift in Sources */,
 				3F705E631F7827AD76411878 /* WallpaperMetadataStore.swift in Sources */,
 				9C7206924D126AE38A11DD51 /* WallpaperStoreManager.swift in Sources */,
 				F6107012989E9FC5810F350E /* WeatherWallpaperManager.swift in Sources */,


### PR DESCRIPTION
## Summary
Adds a SQLite-backed read-side index for wallpaper metadata. Uses the system `libsqlite3` so no new SwiftPM/CocoaPods dependency is introduced.

### What's new
- `Services/WallpaperMetadataCache.swift` — actor-style cache fronted by a serial `DispatchQueue`
  - DB file: `~/Library/Application Support/Wallnetic/metadata.sqlite`
  - WAL journaling + `synchronous=NORMAL` for crash resilience without fsync cost
  - Single `wallpapers` table mirroring the issue spec (key/name/custom_title/path/type/tags_json/color_hex/hue/saturation/width/height/duration/filesize/favourite/mtime/date_added)
  - Indexes on favourite / color_hex / name / mtime
  - `schema_version` table for future migrations
- `Tests/WallpaperMetadataCacheTests.swift` — 7 in-memory tests (upsert, dedupe, search, delete, replaceAll, color filter)
- `WallpaperManager` write-through hooks at all mutation points (import, remove, rename, toggleFavorite, addTag, removeTag, reload)
- `Log.cache` os.log category

### Design
The cache is a **secondary read-side index**, not a replacement for `WallpaperMetadataStore` or the on-disk library. If the cache file is missing/corrupt, the next `loadWallpapers()` rebuilds it via `replaceAll`. Every write is best-effort and never throws into UI code — failures only log.

`mtime` is stored for future invalidation logic; this PR does not yet use it to drive incremental rescans.

### Why not GRDB.swift?
Adding a SwiftPM dependency would require wiring `packages:` into `project.yml`, which `xcodegen` regenerates from. Using the system `SQLite3` module keeps the build hermetic and matches the issue's "lightweight" preference.

## Test plan
- [x] Debug build SUCCEEDED
- [x] Release build SUCCEEDED
- [x] 64/64 tests pass (7 new)
- [ ] Manual: launch app, verify `metadata.sqlite` appears in App Support, contains rows for current library
- [ ] Manual: rename / favorite / delete a wallpaper, verify row reflects change

## Follow-ups (out of scope here)
- Cut over `WallpaperManager.searchWallpapers` from in-memory fuzzy to SQL search
- Wire `mtime` for incremental rescans instead of full `replaceAll`
- Surface SQL-backed tag autocomplete

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)