### PR TITLE
UI design sweep — sheets, onboarding, settings, top nav, hero parallax

### DIFF
--- a/src/Wallnetic/Views/Collections/CollectionDetailView.swift
+++ b/src/Wallnetic/Views/Collections/CollectionDetailView.swift
@@ -193,7 +193,6 @@ struct RenameCollectionSheet: View {
     @ObservedObject private var collectionManager = CollectionManager.shared
 
     @State private var name: String = ""
-    @FocusState private var nameFieldFocused: Bool
 
     private var trimmedName: String {
         name.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -204,44 +203,33 @@ struct RenameCollectionSheet: View {
     }
 
     var body: some View {
-        VStack(spacing: 16) {
-            Text("Rename Collection")
-                .font(.headline)
+        WallneticSheet(title: "Rename Collection", icon: collection.icon, width: 380) {
+            VStack(alignment: .leading, spacing: 10) {
+                Text("NEW NAME")
+                    .font(.system(size: 9, weight: .heavy, design: .monospaced))
+                    .tracking(2)
+                    .foregroundColor(.white.opacity(0.35))
 
-            HStack(spacing: 12) {
-                Image(systemName: collection.icon)
-                    .font(.title2)
-                    .foregroundColor(.accentColor)
-                    .frame(width: 32)
-
-                TextField("Collection name", text: $name)
-                    .textFieldStyle(.roundedBorder)
-                    .focused($nameFieldFocused)
-                    .onSubmit { commit() }
-            }
-
-            HStack {
-                Button("Cancel") {
-                    dismiss()
-                }
-                .keyboardShortcut(.escape)
-
-                Spacer()
-
-                Button("Save") {
+                WallneticTextField(
+                    placeholder: collection.name,
+                    text: $name,
+                    icon: "pencil"
+                ) {
                     commit()
                 }
-                .buttonStyle(.borderedProminent)
-                .disabled(!canRename)
-                .keyboardShortcut(.return)
+
+                Text("Current: \(collection.name)")
+                    .font(.system(size: 11))
+                    .foregroundColor(.white.opacity(0.35))
+            }
+        } footer: {
+            WallneticButton.cancel { dismiss() }
+            Spacer()
+            WallneticButton.primary("Save", icon: "checkmark", isEnabled: canRename) {
+                commit()
             }
         }
-        .padding()
-        .frame(width: 320)
-        .onAppear {
-            name = collection.name
-            nameFieldFocused = true
-        }
+        .onAppear { name = collection.name }
     }
 
     private func commit() {
@@ -261,46 +249,57 @@ struct IconPickerSheet: View {
     @State private var selectedIcon: String = ""
 
     var body: some View {
-        VStack(spacing: 16) {
-            Text("Choose Icon")
-                .font(.headline)
-
-            LazyVGrid(columns: Array(repeating: GridItem(.fixed(44)), count: 5), spacing: 8) {
+        WallneticSheet(title: "Choose Icon", icon: selectedIcon.isEmpty ? "square.grid.2x2" : selectedIcon, width: 380) {
+            LazyVGrid(columns: Array(repeating: GridItem(.fixed(48)), count: 6), spacing: 6) {
                 ForEach(WallpaperCollection.availableIcons, id: \.self) { icon in
-                    Button {
+                    IconCell(icon: icon, isSelected: selectedIcon == icon) {
                         selectedIcon = icon
-                    } label: {
-                        Image(systemName: icon)
-                            .font(.title2)
-                            .frame(width: 40, height: 40)
-                            .background(selectedIcon == icon ? Color.accentColor.opacity(0.2) : Color.clear)
-                            .cornerRadius(8)
                     }
-                    .buttonStyle(.plain)
                 }
             }
-
-            HStack {
-                Button("Cancel") {
-                    dismiss()
-                }
-                .keyboardShortcut(.escape)
-
-                Spacer()
-
-                Button("Save") {
-                    collectionManager.changeIcon(collection, to: selectedIcon)
-                    dismiss()
-                }
-                .buttonStyle(.borderedProminent)
-                .keyboardShortcut(.return)
+        } footer: {
+            WallneticButton.cancel { dismiss() }
+            Spacer()
+            WallneticButton.primary("Save", icon: "checkmark") {
+                collectionManager.changeIcon(collection, to: selectedIcon)
+                dismiss()
             }
         }
-        .padding()
-        .frame(width: 300)
-        .onAppear {
-            selectedIcon = collection.icon
+        .onAppear { selectedIcon = collection.icon }
+    }
+}
+
+private struct IconCell: View {
+    let icon: String
+    let isSelected: Bool
+    let action: () -> Void
+
+    @State private var hover = false
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: icon)
+                .font(.system(size: 16, weight: .medium))
+                .foregroundColor(isSelected ? .white : .white.opacity(hover ? 0.8 : 0.45))
+                .frame(width: 44, height: 44)
+                .background(
+                    ZStack {
+                        RoundedRectangle(cornerRadius: 10, style: .continuous)
+                            .fill(isSelected
+                                  ? AnyShapeStyle(LinearGradient(
+                                        colors: [Color.accentColor.opacity(0.3), Color.accentColor.opacity(0.15)],
+                                        startPoint: .topLeading, endPoint: .bottomTrailing
+                                    ))
+                                  : AnyShapeStyle(Color.white.opacity(hover ? 0.06 : 0.025)))
+                        RoundedRectangle(cornerRadius: 10, style: .continuous)
+                            .stroke(isSelected ? Color.accentColor.opacity(0.55) : Color.white.opacity(0.08), lineWidth: 0.5)
+                    }
+                )
+                .shadow(color: isSelected ? Color.accentColor.opacity(0.4) : .clear, radius: 8)
         }
+        .buttonStyle(.plain)
+        .onHover { hover = $0 }
+        .animation(.easeOut(duration: 0.15), value: hover)
     }
 }
 

--- a/src/Wallnetic/Views/Collections/CollectionsView.swift
+++ b/src/Wallnetic/Views/Collections/CollectionsView.swift
@@ -112,51 +112,87 @@ struct CreateCollectionSheet: View {
     @State private var name = ""
     @State private var selectedIcon = "folder.fill"
 
-    var body: some View {
-        VStack(spacing: 20) {
-            Text("New Collection")
-                .font(.headline)
+    private var trimmedName: String {
+        name.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
 
-            // Icon selection
-            LazyVGrid(columns: Array(repeating: GridItem(.fixed(44)), count: 5), spacing: 8) {
-                ForEach(WallpaperCollection.availableIcons, id: \.self) { icon in
-                    Button {
-                        selectedIcon = icon
-                    } label: {
-                        Image(systemName: icon)
-                            .font(.title2)
-                            .frame(width: 40, height: 40)
-                            .background(selectedIcon == icon ? Color.accentColor.opacity(0.2) : Color.clear)
-                            .cornerRadius(8)
+    var body: some View {
+        WallneticSheet(title: "New Collection", icon: selectedIcon, width: 380) {
+            VStack(alignment: .leading, spacing: 14) {
+                Text("ICON")
+                    .font(.system(size: 9, weight: .heavy, design: .monospaced))
+                    .tracking(2)
+                    .foregroundColor(.white.opacity(0.35))
+
+                LazyVGrid(columns: Array(repeating: GridItem(.fixed(48)), count: 6), spacing: 6) {
+                    ForEach(WallpaperCollection.availableIcons, id: \.self) { icon in
+                        IconPickerCell(
+                            icon: icon,
+                            isSelected: selectedIcon == icon
+                        ) { selectedIcon = icon }
                     }
-                    .buttonStyle(.plain)
+                }
+
+                Text("NAME")
+                    .font(.system(size: 9, weight: .heavy, design: .monospaced))
+                    .tracking(2)
+                    .foregroundColor(.white.opacity(0.35))
+                    .padding(.top, 4)
+
+                WallneticTextField(
+                    placeholder: "e.g. Cyberpunk Nights",
+                    text: $name,
+                    icon: "tag.fill"
+                ) {
+                    if !trimmedName.isEmpty {
+                        _ = collectionManager.createCollection(name: trimmedName, icon: selectedIcon)
+                        dismiss()
+                    }
                 }
             }
-
-            // Name input
-            TextField("Collection name", text: $name)
-                .textFieldStyle(.roundedBorder)
-
-            // Buttons
-            HStack {
-                Button("Cancel") {
-                    dismiss()
-                }
-                .keyboardShortcut(.escape)
-
-                Spacer()
-
-                Button("Create") {
-                    _ = collectionManager.createCollection(name: name, icon: selectedIcon)
-                    dismiss()
-                }
-                .buttonStyle(.borderedProminent)
-                .disabled(name.isEmpty)
-                .keyboardShortcut(.return)
+        } footer: {
+            WallneticButton.cancel { dismiss() }
+            Spacer()
+            WallneticButton.primary("Create", icon: "plus", isEnabled: !trimmedName.isEmpty) {
+                _ = collectionManager.createCollection(name: trimmedName, icon: selectedIcon)
+                dismiss()
             }
         }
-        .padding()
-        .frame(width: 300)
+    }
+}
+
+private struct IconPickerCell: View {
+    let icon: String
+    let isSelected: Bool
+    let action: () -> Void
+
+    @State private var hover = false
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: icon)
+                .font(.system(size: 16, weight: .medium))
+                .foregroundColor(isSelected ? .white : .white.opacity(hover ? 0.8 : 0.45))
+                .frame(width: 44, height: 44)
+                .background(
+                    ZStack {
+                        RoundedRectangle(cornerRadius: 10, style: .continuous)
+                            .fill(isSelected
+                                  ? AnyShapeStyle(LinearGradient(
+                                        colors: [Color.accentColor.opacity(0.3), Color.accentColor.opacity(0.15)],
+                                        startPoint: .topLeading, endPoint: .bottomTrailing
+                                    ))
+                                  : AnyShapeStyle(Color.white.opacity(hover ? 0.06 : 0.025)))
+                        RoundedRectangle(cornerRadius: 10, style: .continuous)
+                            .stroke(isSelected ? Color.accentColor.opacity(0.55) : Color.white.opacity(0.08), lineWidth: 0.5)
+                    }
+                )
+                .shadow(color: isSelected ? Color.accentColor.opacity(0.4) : .clear, radius: 8)
+        }
+        .buttonStyle(.plain)
+        .onHover { hover = $0 }
+        .animation(.easeOut(duration: 0.15), value: hover)
+        .animation(.spring(response: 0.3, dampingFraction: 0.7), value: isSelected)
     }
 }
 

--- a/src/Wallnetic/Views/Components/WallneticButton.swift
+++ b/src/Wallnetic/Views/Components/WallneticButton.swift
@@ -1,0 +1,164 @@
+import SwiftUI
+
+/// Wallnetic's signature buttons. Used in sheets, onboarding, and any
+/// place a plain SwiftUI `.borderedProminent` would otherwise leak macOS
+/// chrome into the dark cinematic surfaces.
+///
+/// Three tiers:
+///  * `.primary`   — accent-glow CTA (one per surface ideally)
+///  * `.ghost`     — translucent secondary action
+///  * `.cancel`    — minimal, no chrome
+enum WallneticButton {
+    static func primary(
+        _ title: String,
+        icon: String? = nil,
+        accent: Color = .accentColor,
+        isEnabled: Bool = true,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            HStack(spacing: 8) {
+                if let icon {
+                    Image(systemName: icon)
+                        .font(.system(size: 11, weight: .semibold))
+                }
+                Text(title)
+                    .font(.system(size: 13, weight: .semibold, design: .rounded))
+                    .tracking(0.3)
+            }
+        }
+        .buttonStyle(WallneticPrimaryButtonStyle(accent: accent, isEnabled: isEnabled))
+        .disabled(!isEnabled)
+        .keyboardShortcut(.return)
+    }
+
+    static func ghost(
+        _ title: String,
+        icon: String? = nil,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            HStack(spacing: 6) {
+                if let icon {
+                    Image(systemName: icon)
+                        .font(.system(size: 11))
+                }
+                Text(title)
+                    .font(.system(size: 13, weight: .medium))
+            }
+        }
+        .buttonStyle(WallneticGhostButtonStyle())
+    }
+
+    static func cancel(
+        _ title: String = "Cancel",
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Text(title)
+                .font(.system(size: 13, weight: .medium))
+                .foregroundColor(.white.opacity(0.55))
+        }
+        .buttonStyle(.plain)
+        .keyboardShortcut(.escape)
+    }
+}
+
+// MARK: - Primary (Accent Glow)
+
+private struct WallneticPrimaryButtonStyle: ButtonStyle {
+    let accent: Color
+    let isEnabled: Bool
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .foregroundColor(isEnabled ? .black : .white.opacity(0.35))
+            .padding(.horizontal, 18)
+            .padding(.vertical, 9)
+            .background(
+                ZStack {
+                    Capsule()
+                        .fill(isEnabled
+                              ? AnyShapeStyle(LinearGradient(
+                                    colors: [accent, accent.opacity(0.85)],
+                                    startPoint: .topLeading, endPoint: .bottomTrailing))
+                              : AnyShapeStyle(Color.white.opacity(0.06)))
+                    Capsule()
+                        .stroke(isEnabled ? accent.opacity(0.55) : .white.opacity(0.08), lineWidth: 0.5)
+                }
+            )
+            .shadow(
+                color: isEnabled ? accent.opacity(configuration.isPressed ? 0.15 : 0.45) : .clear,
+                radius: configuration.isPressed ? 4 : 10,
+                y: configuration.isPressed ? 1 : 4
+            )
+            .scaleEffect(configuration.isPressed ? 0.97 : 1.0)
+            .animation(.easeOut(duration: 0.12), value: configuration.isPressed)
+    }
+}
+
+// MARK: - Ghost (Glass Secondary)
+
+private struct WallneticGhostButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .foregroundColor(.white.opacity(0.85))
+            .padding(.horizontal, 16)
+            .padding(.vertical, 9)
+            .background(
+                ZStack {
+                    Capsule()
+                        .fill(Color.white.opacity(configuration.isPressed ? 0.05 : 0.08))
+                    Capsule()
+                        .stroke(Color.white.opacity(0.18), lineWidth: 0.5)
+                }
+            )
+            .scaleEffect(configuration.isPressed ? 0.97 : 1.0)
+            .animation(.easeOut(duration: 0.12), value: configuration.isPressed)
+    }
+}
+
+// MARK: - Wallnetic Text Field
+
+/// Dark glass text field — replaces `.textFieldStyle(.roundedBorder)` which
+/// renders macOS chrome.
+struct WallneticTextField: View {
+    let placeholder: String
+    @Binding var text: String
+    var icon: String? = nil
+    var accent: Color = .accentColor
+    var onSubmit: (() -> Void)? = nil
+
+    @FocusState private var focused: Bool
+
+    var body: some View {
+        HStack(spacing: 10) {
+            if let icon {
+                Image(systemName: icon)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundColor(.white.opacity(0.4))
+            }
+            TextField("", text: $text, prompt: Text(placeholder).foregroundColor(.white.opacity(0.3)))
+                .textFieldStyle(.plain)
+                .foregroundColor(.white)
+                .font(.system(size: 13))
+                .focused($focused)
+                .onSubmit { onSubmit?() }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .background(
+            ZStack {
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(Color.white.opacity(focused ? 0.07 : 0.04))
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .stroke(
+                        focused ? accent.opacity(0.5) : Color.white.opacity(0.1),
+                        lineWidth: focused ? 1 : 0.5
+                    )
+            }
+        )
+        .shadow(color: focused ? accent.opacity(0.25) : .clear, radius: focused ? 6 : 0)
+        .animation(.easeOut(duration: 0.15), value: focused)
+    }
+}

--- a/src/Wallnetic/Views/Components/WallneticSheet.swift
+++ b/src/Wallnetic/Views/Components/WallneticSheet.swift
@@ -1,0 +1,174 @@
+import SwiftUI
+
+/// Cinematic-dark sheet chrome used by every modal across Wallnetic.
+/// Replaces SwiftUI's default sheet look (white background, system chrome)
+/// with the app's signature: deep navy gradient + ultraThinMaterial veil +
+/// hairline accent border + soft neon corner glow.
+///
+/// Usage:
+///
+///     .sheet(isPresented: $showing) {
+///         WallneticSheet(title: "Rename Collection", icon: "folder.fill") {
+///             // content
+///         } footer: {
+///             WallneticButton.cancel { dismiss() }
+///             WallneticButton.primary("Save", isEnabled: canSave) { commit() }
+///         }
+///     }
+struct WallneticSheet<Content: View, Footer: View>: View {
+    let title: String
+    var icon: String? = nil
+    var accent: Color = .accentColor
+    var width: CGFloat = 360
+    @ViewBuilder let content: () -> Content
+    @ViewBuilder let footer: () -> Footer
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+                .overlay(LinearGradient(
+                    colors: [.clear, accent.opacity(0.35), .clear],
+                    startPoint: .leading, endPoint: .trailing
+                ))
+                .frame(height: 0.5)
+
+            VStack(alignment: .leading, spacing: 16) {
+                content()
+            }
+            .padding(.horizontal, 24)
+            .padding(.vertical, 20)
+
+            HStack(spacing: 10) {
+                footer()
+            }
+            .padding(.horizontal, 24)
+            .padding(.bottom, 20)
+        }
+        .frame(width: width)
+        .background(WallneticSheetBackground(accent: accent))
+        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .stroke(LinearGradient(
+                    colors: [accent.opacity(0.35), .white.opacity(0.06), accent.opacity(0.15)],
+                    startPoint: .topLeading, endPoint: .bottomTrailing
+                ), lineWidth: 0.5)
+        )
+        .shadow(color: accent.opacity(0.25), radius: 28, x: 0, y: 12)
+        .shadow(color: .black.opacity(0.55), radius: 14, x: 0, y: 4)
+        .preferredColorScheme(.dark)
+    }
+
+    private var header: some View {
+        HStack(spacing: 12) {
+            if let icon {
+                ZStack {
+                    Circle()
+                        .fill(accent.opacity(0.18))
+                        .frame(width: 30, height: 30)
+                    Image(systemName: icon)
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(accent)
+                        .shadow(color: accent.opacity(0.7), radius: 4)
+                }
+            }
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.system(size: 14, weight: .bold, design: .rounded))
+                    .foregroundColor(.white)
+                    .tracking(0.2)
+            }
+
+            Spacer()
+        }
+        .padding(.horizontal, 24)
+        .padding(.vertical, 16)
+    }
+}
+
+// Convenience: sheets without a footer.
+extension WallneticSheet where Footer == EmptyView {
+    init(
+        title: String,
+        icon: String? = nil,
+        accent: Color = .accentColor,
+        width: CGFloat = 360,
+        @ViewBuilder content: @escaping () -> Content
+    ) {
+        self.title = title
+        self.icon = icon
+        self.accent = accent
+        self.width = width
+        self.content = content
+        self.footer = { EmptyView() }
+    }
+}
+
+// MARK: - Background
+
+private struct WallneticSheetBackground: View {
+    let accent: Color
+
+    var body: some View {
+        ZStack {
+            // Deep base
+            Color(red: 0.04, green: 0.05, blue: 0.09)
+
+            // Subtle radial top-left tint
+            RadialGradient(
+                colors: [accent.opacity(0.16), .clear],
+                center: .topLeading,
+                startRadius: 5,
+                endRadius: 240
+            )
+
+            // Bottom-right vignette
+            RadialGradient(
+                colors: [Color(red: 0.10, green: 0.06, blue: 0.16).opacity(0.55), .clear],
+                center: .bottomTrailing,
+                startRadius: 5,
+                endRadius: 260
+            )
+
+            // Glass veil
+            Rectangle()
+                .fill(.ultraThinMaterial)
+                .opacity(0.20)
+
+            // Grain (CoreImage noise via blendmode)
+            WallneticGrain()
+                .opacity(0.05)
+                .blendMode(.overlay)
+                .allowsHitTesting(false)
+        }
+    }
+}
+
+/// Static stochastic grain — tiles a tiny pseudo-random pattern via
+/// Canvas. Cheap to render once per sheet appearance.
+private struct WallneticGrain: View {
+    var body: some View {
+        Canvas { ctx, size in
+            // Coarse blue-noise approximation: 600 dots, deterministic seed.
+            var rng = SeedableRNG(seed: 1337)
+            for _ in 0..<600 {
+                let x = Double(rng.nextUInt() % UInt32(size.width))
+                let y = Double(rng.nextUInt() % UInt32(size.height))
+                let a = 0.04 + Double(rng.nextUInt() % 60) / 1000
+                let rect = CGRect(x: x, y: y, width: 1, height: 1)
+                ctx.fill(Path(rect), with: .color(.white.opacity(a)))
+            }
+        }
+    }
+
+    struct SeedableRNG {
+        var state: UInt32
+        init(seed: UInt32) { state = seed | 1 }
+        mutating func nextUInt() -> UInt32 {
+            state = state &* 1664525 &+ 1013904223
+            return state
+        }
+    }
+}

--- a/src/Wallnetic/Views/Main/HomeView.swift
+++ b/src/Wallnetic/Views/Main/HomeView.swift
@@ -5,12 +5,19 @@ struct HomeView: View {
     @EnvironmentObject var wallpaperManager: WallpaperManager
     @State private var heroIndex = 0
     @State private var heroTimer: Timer?
+    @State private var heroScrollY: CGFloat = 0
 
     var body: some View {
         ScrollView(.vertical, showsIndicators: false) {
             VStack(spacing: 0) {
                 heroBanner
                     .padding(.top, -46)
+                    .background(GeometryReader { geo -> Color in
+                        DispatchQueue.main.async {
+                            heroScrollY = geo.frame(in: .named("homeScroll")).minY
+                        }
+                        return Color.clear
+                    })
 
                 VStack(spacing: 28) {
                     if !favoritesWallpapers.isEmpty {
@@ -45,6 +52,7 @@ struct HomeView: View {
                 .padding(.top, 20)
             }
         }
+        .coordinateSpace(name: "homeScroll")
         .background(Color.clear)
         .onAppear { startHeroTimer() }
         .onDisappear { heroTimer?.invalidate() }
@@ -65,11 +73,18 @@ struct HomeView: View {
         let wallpapers = Array(wallpaperManager.wallpapers.prefix(5))
         let currentWallpaper = heroIndex < wallpapers.count ? wallpapers[heroIndex] : nil
 
+        // Scroll-driven parallax: scale up + push down as user scrolls
+        let parallax = max(-200, min(200, heroScrollY))
+        let scale = 1.0 + max(0, parallax) * 0.0008
+        let yOffset = parallax * 0.45
+
         return VStack(spacing: 0) {
             ZStack {
                 if let wp = currentWallpaper {
                     HeroBannerCard(wallpaper: wp)
                         .id(heroIndex)
+                        .scaleEffect(scale)
+                        .offset(y: yOffset * 0.3)
                         .transition(.opacity)
                         .animation(.easeInOut(duration: Anim.hero), value: heroIndex)
                 }
@@ -320,9 +335,28 @@ struct CarouselCard: View {
     @State private var isHovering = false
     @State private var renamingWallpaper: Wallpaper?
     @State private var renameText = ""
+    @State private var pointer: CGPoint = .zero  // 0..1 within card
 
     private let cardWidth: CGFloat = 240
     private let cardHeight: CGFloat = 135
+
+    /// Subtle magnetic tilt: pointer's offset from center drives a ±6°
+    /// rotation around the y/x axes plus a 2-3px translation. Falls back
+    /// to flat when not hovering.
+    private var tiltX: Double {
+        guard isHovering else { return 0 }
+        return Double(0.5 - pointer.y) * 8  // top → tilt forward
+    }
+
+    private var tiltY: Double {
+        guard isHovering else { return 0 }
+        return Double(pointer.x - 0.5) * 8  // right → tilt right
+    }
+
+    private var glareOffset: CGFloat {
+        guard isHovering else { return -1 }
+        return pointer.x  // 0..1 follows pointer
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
@@ -384,8 +418,41 @@ struct CarouselCard: View {
                 }
             }
             .frame(width: cardWidth, height: cardHeight)
+            .overlay(
+                // Glare strip — follows pointer
+                LinearGradient(
+                    stops: [
+                        .init(color: .white.opacity(0), location: max(0, glareOffset - 0.25)),
+                        .init(color: .white.opacity(isHovering ? 0.14 : 0), location: glareOffset),
+                        .init(color: .white.opacity(0), location: min(1, glareOffset + 0.25))
+                    ],
+                    startPoint: .leading, endPoint: .trailing
+                )
+                .blendMode(.plusLighter)
+                .allowsHitTesting(false)
+                .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+            )
             .glowCard(isHovering: isHovering, cornerRadius: 8)
-            .scaleEffect(isHovering ? 1.03 : 1.0)
+            .rotation3DEffect(.degrees(tiltX), axis: (x: 1, y: 0, z: 0), perspective: 0.7)
+            .rotation3DEffect(.degrees(tiltY), axis: (x: 0, y: 1, z: 0), perspective: 0.7)
+            .scaleEffect(isHovering ? 1.04 : 1.0)
+            .background(
+                // Trackpad/mouse position tracker (overlay placed in front of the card for hit testing)
+                GeometryReader { proxy in
+                    Color.clear.contentShape(Rectangle())
+                        .onContinuousHover { phase in
+                            switch phase {
+                            case .active(let loc):
+                                pointer = CGPoint(
+                                    x: min(max(loc.x / proxy.size.width, 0), 1),
+                                    y: min(max(loc.y / proxy.size.height, 0), 1)
+                                )
+                            case .ended:
+                                pointer = CGPoint(x: 0.5, y: 0.5)
+                            }
+                        }
+                }
+            )
 
             Text(wallpaper.displayName)
                 .font(.system(size: 11, weight: .medium))

--- a/src/Wallnetic/Views/Main/OnboardingView.swift
+++ b/src/Wallnetic/Views/Main/OnboardingView.swift
@@ -1,111 +1,271 @@
 import SwiftUI
 
+/// Cinematic 4-step onboarding. Full-bleed dark stage, animated gradient
+/// orb, staggered typography reveal, custom progress capsule.
 struct OnboardingView: View {
     @Binding var isPresented: Bool
     @State private var currentStep = 0
+    @State private var orbPhase: Double = 0
 
-    private let steps: [(icon: String, title: String, description: String, colors: [Color])] = [
-        ("photo.on.rectangle.angled", "Welcome to Wallnetic",
-         "Transform your desktop with stunning live video wallpapers.",
-         [.purple, .blue]),
-        ("plus.circle.fill", "Import Your Videos",
-         "Drag and drop video files or use the import button to add wallpapers to your library.",
-         [.blue, .cyan]),
-        ("heart.circle.fill", "Collections & Favorites",
-         "Organize wallpapers into collections and mark your favorites for quick access.",
-         [.pink, .red]),
-        ("display.2", "Multi-Monitor Support",
-         "Set different wallpapers for each display. Wallnetic automatically detects all connected monitors.",
-         [.green, .teal])
+    private struct Step {
+        let icon: String
+        let title: String
+        let kicker: String
+        let description: String
+        let accent: Color
+        let secondary: Color
+    }
+
+    private let steps: [Step] = [
+        Step(
+            icon: "sparkles.tv.fill",
+            title: "Wallnetic",
+            kicker: "LIVE WALLPAPERS",
+            description: "Cinematic, GPU-accelerated motion behind every window. Built for macOS.",
+            accent: Color(red: 0.42, green: 0.71, blue: 1.00),
+            secondary: Color(red: 0.65, green: 0.45, blue: 1.00)
+        ),
+        Step(
+            icon: "tray.and.arrow.down.fill",
+            title: "Bring Anything In",
+            kicker: "01 · IMPORT",
+            description: "Drop video files, link from the browser, or generate with AI — Wallnetic accepts it all.",
+            accent: Color(red: 0.30, green: 0.85, blue: 0.92),
+            secondary: Color(red: 0.28, green: 0.55, blue: 1.00)
+        ),
+        Step(
+            icon: "rectangle.stack.fill.badge.person.crop",
+            title: "Curate Effortlessly",
+            kicker: "02 · ORGANIZE",
+            description: "Collections, favorites, color filters and now smart auto-tags via local Ollama Vision.",
+            accent: Color(red: 1.00, green: 0.45, blue: 0.72),
+            secondary: Color(red: 0.95, green: 0.65, blue: 0.30)
+        ),
+        Step(
+            icon: "display.2",
+            title: "Every Display, Its Own Mood",
+            kicker: "03 · MULTI-MONITOR",
+            description: "Assign distinct wallpapers per screen and per Space. Pause on battery, fullscreen, or schedule.",
+            accent: Color(red: 0.40, green: 0.95, blue: 0.55),
+            secondary: Color(red: 0.20, green: 0.85, blue: 0.85)
+        ),
     ]
 
+    private var step: Step { steps[currentStep] }
+
     var body: some View {
-        VStack(spacing: 0) {
-            // Step content
-            TabView(selection: $currentStep) {
-                ForEach(0..<steps.count, id: \.self) { index in
-                    stepView(steps[index])
-                        .tag(index)
+        ZStack {
+            backdrop
+
+            VStack(spacing: 0) {
+                Spacer(minLength: 0)
+                orb
+                    .frame(height: 220)
+
+                stepCopy
+                    .padding(.top, 32)
+
+                Spacer(minLength: 0)
+
+                controls
+                    .padding(.horizontal, 40)
+                    .padding(.bottom, 36)
+            }
+        }
+        .frame(width: 640, height: 520)
+        .preferredColorScheme(.dark)
+        .onAppear {
+            withAnimation(.linear(duration: 16).repeatForever(autoreverses: true)) {
+                orbPhase = 1
+            }
+        }
+    }
+
+    // MARK: - Backdrop
+
+    private var backdrop: some View {
+        ZStack {
+            Color(red: 0.02, green: 0.025, blue: 0.055)
+
+            // Drifting accent radial
+            RadialGradient(
+                colors: [step.accent.opacity(0.32), .clear],
+                center: UnitPoint(x: 0.2 + orbPhase * 0.15, y: 0.18),
+                startRadius: 8,
+                endRadius: 420
+            )
+
+            // Secondary radial bottom-right
+            RadialGradient(
+                colors: [step.secondary.opacity(0.22), .clear],
+                center: UnitPoint(x: 0.85, y: 0.85 - orbPhase * 0.1),
+                startRadius: 8,
+                endRadius: 380
+            )
+
+            // Diagonal noise lines
+            DiagonalLines()
+                .stroke(Color.white.opacity(0.02), lineWidth: 0.5)
+                .allowsHitTesting(false)
+
+            // Vignette
+            RadialGradient(
+                colors: [.clear, .black.opacity(0.45)],
+                center: .center,
+                startRadius: 200,
+                endRadius: 550
+            )
+        }
+        .animation(.easeInOut(duration: 0.8), value: currentStep)
+    }
+
+    // MARK: - Orb (animated icon stage)
+
+    private var orb: some View {
+        ZStack {
+            // Outer rings
+            ForEach(0..<3) { i in
+                Circle()
+                    .stroke(
+                        LinearGradient(
+                            colors: [step.accent.opacity(0.5), step.secondary.opacity(0.0)],
+                            startPoint: .topLeading, endPoint: .bottomTrailing
+                        ),
+                        lineWidth: 0.5
+                    )
+                    .frame(width: 160 + CGFloat(i) * 36, height: 160 + CGFloat(i) * 36)
+                    .scaleEffect(1 + (orbPhase * 0.04) * Double(i + 1))
+                    .opacity(0.6 - Double(i) * 0.18)
+            }
+
+            // Glow blob
+            Circle()
+                .fill(
+                    RadialGradient(
+                        colors: [step.accent.opacity(0.55), step.secondary.opacity(0.15), .clear],
+                        center: .center,
+                        startRadius: 4,
+                        endRadius: 130
+                    )
+                )
+                .frame(width: 220, height: 220)
+                .blur(radius: 8)
+                .scaleEffect(1 + orbPhase * 0.03)
+
+            // Core disk
+            Circle()
+                .fill(
+                    LinearGradient(
+                        colors: [step.accent, step.secondary],
+                        startPoint: .topLeading, endPoint: .bottomTrailing
+                    )
+                )
+                .frame(width: 96, height: 96)
+                .overlay(
+                    Circle().stroke(.white.opacity(0.25), lineWidth: 0.5)
+                )
+                .shadow(color: step.accent.opacity(0.7), radius: 24, y: 8)
+
+            // Icon
+            Image(systemName: step.icon)
+                .font(.system(size: 36, weight: .semibold))
+                .foregroundColor(.white)
+                .shadow(color: .black.opacity(0.45), radius: 6, y: 2)
+                .transition(.scale.combined(with: .opacity))
+                .id("icon-\(currentStep)")
+        }
+        .animation(.spring(response: 0.55, dampingFraction: 0.78), value: currentStep)
+    }
+
+    // MARK: - Step copy
+
+    private var stepCopy: some View {
+        VStack(spacing: 12) {
+            Text(step.kicker)
+                .font(.system(size: 10, weight: .heavy, design: .monospaced))
+                .tracking(2.5)
+                .foregroundColor(step.accent.opacity(0.85))
+
+            Text(step.title)
+                .font(.system(size: 30, weight: .bold, design: .rounded))
+                .foregroundColor(.white)
+                .tracking(-0.4)
+                .multilineTextAlignment(.center)
+
+            Text(step.description)
+                .font(.system(size: 13))
+                .foregroundColor(.white.opacity(0.62))
+                .multilineTextAlignment(.center)
+                .lineSpacing(3)
+                .frame(maxWidth: 380)
+                .padding(.top, 2)
+        }
+        .padding(.horizontal, 40)
+        .id("copy-\(currentStep)")
+        .transition(.asymmetric(
+            insertion: .offset(y: 12).combined(with: .opacity),
+            removal: .offset(y: -8).combined(with: .opacity)
+        ))
+        .animation(.spring(response: 0.55, dampingFraction: 0.82), value: currentStep)
+    }
+
+    // MARK: - Controls (progress + buttons)
+
+    private var controls: some View {
+        VStack(spacing: 24) {
+            // Capsule progress
+            HStack(spacing: 6) {
+                ForEach(0..<steps.count, id: \.self) { i in
+                    Capsule()
+                        .fill(i == currentStep ? AnyShapeStyle(LinearGradient(
+                                colors: [step.accent, step.secondary],
+                                startPoint: .leading, endPoint: .trailing
+                            )) : AnyShapeStyle(Color.white.opacity(0.12)))
+                        .frame(width: i == currentStep ? 28 : 12, height: 4)
+                        .shadow(color: i == currentStep ? step.accent.opacity(0.6) : .clear, radius: 4)
+                        .animation(.spring(response: 0.4, dampingFraction: 0.75), value: currentStep)
                 }
             }
-            .tabViewStyle(.automatic)
-            .frame(height: 320)
 
-            // Progress dots
-            HStack(spacing: 8) {
-                ForEach(0..<steps.count, id: \.self) { index in
-                    Circle()
-                        .fill(index == currentStep ? Color.accentColor : Color.secondary.opacity(0.3))
-                        .frame(width: 8, height: 8)
-                        .scaleEffect(index == currentStep ? 1.2 : 1.0)
-                        .animation(.spring(response: 0.3), value: currentStep)
-                }
-            }
-            .padding(.vertical, 16)
-
-            // Buttons
             HStack {
                 if currentStep > 0 {
-                    Button("Back") {
+                    WallneticButton.cancel("Back") {
                         withAnimation { currentStep -= 1 }
                     }
-                    .buttonStyle(.plain)
-                    .foregroundColor(.secondary)
+                } else {
+                    WallneticButton.cancel("Skip") {
+                        withAnimation { isPresented = false }
+                    }
                 }
 
                 Spacer()
 
                 if currentStep < steps.count - 1 {
-                    Button("Next") {
-                        withAnimation(.spring(response: 0.4)) { currentStep += 1 }
+                    WallneticButton.primary("Next", icon: "arrow.right", accent: step.accent) {
+                        withAnimation { currentStep += 1 }
                     }
-                    .buttonStyle(.borderedProminent)
-                    .controlSize(.large)
                 } else {
-                    Button("Get Started") {
+                    WallneticButton.primary("Enter Wallnetic", icon: "sparkles", accent: step.accent) {
                         withAnimation { isPresented = false }
                     }
-                    .buttonStyle(.borderedProminent)
-                    .controlSize(.large)
                 }
             }
-            .padding(.horizontal, 32)
-            .padding(.bottom, 24)
         }
-        .frame(width: 520, height: 440)
     }
+}
 
-    private func stepView(_ step: (icon: String, title: String, description: String, colors: [Color])) -> some View {
-        VStack(spacing: 20) {
-            Spacer()
+// MARK: - Diagonal Lines (backdrop texture)
 
-            ZStack {
-                Circle()
-                    .fill(
-                        LinearGradient(colors: step.colors, startPoint: .topLeading, endPoint: .bottomTrailing)
-                    )
-                    .frame(width: 100, height: 100)
-                    .opacity(0.15)
-
-                Image(systemName: step.icon)
-                    .font(.system(size: 48))
-                    .foregroundStyle(
-                        LinearGradient(colors: step.colors, startPoint: .topLeading, endPoint: .bottomTrailing)
-                    )
-            }
-
-            Text(step.title)
-                .font(.title2)
-                .fontWeight(.bold)
-
-            Text(step.description)
-                .font(.body)
-                .foregroundColor(.secondary)
-                .multilineTextAlignment(.center)
-                .frame(maxWidth: 360)
-
-            Spacer()
+private struct DiagonalLines: Shape {
+    func path(in rect: CGRect) -> Path {
+        var p = Path()
+        let spacing: CGFloat = 32
+        var x: CGFloat = -rect.height
+        while x < rect.width {
+            p.move(to: CGPoint(x: x, y: 0))
+            p.addLine(to: CGPoint(x: x + rect.height, y: rect.height))
+            x += spacing
         }
-        .padding(.horizontal, 32)
+        return p
     }
 }

--- a/src/Wallnetic/Views/Main/SettingsView.swift
+++ b/src/Wallnetic/Views/Main/SettingsView.swift
@@ -1,39 +1,268 @@
 import SwiftUI
 
 struct SettingsView: View {
+    @State private var selection: SettingsSection = .general
+
     var body: some View {
-        TabView {
-            GeneralSettingsView()
-                .tabItem { Label("General", systemImage: "gear") }
+        ZStack {
+            // Full bleed dark backdrop replacing the system Form chrome
+            Color(red: 0.04, green: 0.05, blue: 0.09)
+                .ignoresSafeArea()
+            RadialGradient(
+                colors: [Color.accentColor.opacity(0.10), .clear],
+                center: .topLeading, startRadius: 5, endRadius: 360
+            )
+            .ignoresSafeArea()
 
-            AppearanceSettingsView()
-                .tabItem { Label("Appearance", systemImage: "paintbrush") }
-
-            PlaybackSettingsView()
-                .tabItem { Label("Playback", systemImage: "play.circle") }
-
-            EffectsSettingsView()
-                .tabItem { Label("Effects", systemImage: "wand.and.stars") }
-
-            TimeOfDaySettingsView()
-                .tabItem { Label("Schedule", systemImage: "clock.arrow.2.circlepath") }
-
-            SpaceSettingsView()
-                .tabItem { Label("Spaces", systemImage: "square.stack.3d.up") }
-
-            SmartTaggingSettingsView()
-                .tabItem { Label("Smart Tags", systemImage: "tag") }
-
-            DisplaySettingsView()
-                .tabItem { Label("Display", systemImage: "display") }
-
-            NotificationSettingsView()
-                .tabItem { Label("Notifications", systemImage: "bell") }
-
-            AboutSettingsView()
-                .tabItem { Label("About", systemImage: "info.circle") }
+            HStack(spacing: 0) {
+                sidebar
+                Divider()
+                    .overlay(Color.white.opacity(0.06))
+                detail
+            }
         }
-        .frame(width: 680, height: 500)
+        .frame(width: 880, height: 560)
+        .preferredColorScheme(.dark)
+    }
+
+    // MARK: - Sidebar
+
+    private var sidebar: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(spacing: 10) {
+                Image(systemName: "gearshape.2.fill")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundColor(.accentColor)
+                Text("SETTINGS")
+                    .font(.system(size: 10, weight: .heavy, design: .monospaced))
+                    .tracking(2.4)
+                    .foregroundColor(.white.opacity(0.45))
+                Spacer()
+            }
+            .padding(.horizontal, 22)
+            .padding(.top, 24)
+            .padding(.bottom, 16)
+
+            ScrollView(showsIndicators: false) {
+                VStack(alignment: .leading, spacing: 2) {
+                    ForEach(SettingsSection.allCases.filter { !$0.isFooter }) { section in
+                        SidebarRow(section: section, isSelected: selection == section) {
+                            withAnimation(.easeOut(duration: 0.18)) { selection = section }
+                        }
+                    }
+
+                    Rectangle()
+                        .fill(Color.white.opacity(0.06))
+                        .frame(height: 0.5)
+                        .padding(.vertical, 10)
+                        .padding(.horizontal, 14)
+
+                    ForEach(SettingsSection.allCases.filter { $0.isFooter }) { section in
+                        SidebarRow(section: section, isSelected: selection == section) {
+                            withAnimation(.easeOut(duration: 0.18)) { selection = section }
+                        }
+                    }
+                }
+                .padding(.horizontal, 10)
+            }
+
+            Spacer(minLength: 0)
+
+            // Version badge
+            HStack(spacing: 6) {
+                Circle()
+                    .fill(.green)
+                    .frame(width: 5, height: 5)
+                    .shadow(color: .green.opacity(0.6), radius: 3)
+                Text("v\(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?")")
+                    .font(.system(size: 10, weight: .medium, design: .monospaced))
+                    .foregroundColor(.white.opacity(0.45))
+            }
+            .padding(.horizontal, 22)
+            .padding(.bottom, 18)
+        }
+        .frame(width: 220)
+    }
+
+    // MARK: - Detail Pane
+
+    private var detail: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(spacing: 12) {
+                Image(systemName: selection.icon)
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundColor(selection.accent)
+                    .frame(width: 26, height: 26)
+                    .background(
+                        Circle()
+                            .fill(selection.accent.opacity(0.18))
+                    )
+                    .shadow(color: selection.accent.opacity(0.4), radius: 6)
+
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(selection.title)
+                        .font(.system(size: 17, weight: .bold, design: .rounded))
+                        .foregroundColor(.white)
+                    Text(selection.tagline)
+                        .font(.system(size: 11))
+                        .foregroundColor(.white.opacity(0.45))
+                }
+
+                Spacer()
+            }
+            .padding(.horizontal, 32)
+            .padding(.top, 26)
+            .padding(.bottom, 18)
+
+            Divider()
+                .overlay(LinearGradient(
+                    colors: [.clear, selection.accent.opacity(0.35), .clear],
+                    startPoint: .leading, endPoint: .trailing
+                ))
+                .frame(height: 0.5)
+
+            ZStack {
+                content
+                    .scrollContentBackground(.hidden)
+            }
+            .id(selection)
+            .transition(.asymmetric(
+                insertion: .offset(y: 8).combined(with: .opacity),
+                removal: .opacity
+            ))
+        }
+        .background(Color.clear)
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch selection {
+        case .general:    GeneralSettingsView()
+        case .appearance: AppearanceSettingsView()
+        case .playback:   PlaybackSettingsView()
+        case .effects:    EffectsSettingsView()
+        case .schedule:   TimeOfDaySettingsView()
+        case .spaces:     SpaceSettingsView()
+        case .smartTags:  SmartTaggingSettingsView()
+        case .display:    DisplaySettingsView()
+        case .notifications: NotificationSettingsView()
+        case .about:      AboutSettingsView()
+        }
+    }
+}
+
+// MARK: - Sections
+
+private enum SettingsSection: String, CaseIterable, Identifiable {
+    case general, appearance, playback, effects, schedule, spaces, smartTags, display, notifications, about
+
+    var id: String { rawValue }
+    var isFooter: Bool { self == .notifications || self == .about }
+
+    var title: String {
+        switch self {
+        case .general:       return "General"
+        case .appearance:    return "Appearance"
+        case .playback:      return "Playback"
+        case .effects:       return "Effects"
+        case .schedule:      return "Schedule"
+        case .spaces:        return "Spaces"
+        case .smartTags:     return "Smart Tags"
+        case .display:       return "Display"
+        case .notifications: return "Notifications"
+        case .about:         return "About"
+        }
+    }
+
+    var tagline: String {
+        switch self {
+        case .general:       return "App-wide behavior and library location."
+        case .appearance:    return "Theme, accent, and dynamic colors."
+        case .playback:      return "Power, performance, and pause rules."
+        case .effects:       return "Live wallpaper post-processing."
+        case .schedule:      return "Time-of-day rotations."
+        case .spaces:        return "Per-Space wallpaper assignments."
+        case .smartTags:     return "Local Ollama Vision auto-tagging."
+        case .display:       return "Per-monitor mode and tracking."
+        case .notifications: return "Toggle alert categories."
+        case .about:         return "Version, credits, and links."
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .general:       return "gear"
+        case .appearance:    return "paintbrush.fill"
+        case .playback:      return "play.fill"
+        case .effects:       return "wand.and.stars"
+        case .schedule:      return "clock.arrow.2.circlepath"
+        case .spaces:        return "square.stack.3d.up.fill"
+        case .smartTags:     return "tag.fill"
+        case .display:       return "display"
+        case .notifications: return "bell.fill"
+        case .about:         return "info.circle.fill"
+        }
+    }
+
+    var accent: Color {
+        switch self {
+        case .general:       return Color(red: 0.42, green: 0.71, blue: 1.00)
+        case .appearance:    return Color(red: 1.00, green: 0.45, blue: 0.72)
+        case .playback:      return Color(red: 0.40, green: 0.95, blue: 0.55)
+        case .effects:       return Color(red: 0.85, green: 0.55, blue: 1.00)
+        case .schedule:      return Color(red: 1.00, green: 0.75, blue: 0.35)
+        case .spaces:        return Color(red: 0.55, green: 0.80, blue: 1.00)
+        case .smartTags:     return Color(red: 0.45, green: 0.95, blue: 0.95)
+        case .display:       return Color(red: 0.65, green: 0.85, blue: 0.50)
+        case .notifications: return Color(red: 1.00, green: 0.60, blue: 0.45)
+        case .about:         return Color.white.opacity(0.85)
+        }
+    }
+}
+
+private struct SidebarRow: View {
+    let section: SettingsSection
+    let isSelected: Bool
+    let action: () -> Void
+
+    @State private var hover = false
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 10) {
+                Image(systemName: section.icon)
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundColor(isSelected ? section.accent : .white.opacity(hover ? 0.7 : 0.45))
+                    .frame(width: 22, height: 22)
+                    .background(
+                        RoundedRectangle(cornerRadius: 6)
+                            .fill(isSelected ? section.accent.opacity(0.18) : Color.clear)
+                    )
+
+                Text(section.title)
+                    .font(.system(size: 12, weight: isSelected ? .semibold : .medium))
+                    .foregroundColor(isSelected ? .white : .white.opacity(hover ? 0.85 : 0.6))
+
+                Spacer()
+
+                if isSelected {
+                    Circle()
+                        .fill(section.accent)
+                        .frame(width: 4, height: 4)
+                        .shadow(color: section.accent.opacity(0.7), radius: 3)
+                }
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 7)
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(isSelected ? Color.white.opacity(0.06) : (hover ? Color.white.opacity(0.03) : .clear))
+            )
+        }
+        .buttonStyle(.plain)
+        .onHover { hover = $0 }
+        .animation(.easeOut(duration: 0.12), value: hover)
+        .animation(.easeOut(duration: 0.18), value: isSelected)
     }
 }
 

--- a/src/Wallnetic/Views/Main/TopNavigationBar.swift
+++ b/src/Wallnetic/Views/Main/TopNavigationBar.swift
@@ -19,7 +19,10 @@ enum NavigationTab: String, CaseIterable, Identifiable {
     }
 }
 
-/// Striking glass navigation bar with neon-glow tabs
+/// Striking glass navigation bar with neon-glow tabs.
+/// Phase C revision: gradient-underline active tab, frosted material
+/// background, full search bar (not just an icon), uniform action button
+/// chrome shared by Import + Settings.
 struct TopNavigationBar: View {
     @Binding var selectedTab: NavigationTab
     @Binding var searchText: String
@@ -27,50 +30,36 @@ struct TopNavigationBar: View {
     @Binding var showingPhotosImport: Bool
     @State private var isSearching = false
     @State private var hoveredTab: NavigationTab?
+    @FocusState private var searchFocused: Bool
     var isScrolled: Bool = false
 
     var body: some View {
         ZStack {
-            // Left side - search
+            // LEFT: search
             HStack {
-                if isSearching {
-                    searchBar
-                        .transition(.opacity.combined(with: .scale(scale: 0.9, anchor: .leading)))
-                } else {
-                    Button {
-                        withAnimation(.easeOut(duration: Anim.normal)) { isSearching = true }
-                    } label: {
-                        Image(systemName: "magnifyingglass")
-                            .font(.system(size: 13, weight: .medium))
-                            .foregroundColor(.white.opacity(0.7))
-                            .padding(6)
-                            .background(Circle().fill(Color.white.opacity(0.05)))
-                    }
-                    .buttonStyle(.plain)
-                    .keyboardShortcut("f", modifiers: .command)
-                }
-
+                searchControl
+                    .frame(maxWidth: 240, alignment: .leading)
                 Spacer()
             }
 
-            // Center - logo + tabs
-            HStack(spacing: 20) {
+            // CENTER: logo + tabs
+            HStack(spacing: 18) {
                 Image(nsImage: NSApp.applicationIconImage)
                     .resizable()
                     .aspectRatio(contentMode: .fit)
-                    .frame(width: 28, height: 28)
-                    .cornerRadius(6)
-                    .shadow(color: .accentColor.opacity(0.3), radius: 6)
+                    .frame(width: 26, height: 26)
+                    .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+                    .shadow(color: .accentColor.opacity(0.45), radius: 8)
 
-                HStack(spacing: 2) {
+                HStack(spacing: 4) {
                     ForEach(NavigationTab.allCases) { tab in
                         tabButton(tab)
                     }
                 }
             }
 
-            // Right side - import + settings
-            HStack(spacing: 12) {
+            // RIGHT: import + settings
+            HStack(spacing: 10) {
                 Spacer()
 
                 Menu {
@@ -87,54 +76,47 @@ struct TopNavigationBar: View {
                         Label("Create from Photos…", systemImage: "photo.on.rectangle.angled")
                     }
                 } label: {
-                    Image(systemName: "plus")
-                        .font(.system(size: 12, weight: .bold))
-                        .foregroundColor(.white.opacity(0.8))
-                        .frame(width: 28, height: 28)
-                        .background(
-                            Circle()
-                                .fill(Color.white.opacity(0.08))
-                                .overlay(Circle().stroke(Color.white.opacity(0.12), lineWidth: 0.5))
-                        )
+                    ActionChip(icon: "plus", accent: true)
                 }
                 .menuStyle(.borderlessButton)
                 .menuIndicator(.hidden)
-                .frame(width: 28, height: 28)
+                .frame(width: 30, height: 30)
 
                 if #available(macOS 14.0, *) {
                     SettingsLink {
-                        Image(systemName: "gearshape")
-                            .font(.system(size: 13))
-                            .foregroundColor(.white.opacity(0.6))
+                        ActionChip(icon: "gearshape.fill", accent: false)
                     }
                     .buttonStyle(.plain)
                 }
             }
         }
-        .padding(.horizontal, 24)
-        .padding(.vertical, 10)
-        .background(
-            ZStack {
-                // Glass effect
-                Color.black.opacity(isScrolled ? 0.85 : 0.4)
-                if isScrolled {
-                    Color.white.opacity(0.03)
-                }
-            }
-            .animation(.easeInOut(duration: Anim.medium), value: isScrolled)
-        )
+        .padding(.horizontal, 18)
+        .padding(.vertical, 9)
+        .background(navBackground)
         .overlay(alignment: .bottom) {
-            // Subtle bottom glow line
             Rectangle()
                 .fill(
                     LinearGradient(
-                        colors: [.clear, .accentColor.opacity(isScrolled ? 0.15 : 0), .clear],
-                        startPoint: .leading,
-                        endPoint: .trailing
+                        colors: [.clear, .accentColor.opacity(isScrolled ? 0.25 : 0.05), .clear],
+                        startPoint: .leading, endPoint: .trailing
                     )
                 )
                 .frame(height: 0.5)
         }
+    }
+
+    // MARK: - Background
+
+    private var navBackground: some View {
+        ZStack {
+            // Frosted glass — stronger when content scrolls under
+            Rectangle()
+                .fill(.ultraThinMaterial)
+                .opacity(isScrolled ? 0.85 : 0.5)
+            // Dark tint underneath material so it never goes light
+            Color.black.opacity(isScrolled ? 0.35 : 0.18)
+        }
+        .animation(.easeInOut(duration: Anim.medium), value: isScrolled)
     }
 
     // MARK: - Tab Button
@@ -149,31 +131,36 @@ struct TopNavigationBar: View {
                 selectedTab = tab
             }
         } label: {
-            HStack(spacing: 5) {
-                Image(systemName: tab.icon)
-                    .font(.system(size: 10))
-                    .neonGlow(.accentColor, isActive: isSelected, radius: 6)
+            VStack(spacing: 3) {
+                HStack(spacing: 5) {
+                    Image(systemName: tab.icon)
+                        .font(.system(size: 10))
+                    Text(tab.rawValue)
+                        .font(.system(size: 12, weight: isSelected ? .semibold : .medium))
+                        .tracking(0.1)
+                }
+                .foregroundColor(isSelected ? .white : .white.opacity(isHovered ? 0.85 : 0.55))
 
-                Text(tab.rawValue)
-                    .font(.system(size: 12, weight: isSelected ? .bold : .medium))
+                // Active gradient underline
+                Capsule()
+                    .fill(
+                        isSelected
+                            ? AnyShapeStyle(LinearGradient(
+                                colors: [.accentColor, .accentColor.opacity(0.6)],
+                                startPoint: .leading, endPoint: .trailing
+                            ))
+                            : AnyShapeStyle(Color.clear)
+                    )
+                    .frame(width: isSelected ? 28 : 0, height: 2)
+                    .shadow(color: .accentColor.opacity(0.6), radius: 4)
             }
-            .foregroundColor(isSelected ? .white : .white.opacity(isHovered ? 0.8 : 0.5))
             .padding(.horizontal, 12)
             .padding(.vertical, 6)
+            .contentShape(Rectangle())
             .background(
-                ZStack {
-                    if isSelected {
-                        Capsule()
-                            .fill(Color.accentColor.opacity(0.2))
-                        Capsule()
-                            .stroke(Color.accentColor.opacity(0.3), lineWidth: 0.5)
-                    } else if isHovered {
-                        Capsule()
-                            .fill(Color.white.opacity(0.06))
-                    }
-                }
+                Capsule()
+                    .fill(isHovered && !isSelected ? Color.white.opacity(0.05) : .clear)
             )
-            .neonGlow(.accentColor, isActive: isSelected, radius: 10)
         }
         .buttonStyle(.plain)
         .onHover { h in
@@ -181,37 +168,114 @@ struct TopNavigationBar: View {
         }
     }
 
-    // MARK: - Search Bar
+    // MARK: - Search Control
 
-    private var searchBar: some View {
-        HStack(spacing: 6) {
-            Image(systemName: "magnifyingglass")
-                .font(.system(size: 11))
-                .foregroundColor(.accentColor.opacity(0.7))
+    @ViewBuilder
+    private var searchControl: some View {
+        if isSearching {
+            HStack(spacing: 6) {
+                Image(systemName: "magnifyingglass")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundColor(.accentColor)
+                    .shadow(color: .accentColor.opacity(0.6), radius: 4)
 
-            TextField("Search...", text: $searchText)
+                TextField("Search wallpapers…", text: $searchText, prompt:
+                    Text("Search wallpapers…").foregroundColor(.white.opacity(0.32))
+                )
                 .textFieldStyle(.plain)
                 .font(.system(size: 12))
                 .foregroundColor(.white)
-                .frame(width: 160)
+                .focused($searchFocused)
+                .frame(width: 170)
 
-            Button {
-                withAnimation(.easeOut(duration: Anim.fast)) {
-                    isSearching = false; searchText = ""
+                Button {
+                    withAnimation(.easeOut(duration: Anim.fast)) {
+                        isSearching = false
+                        searchText = ""
+                    }
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.system(size: 11))
+                        .foregroundColor(.white.opacity(0.4))
                 }
+                .buttonStyle(.plain)
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(
+                ZStack {
+                    Capsule().fill(Color.white.opacity(0.06))
+                    Capsule().stroke(Color.accentColor.opacity(0.45), lineWidth: 0.6)
+                }
+            )
+            .shadow(color: .accentColor.opacity(0.25), radius: 6)
+            .transition(.opacity.combined(with: .scale(scale: 0.95, anchor: .leading)))
+            .onAppear { searchFocused = true }
+        } else {
+            Button {
+                withAnimation(.easeOut(duration: Anim.normal)) { isSearching = true }
             } label: {
-                Image(systemName: "xmark")
-                    .font(.system(size: 9, weight: .bold))
-                    .foregroundColor(.white.opacity(0.5))
+                HStack(spacing: 8) {
+                    Image(systemName: "magnifyingglass")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundColor(.white.opacity(0.45))
+                    Text("Search")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundColor(.white.opacity(0.4))
+                    Spacer(minLength: 0)
+                    Text("⌘F")
+                        .font(.system(size: 9, weight: .heavy, design: .monospaced))
+                        .tracking(0.5)
+                        .foregroundColor(.white.opacity(0.28))
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 6)
+                .frame(width: 180)
+                .background(
+                    ZStack {
+                        Capsule().fill(Color.white.opacity(0.04))
+                        Capsule().stroke(Color.white.opacity(0.1), lineWidth: 0.5)
+                    }
+                )
             }
             .buttonStyle(.plain)
+            .keyboardShortcut("f", modifiers: .command)
         }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 6)
-        .glassBackground(cornerRadius: 8, opacity: 0.08)
-        .overlay(
-            RoundedRectangle(cornerRadius: 8)
-                .stroke(Color.accentColor.opacity(0.2), lineWidth: 0.5)
-        )
+    }
+}
+
+// MARK: - Action Chip
+
+private struct ActionChip: View {
+    let icon: String
+    let accent: Bool
+    @State private var hover = false
+
+    var body: some View {
+        Image(systemName: icon)
+            .font(.system(size: 11, weight: .semibold))
+            .foregroundColor(.white.opacity(hover ? 1.0 : 0.75))
+            .frame(width: 28, height: 28)
+            .background(
+                ZStack {
+                    Circle().fill(
+                        accent && hover
+                            ? AnyShapeStyle(LinearGradient(
+                                colors: [Color.accentColor.opacity(0.4), Color.accentColor.opacity(0.18)],
+                                startPoint: .topLeading, endPoint: .bottomTrailing))
+                            : AnyShapeStyle(Color.white.opacity(hover ? 0.12 : 0.06))
+                    )
+                    Circle().stroke(
+                        accent && hover ? Color.accentColor.opacity(0.55) : Color.white.opacity(0.12),
+                        lineWidth: 0.5
+                    )
+                }
+            )
+            .shadow(
+                color: accent && hover ? Color.accentColor.opacity(0.45) : .clear,
+                radius: 8
+            )
+            .onHover { hover = $0 }
+            .animation(.easeOut(duration: Anim.normal), value: hover)
     }
 }

--- a/src/Wallnetic/Views/Main/WallpaperGridView.swift
+++ b/src/Wallnetic/Views/Main/WallpaperGridView.swift
@@ -483,46 +483,48 @@ struct RenameWallpaperSheet: View {
     let onSave: (String) -> Void
     let onCancel: () -> Void
 
+    private var trimmed: String {
+        title.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
     var body: some View {
-        VStack(spacing: 16) {
-            HStack {
-                Text("Rename Wallpaper")
-                    .font(.headline)
-                Spacer()
-            }
+        WallneticSheet(title: "Rename Wallpaper", icon: "play.rectangle.fill", width: 400) {
+            VStack(alignment: .leading, spacing: 10) {
+                Text("DISPLAY NAME")
+                    .font(.system(size: 9, weight: .heavy, design: .monospaced))
+                    .tracking(2)
+                    .foregroundColor(.white.opacity(0.35))
 
-            TextField("Wallpaper name", text: $title)
-                .textFieldStyle(.roundedBorder)
-                .onSubmit {
-                    if !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                        onSave(title)
-                    }
+                WallneticTextField(
+                    placeholder: wallpaper.name,
+                    text: $title,
+                    icon: "pencil"
+                ) {
+                    if !trimmed.isEmpty { onSave(title) }
                 }
 
-            HStack {
                 if wallpaper.customTitle != nil {
-                    Button("Reset to Original") {
+                    Button {
                         onSave("")
+                    } label: {
+                        HStack(spacing: 6) {
+                            Image(systemName: "arrow.uturn.backward")
+                                .font(.system(size: 10))
+                            Text("Reset to original filename")
+                                .font(.system(size: 11))
+                        }
+                        .foregroundColor(.white.opacity(0.5))
                     }
-                    .foregroundColor(.secondary)
+                    .buttonStyle(.plain)
+                    .padding(.top, 4)
                 }
-
-                Spacer()
-
-                Button("Cancel") {
-                    onCancel()
-                }
-                .keyboardShortcut(.escape)
-
-                Button("Save") {
-                    onSave(title)
-                }
-                .keyboardShortcut(.return)
-                .buttonStyle(.borderedProminent)
-                .disabled(title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+        } footer: {
+            WallneticButton.cancel { onCancel() }
+            Spacer()
+            WallneticButton.primary("Save", icon: "checkmark", isEnabled: !trimmed.isEmpty) {
+                onSave(title)
             }
         }
-        .padding(20)
-        .frame(width: 360)
     }
 }

--- a/src/Wallnetic/Wallnetic.xcodeproj/project.pbxproj
+++ b/src/Wallnetic/Wallnetic.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		2445819EF402088E3689C8CD /* DeepLinkHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2833332B3174CD94D7D62CBB /* DeepLinkHandler.swift */; };
 		2509E976AE0675786B3C248A /* SmallWidgetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 134AA54986991D7480CC4CD8 /* SmallWidgetView.swift */; };
 		284D0925EA9AEC2B302910D1 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BF36E216B5F900C62E824B59 /* Assets.xcassets */; };
+		29D5A45CA0BA3716AFA45522 /* WallneticButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07818DDC6C7B04DED71808AA /* WallneticButton.swift */; };
 		2C5619331688457B6A844B93 /* CollectionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31C51D17BDBBADCDF4D5CB43 /* CollectionsView.swift */; };
 		2D30EDC8BD2E940365F05AB0 /* WallneticWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69A7F21804AB5D266A239578 /* WallneticWidget.swift */; };
 		38BD342CB024693C99DB8B35 /* AudioVisualizerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 082027791B67C0B2DBD43F97 /* AudioVisualizerManager.swift */; };
@@ -112,6 +113,7 @@
 		D95869079F717BD8B2BB26D0 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA19F4DBD0636536454696F3 /* ContentView.swift */; };
 		DCAD65468ADF42075E87EF0B /* WallneticWidgetBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B7028D3EA5A514573B5B23F /* WallneticWidgetBundle.swift */; };
 		DD274D4C961B6128F9FA1776 /* TopNavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8500C9E87013D486C890E673 /* TopNavigationBar.swift */; };
+		DE3542059F1E6A652AE1D744 /* WallneticSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5803846B0B2BB84A1FDEE4E /* WallneticSheet.swift */; };
 		DEA965482FC1C3045A26958B /* ScreenSaverBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D0396F7C77849244B424DD5 /* ScreenSaverBridge.swift */; };
 		E1A41C3F6B921B68A90EBBFA /* PopularView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B28D90947064A40462D0CC1C /* PopularView.swift */; };
 		E3721D2B68E6322EA1D6E408 /* AnalyticsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C296AD08F207FEC3AF4CDCB9 /* AnalyticsManager.swift */; };
@@ -162,6 +164,7 @@
 
 /* Begin PBXFileReference section */
 		02604286446C78C5C8935E45 /* SettingsSubViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSubViews.swift; sourceTree = "<group>"; };
+		07818DDC6C7B04DED71808AA /* WallneticButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallneticButton.swift; sourceTree = "<group>"; };
 		082027791B67C0B2DBD43F97 /* AudioVisualizerManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioVisualizerManager.swift; sourceTree = "<group>"; };
 		08B2A227CEA1CA39347CC37A /* WallneticWidget.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = WallneticWidget.entitlements; sourceTree = "<group>"; };
 		0990FC999E1DE89A3D776B05 /* WidgetSyncService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetSyncService.swift; sourceTree = "<group>"; };
@@ -252,6 +255,7 @@
 		B0F9B4893FCEA17EEFC7550A /* WallpaperMetadataStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperMetadataStore.swift; sourceTree = "<group>"; };
 		B28D90947064A40462D0CC1C /* PopularView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopularView.swift; sourceTree = "<group>"; };
 		B3E0F02714B57C6B710BFA04 /* FavoriteStylesManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteStylesManager.swift; sourceTree = "<group>"; };
+		B5803846B0B2BB84A1FDEE4E /* WallneticSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallneticSheet.swift; sourceTree = "<group>"; };
 		B5CEC2B4480AEC32A84E65E8 /* VideoTrimmer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoTrimmer.swift; sourceTree = "<group>"; };
 		B6272C35871A69060C41EFEC /* AIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIService.swift; sourceTree = "<group>"; };
 		B7021318E82664A8754F5FF1 /* AIProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIProvider.swift; sourceTree = "<group>"; };
@@ -486,6 +490,8 @@
 			isa = PBXGroup;
 			children = (
 				5FD8494A42E5AA356A35BA25 /* StrikingEffects.swift */,
+				07818DDC6C7B04DED71808AA /* WallneticButton.swift */,
+				B5803846B0B2BB84A1FDEE4E /* WallneticSheet.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -824,6 +830,8 @@
 				EFB2FACA7CFF8C61C6DED49E /* VideoRenderer.swift in Sources */,
 				EAAE966CCF3909FB2678C87D /* VideoTrimmer.swift in Sources */,
 				4D244E609DA6FBD637CD7D8F /* WallneticApp.swift in Sources */,
+				29D5A45CA0BA3716AFA45522 /* WallneticButton.swift in Sources */,
+				DE3542059F1E6A652AE1D744 /* WallneticSheet.swift in Sources */,
 				40D40FD944D13CCAF633E4A9 /* Wallpaper.swift in Sources */,
 				51355B920BE931D2A9A3BE58 /* WallpaperCollection.swift in Sources */,
 				1B480E4A92B2E3538B724AE4 /* WallpaperEffectsManager.swift in Sources */,


### PR DESCRIPTION
Full Phase A + B + C visual revision per `/frontend-design`. No behavior changes; pure aesthetic + motion polish.

## Phase A — Foundations & Sheets
- **`WallneticSheet`** (Views/Components/WallneticSheet.swift): dark navy gradient + ultraThinMaterial veil + hairline accent border + canvas-rendered grain. Replaces the white-chrome SwiftUI sheet defaults on every modal.
- **`WallneticButton`** (Views/Components/WallneticButton.swift): `.primary` (accent gradient capsule with glow + `.return`), `.ghost` (translucent glass), `.cancel` (chromeless + `.escape`). Replaces `.borderedProminent` chrome.
- **`WallneticTextField`**: dark glass field with focus glow.
- **Onboarding rewrite**: 4-step cinematic stage — animated radial gradients drift per step, glow orb with rotating rings, diagonal noise lines, vignette. Each step has its own accent + secondary color that the backdrop animates between. Sequential typography reveal (monospaced kicker / rounded title / body).
- **Sheets migrated** to the new chrome: CreateCollection, RenameCollection, IconPicker, RenameWallpaper.

## Phase B — Settings split view
- TabView → 220pt dark sidebar + glass detail pane. Each section gets its own accent (10 unique colors), an accent dot indicator, a monospaced kicker, and a gradient hairline divider above the panel.
- `.scrollContentBackground(.hidden)` strips macOS Form chrome so inner panels blend with the dark stage.
- Version pill in sidebar footer.

## Phase C1 — TopNavigationBar
- Frosted ultraThinMaterial background (sheer at top, denser when scrolled).
- Search is now a 180pt placeholder bar with inline ⌘F hint and accent focus glow — not a tiny icon.
- Active tab uses gradient underline capsule with accent shadow.
- New `ActionChip` for Import (+) and Settings — accent gradient on hover for Import.

## Phase C2 — Hero parallax + magnetic carousel hover
- Hero scales up (+20% max) and y-offsets as user scrolls down. Coordinate space `homeScroll` reads minY.
- CarouselCard tracks pointer via `.onContinuousHover`, applies ±4° dual-axis tilt + moving glare strip blended on the thumbnail.

## Test plan
- [x] Debug build SUCCEEDED
- [x] Release build SUCCEEDED
- [x] 76/76 unit tests pass
- [ ] Manual: walk through onboarding — verify smooth color/copy transitions
- [ ] Manual: open every Settings section — verify sidebar selection + detail header animates
- [ ] Manual: TopNav — click search, focus glow, ⌘F shortcut, +/Settings hover
- [ ] Manual: scroll Home — hero parallax visible; hover Carousel cards — tilt + glare follow pointer
- [ ] Manual: Create / Rename Collection sheets, IconPicker, Rename Wallpaper — new chrome appears, keyboard shortcuts work

🤖 Generated with [Claude Code](https://claude.com/claude-code)