### PR TITLE
Ollama Vision smart-tagging (#116)

### DIFF
--- a/src/Wallnetic/Services/OllamaTaggingService.swift
+++ b/src/Wallnetic/Services/OllamaTaggingService.swift
@@ -1,0 +1,135 @@
+import Foundation
+import AppKit
+import Combine
+
+/// Orchestrates Ollama Vision auto-tagging across the wallpaper library
+/// (#116). Exposes progress + cancellation so the Settings UI can show a
+/// status indicator.
+///
+/// All requests are sequential — vision inference is GPU-bound on the local
+/// Ollama process; firing them concurrently would just queue inside Ollama.
+@MainActor
+final class OllamaTaggingService: ObservableObject {
+    static let shared = OllamaTaggingService()
+
+    @Published private(set) var isRunning = false
+    @Published private(set) var progress: Double = 0
+    @Published private(set) var statusText: String = ""
+    @Published private(set) var lastError: String?
+
+    @AppStorageKeyed("ollama.endpoint")
+    var endpointString: String = "http://localhost:11434/api/generate"
+
+    @AppStorageKeyed("ollama.model")
+    var modelName: String = OllamaVisionTagger.defaultModel
+
+    private let tagger: OllamaVisionTagger
+    private var task: Task<Void, Never>?
+
+    init(tagger: OllamaVisionTagger = OllamaVisionTagger()) {
+        self.tagger = tagger
+    }
+
+    var configuredEndpoint: URL {
+        URL(string: endpointString) ?? OllamaVisionTagger.defaultEndpoint
+    }
+
+    var config: OllamaVisionTagger.Config {
+        OllamaVisionTagger.Config(
+            endpoint: configuredEndpoint,
+            model: modelName.isEmpty ? OllamaVisionTagger.defaultModel : modelName
+        )
+    }
+
+    // MARK: - Batch Tagging
+
+    /// Tags every wallpaper that has no existing tags. Existing tags are
+    /// preserved — auto-tags only fill in the gap.
+    func tagAll(wallpapers: [Wallpaper], manager: WallpaperManager) {
+        guard !isRunning else { return }
+        let untagged = wallpapers.filter { $0.tags.isEmpty }
+        guard !untagged.isEmpty else {
+            statusText = "All wallpapers already tagged."
+            return
+        }
+
+        isRunning = true
+        progress = 0
+        lastError = nil
+        statusText = "Preparing…"
+
+        let cfg = config
+        task = Task { [weak self] in
+            guard let self else { return }
+            let total = Double(untagged.count)
+            var done: Double = 0
+
+            for wallpaper in untagged {
+                if Task.isCancelled { break }
+                self.statusText = "Tagging \(wallpaper.displayName)…"
+
+                let thumb = await wallpaper.generateThumbnail(size: CGSize(width: 512, height: 288))
+                guard let thumb else {
+                    done += 1
+                    self.progress = done / total
+                    continue
+                }
+
+                let tags = await self.tagger.tags(for: thumb, config: cfg)
+                if let tags, !tags.isEmpty {
+                    for tag in tags {
+                        manager.addTag(tag, to: wallpaper)
+                    }
+                } else if tags == nil && done == 0 {
+                    self.lastError = "Could not reach Ollama at \(cfg.endpoint.absoluteString)."
+                    break
+                }
+
+                done += 1
+                self.progress = done / total
+            }
+
+            self.isRunning = false
+            if Task.isCancelled {
+                self.statusText = "Cancelled."
+            } else if self.lastError != nil {
+                self.statusText = "Stopped."
+            } else {
+                self.statusText = "Done — tagged \(Int(done)) wallpaper(s)."
+                self.progress = 1
+            }
+        }
+    }
+
+    func cancel() {
+        task?.cancel()
+    }
+}
+
+/// Tiny @AppStorage wrapper for non-View call sites. SwiftUI's @AppStorage
+/// only works inside Views, so we route through UserDefaults manually.
+@propertyWrapper
+struct AppStorageKeyed<Value: Codable> {
+    let key: String
+    let defaultValue: Value
+
+    init(wrappedValue: Value, _ key: String) {
+        self.key = key
+        self.defaultValue = wrappedValue
+    }
+
+    var wrappedValue: Value {
+        get {
+            guard let data = UserDefaults.standard.data(forKey: key),
+                  let value = try? JSONDecoder().decode(Value.self, from: data) else {
+                return defaultValue
+            }
+            return value
+        }
+        set {
+            if let data = try? JSONEncoder().encode(newValue) {
+                UserDefaults.standard.set(data, forKey: key)
+            }
+        }
+    }
+}

--- a/src/Wallnetic/Services/OllamaVisionTagger.swift
+++ b/src/Wallnetic/Services/OllamaVisionTagger.swift
@@ -1,0 +1,194 @@
+import Foundation
+import AppKit
+
+/// Local Ollama vision tagger (#116). Sends a base64-encoded thumbnail to a
+/// vision-capable Ollama model (e.g. `llava`) running on `localhost:11434`
+/// and parses the JSON `tags` array out of the streaming response.
+///
+/// **Optional feature.** If Ollama is not running, the request times out
+/// quickly and the caller treats the wallpaper as "no auto-tags" — never a
+/// hard failure.
+///
+/// Authoritative tags still live in `Wallpaper.tags` / `WallpaperMetadataStore.savedTags`;
+/// this service just produces candidates and lets the caller apply them.
+final class OllamaVisionTagger {
+    /// Defaults — overridable via the OllamaConfig struct passed at call time.
+    static let defaultEndpoint = URL(string: "http://localhost:11434/api/generate")!
+    static let defaultModel = "llava"
+    static let defaultPrompt = """
+    Analyze this wallpaper. Reply with ONLY a JSON object in this exact shape:
+    {"tags": ["tag1", "tag2", "tag3"]}
+    Rules:
+    - 3 to 6 tags
+    - Each tag is one or two lowercase English words (e.g. "nature", "neon city", "anime")
+    - No commentary, no markdown, no explanation. Just the JSON.
+    """
+
+    struct Config {
+        let endpoint: URL
+        let model: String
+        let prompt: String
+        let timeout: TimeInterval
+
+        init(
+            endpoint: URL = OllamaVisionTagger.defaultEndpoint,
+            model: String = OllamaVisionTagger.defaultModel,
+            prompt: String = OllamaVisionTagger.defaultPrompt,
+            timeout: TimeInterval = 30
+        ) {
+            self.endpoint = endpoint
+            self.model = model
+            self.prompt = prompt
+            self.timeout = timeout
+        }
+    }
+
+    enum TaggerError: Error, Equatable {
+        case ollamaUnreachable
+        case badStatus(Int)
+        case decodeFailed
+        case malformedResponse
+    }
+
+    private let session: URLSession
+
+    init(session: URLSession = .shared) {
+        self.session = session
+    }
+
+    // MARK: - Public API
+
+    /// Generates tags for a single wallpaper. Resolves to an empty array if
+    /// Ollama is offline — distinguishable from "tagged with 0 results"
+    /// because this method returns `nil` for the offline case.
+    func tags(for image: NSImage, config: Config = Config()) async -> [String]? {
+        guard let base64 = base64Encode(image: image, maxDimension: 512) else {
+            Log.ollama.debug("Skipping — could not encode thumbnail to JPEG.")
+            return nil
+        }
+
+        let body: [String: Any] = [
+            "model": config.model,
+            "prompt": config.prompt,
+            "images": [base64],
+            "stream": false
+        ]
+
+        var request = URLRequest(url: config.endpoint)
+        request.httpMethod = "POST"
+        request.timeoutInterval = config.timeout
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        do {
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        } catch {
+            Log.ollama.error("Request body encoding failed: \(String(describing: error), privacy: .public)")
+            return nil
+        }
+
+        do {
+            let (data, response) = try await session.data(for: request)
+            guard let http = response as? HTTPURLResponse else {
+                Log.ollama.error("Non-HTTP response from Ollama.")
+                return nil
+            }
+            guard (200..<300).contains(http.statusCode) else {
+                Log.ollama.error("Ollama returned status \(http.statusCode, privacy: .public)")
+                return nil
+            }
+            return Self.parseTags(fromResponseData: data)
+        } catch let urlError as URLError where urlError.code == .cannotConnectToHost
+                                              || urlError.code == .timedOut
+                                              || urlError.code == .notConnectedToInternet {
+            // Expected when Ollama is not running locally — debug only.
+            Log.ollama.debug("Ollama not reachable: \(urlError.localizedDescription, privacy: .public)")
+            return nil
+        } catch {
+            Log.ollama.error("Ollama request failed: \(String(describing: error), privacy: .public)")
+            return nil
+        }
+    }
+
+    // MARK: - Parser (pure, testable)
+
+    /// Parses the `response` field of an Ollama `/api/generate` reply and
+    /// extracts the JSON `tags` array. Tolerant: handles markdown code
+    /// fences and trailing prose around the JSON.
+    static func parseTags(fromResponseData data: Data) -> [String]? {
+        guard
+            let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let text = json["response"] as? String
+        else {
+            Log.ollama.error("Ollama reply was not valid JSON or missing 'response' field.")
+            return nil
+        }
+        return parseTags(fromText: text)
+    }
+
+    /// Extracts the `tags` array from free-form model text. Returns nil if
+    /// nothing JSON-looking is found.
+    static func parseTags(fromText text: String) -> [String]? {
+        // Find the first '{' and last '}' to tolerate prose / markdown
+        // fences around the JSON.
+        guard
+            let start = text.firstIndex(of: "{"),
+            let end = text.lastIndex(of: "}"),
+            start <= end
+        else { return nil }
+
+        let slice = String(text[start...end])
+        guard let payload = slice.data(using: .utf8) else { return nil }
+
+        guard
+            let obj = try? JSONSerialization.jsonObject(with: payload) as? [String: Any],
+            let raw = obj["tags"] as? [Any]
+        else { return nil }
+
+        let cleaned: [String] = raw.compactMap { value in
+            let s: String
+            if let str = value as? String { s = str }
+            else { s = String(describing: value) }
+            return cleanTag(s)
+        }
+        return cleaned.isEmpty ? nil : Array(Set(cleaned)).sorted()
+    }
+
+    static func cleanTag(_ raw: String) -> String? {
+        let trimmed = raw
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "\"'.,;:#"))
+            .lowercased()
+        guard !trimmed.isEmpty, trimmed.count <= 32 else { return nil }
+        return trimmed
+    }
+
+    // MARK: - Image Encoding
+
+    private func base64Encode(image: NSImage, maxDimension: CGFloat) -> String? {
+        guard let tiff = image.tiffRepresentation,
+              let rep = NSBitmapImageRep(data: tiff)
+        else { return nil }
+
+        // Downscale for bandwidth — vision models do not need full-res.
+        let originalSize = NSSize(width: rep.pixelsWide, height: rep.pixelsHigh)
+        let scale = min(1, maxDimension / max(originalSize.width, originalSize.height))
+        let targetSize = NSSize(width: originalSize.width * scale, height: originalSize.height * scale)
+
+        let scaled = NSImage(size: targetSize)
+        scaled.lockFocus()
+        image.draw(
+            in: NSRect(origin: .zero, size: targetSize),
+            from: NSRect(origin: .zero, size: image.size),
+            operation: .copy,
+            fraction: 1.0
+        )
+        scaled.unlockFocus()
+
+        guard
+            let scaledTiff = scaled.tiffRepresentation,
+            let scaledRep = NSBitmapImageRep(data: scaledTiff),
+            let jpeg = scaledRep.representation(using: .jpeg, properties: [.compressionFactor: 0.8])
+        else { return nil }
+
+        return jpeg.base64EncodedString()
+    }
+}

--- a/src/Wallnetic/Tests/OllamaVisionTaggerTests.swift
+++ b/src/Wallnetic/Tests/OllamaVisionTaggerTests.swift
@@ -1,0 +1,106 @@
+import XCTest
+@testable import Wallnetic
+
+/// Tests cover the pure parsing surface of OllamaVisionTagger (#116). The
+/// network path is intentionally not exercised here — its only contract is
+/// "fail soft when Ollama is offline", and that already returns nil via the
+/// catch path. We verify the JSON contract that lives between Ollama and us.
+final class OllamaVisionTaggerTests: XCTestCase {
+
+    // MARK: - Plain JSON response
+
+    func test_parseTags_extracts_array_from_clean_json() {
+        let payload = """
+        {"tags": ["nature", "sunrise", "mountain"]}
+        """
+        let tags = OllamaVisionTagger.parseTags(fromText: payload)
+        XCTAssertEqual(tags, ["mountain", "nature", "sunrise"], "Should be deduped + sorted.")
+    }
+
+    // MARK: - JSON wrapped in prose
+
+    func test_parseTags_extracts_array_when_model_prepended_prose() {
+        let payload = """
+        Sure! Here are the tags I found:
+
+        {"tags": ["anime", "city"]}
+
+        Hope this helps!
+        """
+        XCTAssertEqual(OllamaVisionTagger.parseTags(fromText: payload), ["anime", "city"])
+    }
+
+    // MARK: - Markdown fences
+
+    func test_parseTags_extracts_array_from_markdown_fenced_json() {
+        let payload = """
+        ```json
+        {"tags": ["abstract", "neon"]}
+        ```
+        """
+        XCTAssertEqual(OllamaVisionTagger.parseTags(fromText: payload), ["abstract", "neon"])
+    }
+
+    // MARK: - Dirty tags
+
+    func test_parseTags_cleans_quotes_and_lowercases() {
+        let payload = """
+        {"tags": ["\\"Nature\\"", "Sunrise.", "  Mountain  "]}
+        """
+        let tags = OllamaVisionTagger.parseTags(fromText: payload)
+        XCTAssertEqual(tags, ["mountain", "nature", "sunrise"])
+    }
+
+    func test_parseTags_drops_overlong_garbage() {
+        let payload = """
+        {"tags": ["ok", "this-tag-is-way-way-way-way-too-long-and-should-be-rejected-by-the-cleaner"]}
+        """
+        XCTAssertEqual(OllamaVisionTagger.parseTags(fromText: payload), ["ok"])
+    }
+
+    // MARK: - Malformed input
+
+    func test_parseTags_returns_nil_when_no_json() {
+        XCTAssertNil(OllamaVisionTagger.parseTags(fromText: "Sorry, I cannot analyze this image."))
+    }
+
+    func test_parseTags_returns_nil_when_tags_missing() {
+        XCTAssertNil(OllamaVisionTagger.parseTags(fromText: #"{"other": ["nope"]}"#))
+    }
+
+    func test_parseTags_returns_nil_for_empty_string() {
+        XCTAssertNil(OllamaVisionTagger.parseTags(fromText: ""))
+    }
+
+    // MARK: - Full /api/generate response shape
+
+    func test_parseTags_fromResponseData_handles_ollama_reply_envelope() {
+        let envelope = """
+        {
+            "model": "llava",
+            "created_at": "2026-05-16T12:00:00Z",
+            "response": "{\\"tags\\": [\\"forest\\", \\"green\\"]}",
+            "done": true
+        }
+        """
+        let data = envelope.data(using: .utf8)!
+        XCTAssertEqual(OllamaVisionTagger.parseTags(fromResponseData: data), ["forest", "green"])
+    }
+
+    func test_parseTags_fromResponseData_returns_nil_for_non_json_envelope() {
+        let data = "not json".data(using: .utf8)!
+        XCTAssertNil(OllamaVisionTagger.parseTags(fromResponseData: data))
+    }
+
+    // MARK: - cleanTag
+
+    func test_cleanTag_strips_punctuation_and_whitespace() {
+        XCTAssertEqual(OllamaVisionTagger.cleanTag("  \"Nature.\" "), "nature")
+        XCTAssertEqual(OllamaVisionTagger.cleanTag("#anime;"), "anime")
+    }
+
+    func test_cleanTag_rejects_empty_and_overlong() {
+        XCTAssertNil(OllamaVisionTagger.cleanTag(""))
+        XCTAssertNil(OllamaVisionTagger.cleanTag(String(repeating: "x", count: 50)))
+    }
+}

--- a/src/Wallnetic/Utils/Log.swift
+++ b/src/Wallnetic/Utils/Log.swift
@@ -25,6 +25,7 @@ enum Log {
 
     static let app          = Logger(subsystem: subsystem, category: "App")
     static let ai           = Logger(subsystem: subsystem, category: "AI")
+    static let ollama       = Logger(subsystem: subsystem, category: "OllamaVision")
     static let browser      = Logger(subsystem: subsystem, category: "Browser")
     static let analytics    = Logger(subsystem: subsystem, category: "Analytics")
     static let auth         = Logger(subsystem: subsystem, category: "Auth")

--- a/src/Wallnetic/Views/Main/SettingsView.swift
+++ b/src/Wallnetic/Views/Main/SettingsView.swift
@@ -21,6 +21,9 @@ struct SettingsView: View {
             SpaceSettingsView()
                 .tabItem { Label("Spaces", systemImage: "square.stack.3d.up") }
 
+            SmartTaggingSettingsView()
+                .tabItem { Label("Smart Tags", systemImage: "tag") }
+
             DisplaySettingsView()
                 .tabItem { Label("Display", systemImage: "display") }
 

--- a/src/Wallnetic/Views/Settings/SmartTaggingSettingsView.swift
+++ b/src/Wallnetic/Views/Settings/SmartTaggingSettingsView.swift
@@ -1,0 +1,83 @@
+import SwiftUI
+
+/// Settings panel for the optional Ollama Vision auto-tagger (#116).
+struct SmartTaggingSettingsView: View {
+    @EnvironmentObject var wallpaperManager: WallpaperManager
+    @ObservedObject private var service = OllamaTaggingService.shared
+
+    @State private var endpoint: String = ""
+    @State private var model: String = ""
+
+    var body: some View {
+        Form {
+            Section {
+                Text("Smart Tagging uses a local Ollama vision model to read each wallpaper thumbnail and suggest tags. Ollama must be running on your Mac — nothing is sent to the cloud.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+
+            Section("Ollama Server") {
+                LabeledContent("Endpoint") {
+                    TextField("http://localhost:11434/api/generate", text: $endpoint)
+                        .textFieldStyle(.roundedBorder)
+                        .frame(maxWidth: 360)
+                }
+                LabeledContent("Model") {
+                    TextField("llava", text: $model)
+                        .textFieldStyle(.roundedBorder)
+                        .frame(maxWidth: 200)
+                }
+                Text("Suggested models: llava, llava:13b, bakllava. Larger models give better tags but take longer.")
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+            }
+
+            Section("Run") {
+                HStack {
+                    Button(service.isRunning ? "Cancel" : "Tag Untagged Wallpapers") {
+                        if service.isRunning {
+                            service.cancel()
+                        } else {
+                            commitSettings()
+                            service.tagAll(
+                                wallpapers: wallpaperManager.wallpapers,
+                                manager: wallpaperManager
+                            )
+                        }
+                    }
+                    .buttonStyle(.borderedProminent)
+
+                    Spacer()
+                }
+
+                if service.isRunning || service.progress > 0 {
+                    VStack(alignment: .leading, spacing: 4) {
+                        ProgressView(value: service.progress)
+                        Text(service.statusText)
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                }
+
+                if let error = service.lastError {
+                    Label(error, systemImage: "exclamationmark.triangle.fill")
+                        .font(.caption)
+                        .foregroundColor(.orange)
+                }
+            }
+        }
+        .formStyle(.grouped)
+        .onAppear {
+            endpoint = service.endpointString
+            model = service.modelName
+        }
+        .onDisappear { commitSettings() }
+    }
+
+    private func commitSettings() {
+        let trimmedEndpoint = endpoint.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedModel = model.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmedEndpoint.isEmpty { service.endpointString = trimmedEndpoint }
+        if !trimmedModel.isEmpty { service.modelName = trimmedModel }
+    }
+}

--- a/src/Wallnetic/Wallnetic.xcodeproj/project.pbxproj
+++ b/src/Wallnetic/Wallnetic.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		4BC3BA52E3938E15E6BC7AAA /* Log.swift in Sources */ = {isa = PBXBuildFile; fileRef = F62ADB679C576DF4637BA6C9 /* Log.swift */; };
 		4D244E609DA6FBD637CD7D8F /* WallneticApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D9A31C3562655D7C27A30B1 /* WallneticApp.swift */; };
 		4DC3D57FC37765D6CEABF304 /* ColorCategoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56F59C3C7AB56348DA1D9D45 /* ColorCategoryTests.swift */; };
+		4E139BC5AAC4545984E4B4D3 /* SmartTaggingSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76DFDCB44158B7225C519C63 /* SmartTaggingSettingsView.swift */; };
 		502AEDE09B50668E7154DC6E /* CreateFromPhotosView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC8F63EBF5F78663165C4697 /* CreateFromPhotosView.swift */; };
 		51355B920BE931D2A9A3BE58 /* WallpaperCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8562F59693CF276239AD0905 /* WallpaperCollection.swift */; };
 		53984128C8EBA3CD0BDEB573 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFD329195A86A0398FB6B4D0 /* AppDelegate.swift */; };
@@ -48,6 +49,7 @@
 		5E298128B4AE9AB89B656E86 /* DesktopOverlayController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D726427A9199C4D93B9E93F2 /* DesktopOverlayController.swift */; };
 		61773D343F4EBEEB12FF8AFB /* BatteryPromptService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0187521E8CC2C0BB29CE90D /* BatteryPromptService.swift */; };
 		61B1EC0DBC85801311FA1F2F /* MenuBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B106464A071BF6E736C3272 /* MenuBarView.swift */; };
+		61B8431DE4EA724F4E55C7B2 /* OllamaVisionTagger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FD3DFBD42A5D9B294784C5F /* OllamaVisionTagger.swift */; };
 		6A650CD75C4B32AB9889A6A7 /* SharedWidgetModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDFCAB2A636011BB543DD1B5 /* SharedWidgetModels.swift */; };
 		6ADBCB967C34EB7B36825043 /* WallpaperMetadataCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 941B25667F75E00393C7E895 /* WallpaperMetadataCacheTests.swift */; };
 		6B3FA8945F430A067CC4DB4D /* WallpaperLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F557952B625823A2689EBE7 /* WallpaperLibrary.swift */; };
@@ -63,10 +65,12 @@
 		80B94DC02A568914623EDE05 /* VideoFormatConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4662279ADB65DBA3957578B7 /* VideoFormatConverter.swift */; };
 		82F024AE9E99C4A77098AD9B /* FuzzySearchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA18283F2FD8E99F3FFDC805 /* FuzzySearchTests.swift */; };
 		84ACCBC72C120B8B6E00A64F /* SupabaseClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CEBCAF9E5F767C08A15158C /* SupabaseClient.swift */; };
+		8690167783A5141E8CA3EC71 /* OllamaTaggingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BB89C6E613696A053681E46 /* OllamaTaggingService.swift */; };
 		88C6A7F9AD19AA876CEEC465 /* iCloudSyncManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9960B917192178D2217E668 /* iCloudSyncManager.swift */; };
 		8AAE56E8D08264474270D889 /* AIGenerateViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B59109A0A0707AFA611D15A /* AIGenerateViewModel.swift */; };
 		8BED6ED6D599D3F3C32821D5 /* HistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A32AE3710192737ABA41FDA0 /* HistoryView.swift */; };
 		8EFAE3E67407537EC1B9A705 /* DiscoverView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB036BA69CC6D00731C1D273 /* DiscoverView.swift */; };
+		92D9C1672FDC4498193B9949 /* OllamaVisionTaggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D709F3F20160782C077CAF5 /* OllamaVisionTaggerTests.swift */; };
 		93BC58F85DF7EBC9B6D3970F /* SharedWidgetModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDFCAB2A636011BB543DD1B5 /* SharedWidgetModels.swift */; };
 		93CA4E731227254F983F6270 /* TimeOfDaySettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E4002911F0B7869F3183DA /* TimeOfDaySettingsView.swift */; };
 		9721B6140E12A2FA558584B8 /* NowPlayingOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79BC197A9E8C082F2C39C673 /* NowPlayingOverlayView.swift */; };
@@ -162,6 +166,7 @@
 		08B2A227CEA1CA39347CC37A /* WallneticWidget.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = WallneticWidget.entitlements; sourceTree = "<group>"; };
 		0990FC999E1DE89A3D776B05 /* WidgetSyncService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetSyncService.swift; sourceTree = "<group>"; };
 		0B86B489A26E64EF63ED72A8 /* WallpaperEffectsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperEffectsManager.swift; sourceTree = "<group>"; };
+		0BB89C6E613696A053681E46 /* OllamaTaggingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OllamaTaggingService.swift; sourceTree = "<group>"; };
 		0D76E5D0AB6B966E492D0342 /* WallpaperGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperGridView.swift; sourceTree = "<group>"; };
 		0DF980A4142FBBE468FBBD05 /* SchedulerSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchedulerSettingsView.swift; sourceTree = "<group>"; };
 		102BCD8F05208BC14E211E51 /* StoreKitManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKitManager.swift; sourceTree = "<group>"; };
@@ -177,6 +182,7 @@
 		2958EEAF2DA16543DBA9453F /* SpaceSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceSettingsView.swift; sourceTree = "<group>"; };
 		2A3CC73608BAFA155E615F1B /* SchedulerService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchedulerService.swift; sourceTree = "<group>"; };
 		2A9660F71829E6C2D5F2B5E6 /* DeepLinkHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepLinkHandlerTests.swift; sourceTree = "<group>"; };
+		2D709F3F20160782C077CAF5 /* OllamaVisionTaggerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OllamaVisionTaggerTests.swift; sourceTree = "<group>"; };
 		2F48518E41B9C56DFE5EB099 /* MusicReactiveManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicReactiveManager.swift; sourceTree = "<group>"; };
 		31C51D17BDBBADCDF4D5CB43 /* CollectionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionsView.swift; sourceTree = "<group>"; };
 		35A70D71A1BFA621DE839CA5 /* MLWDecryptorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MLWDecryptorTests.swift; sourceTree = "<group>"; };
@@ -185,6 +191,7 @@
 		3A5D74A5C252020316F511D6 /* CollectionDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionDetailView.swift; sourceTree = "<group>"; };
 		3C858C83BC8D22A21A53D7BD /* AudioVisualizerOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioVisualizerOverlayView.swift; sourceTree = "<group>"; };
 		3CFBA173095D37D5702C5C18 /* PerformanceManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceManager.swift; sourceTree = "<group>"; };
+		3FD3DFBD42A5D9B294784C5F /* OllamaVisionTagger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OllamaVisionTagger.swift; sourceTree = "<group>"; };
 		40A93EE0CF1D353315FEA25D /* WallpaperStoreManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperStoreManager.swift; sourceTree = "<group>"; };
 		43A9F2E051E3DDAA18ACAC9D /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		4662279ADB65DBA3957578B7 /* VideoFormatConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoFormatConverter.swift; sourceTree = "<group>"; };
@@ -218,6 +225,7 @@
 		6D0396F7C77849244B424DD5 /* ScreenSaverBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenSaverBridge.swift; sourceTree = "<group>"; };
 		739D8C6AD1566F8C21F48DFD /* WeatherWallpaperManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherWallpaperManager.swift; sourceTree = "<group>"; };
 		73A3E9458476683E0230677D /* ErrorReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorReporter.swift; sourceTree = "<group>"; };
+		76DFDCB44158B7225C519C63 /* SmartTaggingSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartTaggingSettingsView.swift; sourceTree = "<group>"; };
 		77E4D58C6269978E4994C7CE /* AppShortcuts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppShortcuts.swift; sourceTree = "<group>"; };
 		79BC197A9E8C082F2C39C673 /* NowPlayingOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowPlayingOverlayView.swift; sourceTree = "<group>"; };
 		7BB04CF2E27DC75B29EE8A67 /* ErrorReporterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorReporterTests.swift; sourceTree = "<group>"; };
@@ -358,6 +366,8 @@
 				2F48518E41B9C56DFE5EB099 /* MusicReactiveManager.swift */,
 				140AE9B28FFA1BF12B3651C5 /* NotificationManager.swift */,
 				5B7D2F1C8E95985C42051A32 /* NowPlayingManager.swift */,
+				0BB89C6E613696A053681E46 /* OllamaTaggingService.swift */,
+				3FD3DFBD42A5D9B294784C5F /* OllamaVisionTagger.swift */,
 				3CFBA173095D37D5702C5C18 /* PerformanceManager.swift */,
 				65B960F4D2BFD36368F336A4 /* PexelsService.swift */,
 				BA4D12B25631A66EDCB10593 /* PhotosLibraryService.swift */,
@@ -397,6 +407,7 @@
 				BA2392B868E0D5B6994FF657 /* EffectsSettingsView.swift */,
 				0DF980A4142FBBE468FBBD05 /* SchedulerSettingsView.swift */,
 				02604286446C78C5C8935E45 /* SettingsSubViews.swift */,
+				76DFDCB44158B7225C519C63 /* SmartTaggingSettingsView.swift */,
 				2958EEAF2DA16543DBA9453F /* SpaceSettingsView.swift */,
 				84E4002911F0B7869F3183DA /* TimeOfDaySettingsView.swift */,
 			);
@@ -543,6 +554,7 @@
 				7BB04CF2E27DC75B29EE8A67 /* ErrorReporterTests.swift */,
 				DA18283F2FD8E99F3FFDC805 /* FuzzySearchTests.swift */,
 				35A70D71A1BFA621DE839CA5 /* MLWDecryptorTests.swift */,
+				2D709F3F20160782C077CAF5 /* OllamaVisionTaggerTests.swift */,
 				4C428B5A76D12B2D39EB866E /* SlideshowGeneratorTests.swift */,
 				A0AADE7F3045087811919B3C /* URLImporterTests.swift */,
 				941B25667F75E00393C7E895 /* WallpaperMetadataCacheTests.swift */,
@@ -715,6 +727,7 @@
 				1AEF59FC27860B386A6D7049 /* ErrorReporterTests.swift in Sources */,
 				82F024AE9E99C4A77098AD9B /* FuzzySearchTests.swift in Sources */,
 				1ACE67A285A3AC235ECF7904 /* MLWDecryptorTests.swift in Sources */,
+				92D9C1672FDC4498193B9949 /* OllamaVisionTaggerTests.swift in Sources */,
 				D812BECBE0458A174EF2696E /* SlideshowGeneratorTests.swift in Sources */,
 				B03176CE3858D5C7915FA8BB /* URLImporterTests.swift in Sources */,
 				6ADBCB967C34EB7B36825043 /* WallpaperMetadataCacheTests.swift in Sources */,
@@ -775,6 +788,8 @@
 				A160526FEFD4F71CB15980CA /* NowPlayingManager.swift in Sources */,
 				B33B54C0FB9B7ADD1373DCA8 /* NowPlayingOverlayController.swift in Sources */,
 				9721B6140E12A2FA558584B8 /* NowPlayingOverlayView.swift in Sources */,
+				8690167783A5141E8CA3EC71 /* OllamaTaggingService.swift in Sources */,
+				61B8431DE4EA724F4E55C7B2 /* OllamaVisionTagger.swift in Sources */,
 				BED9A1AD659C124D26D37355 /* OnboardingView.swift in Sources */,
 				D729B636A0E78713E53C77FD /* PerformanceManager.swift in Sources */,
 				39C032EFB614D68ADAE9403B /* PexelsService.swift in Sources */,
@@ -790,6 +805,7 @@
 				AE9FCE08CE4EDEECE7A843BD /* SharedDataManager.swift in Sources */,
 				6A650CD75C4B32AB9889A6A7 /* SharedWidgetModels.swift in Sources */,
 				AC32B1A81A352A35055916BC /* SlideshowGenerator.swift in Sources */,
+				4E139BC5AAC4545984E4B4D3 /* SmartTaggingSettingsView.swift in Sources */,
 				0D0FFA07C32604C5448D9BD6 /* SpaceSettingsView.swift in Sources */,
 				B61FA302398523F6F9AFE321 /* SpaceWallpaperManager.swift in Sources */,
 				04BCEB8AB6239A8DB7D5C257 /* StoreKitManager.swift in Sources */,


### PR DESCRIPTION
## Summary
Adds an **opt-in** local-only auto-tagging feature backed by Ollama's vision models (e.g. llava). Nothing runs automatically; users open Settings → Smart Tags and click "Tag Untagged Wallpapers".

### What's new
- `Services/OllamaVisionTagger.swift` — POSTs base64-encoded thumbnail (downscaled to 512px JPEG for bandwidth) to `http://localhost:11434/api/generate`. Returns `[String]?` — `nil` means "could not contact Ollama" so the caller can stop the batch.
- `Services/OllamaTaggingService.swift` — `@MainActor` ObservableObject that orchestrates sequential batch tagging across the library. Publishes `isRunning`, `progress`, `statusText`, `lastError`. Only fills empty tag lists; never overwrites existing tags.
- `Views/Settings/SmartTaggingSettingsView.swift` — new Settings tab with endpoint + model fields, run/cancel button, progress UI.
- `Tests/OllamaVisionTaggerTests.swift` — **12 tests** covering the JSON contract: clean JSON, prose-wrapped, markdown-fenced, dirty quotes/case, overlong garbage rejection, missing fields, empty input, full Ollama envelope.
- `Log.ollama` os.log category.

### Design notes
- Network failure is the **expected** path when Ollama is not installed. Surfaced via debug-level logs + a single user-visible "couldn't reach Ollama" line on the first failure; the batch then stops rather than hammering localhost.
- The parser is pure / static so it can be unit-tested without spinning up a real Ollama. Network code itself is a thin do-or-log wrapper.
- Tag cleaner enforces lowercase, strips quotes/punctuation, rejects >32 chars to keep AI hallucinations from polluting the tag space.

## Test plan
- [x] Debug build SUCCEEDED
- [x] Release build SUCCEEDED
- [x] 76/76 tests pass (12 new)
- [ ] Manual: `brew install ollama && ollama pull llava && ollama serve`, then in Wallnetic: Settings → Smart Tags → Run. Verify tags appear on wallpaper cards.
- [ ] Manual: with Ollama stopped, run the batch — verify graceful failure (no crash, error label appears).

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)