### PR TITLE
Liquid Glass — 2026 Apple design language polyfill

### DIFF
--- a/src/Wallnetic/Views/Components/DesignTokens.swift
+++ b/src/Wallnetic/Views/Components/DesignTokens.swift
@@ -1,0 +1,102 @@
+import SwiftUI
+
+// MARK: - Concentric Radius Scale
+//
+// Apple's 2026 system: nested corners follow `inner = outer - inset` so
+// the curvature stays parallel. Pick one outer value, then derive the rest
+// from the padding you add. These constants codify the chain we use.
+
+enum Radius {
+    /// Window edge — top of the chain.
+    static let window: CGFloat = 18
+    /// Floating panels (sheets, floating toolbars, HUDs).
+    static let panel: CGFloat = 16
+    /// Cards (hero, carousel, grid).
+    static let card: CGFloat = 12
+    /// Controls (buttons, fields, chips).
+    static let control: CGFloat = 10
+    /// Tags / capsules.
+    static let tag: CGFloat = 8
+    /// Inner accents (selection rings, dots).
+    static let accent: CGFloat = 6
+
+    /// Compute inner radius from a containing outer radius and the inset
+    /// between them. Clamped to a minimum of `Radius.accent` so the inner
+    /// never degenerates to a sharp corner.
+    static func nested(in outer: CGFloat, inset: CGFloat) -> CGFloat {
+        max(accent, outer - inset)
+    }
+}
+
+// MARK: - Spacing Scale
+//
+// 4-pt grid. Use the named values; never sprinkle raw numbers.
+
+enum Space {
+    static let micro: CGFloat = 2
+    static let xxs: CGFloat = 4
+    static let xs: CGFloat = 8
+    static let sm: CGFloat = 12
+    static let md: CGFloat = 16
+    static let lg: CGFloat = 20
+    static let xl: CGFloat = 28
+    static let xxl: CGFloat = 40
+}
+
+// MARK: - Typography Scale
+//
+// 2026 SF Pro with explicit tracking. Use these instead of inline
+// `.font(.system(...))` so the type voice stays consistent across the app.
+
+enum Typo {
+    // Display — hero titles, single-line, dramatic
+    static let display: Font = .system(size: 34, weight: .bold, design: .rounded)
+    static let displayTracking: CGFloat = -0.6
+
+    // Title 1 — section heroes, sheet headers
+    static let title1: Font = .system(size: 22, weight: .bold, design: .rounded)
+    static let title1Tracking: CGFloat = -0.4
+
+    // Title 2 — group titles
+    static let title2: Font = .system(size: 17, weight: .semibold, design: .rounded)
+    static let title2Tracking: CGFloat = -0.2
+
+    // Body
+    static let body: Font = .system(size: 13, weight: .regular)
+    static let bodyTracking: CGFloat = 0
+
+    // Caption
+    static let caption: Font = .system(size: 11, weight: .medium)
+    static let captionTracking: CGFloat = 0.1
+
+    // Kicker — uppercase monospaced labels (e.g. "01 · IMPORT")
+    static let kicker: Font = .system(size: 9, weight: .heavy, design: .monospaced)
+    static let kickerTracking: CGFloat = 2.5
+
+    // Data — numbers, paths, dimensions
+    static let data: Font = .system(size: 11, weight: .medium, design: .monospaced)
+    static let dataTracking: CGFloat = 0.2
+
+    // Button label
+    static let button: Font = .system(size: 13, weight: .semibold, design: .rounded)
+    static let buttonTracking: CGFloat = 0.3
+}
+
+// MARK: - Reusable Text Styles
+
+extension Text {
+    func styledKicker(color: Color = .white.opacity(0.4)) -> some View {
+        self
+            .font(Typo.kicker)
+            .tracking(Typo.kickerTracking)
+            .foregroundColor(color)
+            .textCase(.uppercase)
+    }
+
+    func styledData(color: Color = .white.opacity(0.5)) -> some View {
+        self
+            .font(Typo.data)
+            .tracking(Typo.dataTracking)
+            .foregroundColor(color)
+    }
+}

--- a/src/Wallnetic/Views/Components/LiquidGlass.swift
+++ b/src/Wallnetic/Views/Components/LiquidGlass.swift
@@ -1,0 +1,162 @@
+import SwiftUI
+
+// MARK: - Liquid Glass Material (2026 polyfill)
+//
+// Captures the visual language of macOS 26's "Liquid Glass" without the
+// `glassEffect()` API (which requires macOS 26+, while we target macOS 13+).
+//
+// The illusion is built from four stable layers:
+//   1. `.regularMaterial` — content blur (the actual translucent base)
+//   2. **Accent tint** — a soft overlay that pulls the chrome toward the
+//      current accent color (acts like the refractive color cast of glass
+//      bending light from underlying content)
+//   3. **Lensing strokes** — bright top-inner stroke + dim bottom-inner
+//      stroke, simulating how real glass catches and absorbs light
+//   4. **Multi-layer shadow** — close ambient + far drop, gives the panel
+//      real spatial depth
+//
+// Always paired with a `.continuous`-style RoundedRectangle so the shape
+// language stays squircle.
+
+struct LiquidGlassStyle {
+    var radius: CGFloat = Radius.panel
+    var accent: Color = .accentColor
+    var accentStrength: Double = 0.10       // 0 = pure neutral glass, 1 = strong tint
+    var tone: Tone = .standard
+
+    enum Tone {
+        /// Default — slightly darker than ultraThin; sits over content.
+        case standard
+        /// Floating chrome (toolbars, HUDs) — denser, more legible.
+        case prominent
+        /// Inline controls (buttons, chips) — thin, accent-led.
+        case control
+    }
+
+    fileprivate var baseFill: Color {
+        switch tone {
+        case .standard:  return Color.black.opacity(0.18)
+        case .prominent: return Color.black.opacity(0.32)
+        case .control:   return Color.white.opacity(0.05)
+        }
+    }
+
+    fileprivate var topStroke: Color { .white.opacity(0.16) }
+    fileprivate var bottomStroke: Color { .black.opacity(0.32) }
+    fileprivate var innerHighlight: Color { .white.opacity(0.06) }
+    fileprivate var ambientShadow: Color {
+        switch tone {
+        case .prominent: return .black.opacity(0.35)
+        case .standard:  return .black.opacity(0.25)
+        case .control:   return .black.opacity(0.15)
+        }
+    }
+
+    fileprivate var dropShadow: Color { accent.opacity(0.22 * accentStrength + 0.10) }
+}
+
+extension View {
+    /// Wraps the view in a Liquid Glass panel.
+    func liquidGlass(_ style: LiquidGlassStyle = LiquidGlassStyle()) -> some View {
+        modifier(LiquidGlassModifier(style: style))
+    }
+}
+
+private struct LiquidGlassModifier: ViewModifier {
+    let style: LiquidGlassStyle
+
+    func body(content: Content) -> some View {
+        content
+            .background(
+                ZStack {
+                    // 1) Material blur
+                    RoundedRectangle(cornerRadius: style.radius, style: .continuous)
+                        .fill(.regularMaterial)
+
+                    // 2) Base tint
+                    RoundedRectangle(cornerRadius: style.radius, style: .continuous)
+                        .fill(style.baseFill)
+
+                    // 3) Accent tint
+                    RoundedRectangle(cornerRadius: style.radius, style: .continuous)
+                        .fill(LinearGradient(
+                            colors: [
+                                style.accent.opacity(0.20 * style.accentStrength),
+                                .clear,
+                                style.accent.opacity(0.08 * style.accentStrength)
+                            ],
+                            startPoint: .topLeading, endPoint: .bottomTrailing
+                        ))
+                        .blendMode(.plusLighter)
+                }
+            )
+            .overlay(
+                // Lensing strokes — top bright, bottom dim, fading around
+                RoundedRectangle(cornerRadius: style.radius, style: .continuous)
+                    .strokeBorder(
+                        LinearGradient(
+                            stops: [
+                                .init(color: style.topStroke, location: 0),
+                                .init(color: style.topStroke.opacity(0.3), location: 0.45),
+                                .init(color: style.bottomStroke.opacity(0.55), location: 0.55),
+                                .init(color: style.bottomStroke, location: 1)
+                            ],
+                            startPoint: .top, endPoint: .bottom
+                        ),
+                        lineWidth: 0.75
+                    )
+            )
+            .overlay(
+                // Inner highlight ring — refraction simulation
+                RoundedRectangle(cornerRadius: max(2, style.radius - 1), style: .continuous)
+                    .stroke(style.innerHighlight, lineWidth: 0.5)
+                    .padding(0.75)
+                    .blendMode(.plusLighter)
+                    .allowsHitTesting(false)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: style.radius, style: .continuous))
+            // 4) Multi-layer shadows — ambient close + accent drop far
+            .shadow(color: style.ambientShadow, radius: 6, x: 0, y: 2)
+            .shadow(color: style.dropShadow, radius: 28, x: 0, y: 14)
+    }
+}
+
+// MARK: - Liquid Glass HUD (floating)
+//
+// Used for toolbars / detached panels: same body but with a stronger
+// shadow and prominent tone preset.
+
+extension View {
+    func liquidGlassHUD(radius: CGFloat = Radius.panel, accent: Color = .accentColor) -> some View {
+        self.liquidGlass(LiquidGlassStyle(radius: radius, accent: accent, accentStrength: 0.18, tone: .prominent))
+    }
+
+    func liquidGlassControl(radius: CGFloat = Radius.control, accent: Color = .accentColor, accentStrength: Double = 0.0) -> some View {
+        self.liquidGlass(LiquidGlassStyle(radius: radius, accent: accent, accentStrength: accentStrength, tone: .control))
+    }
+}
+
+// MARK: - Refractive Border (standalone)
+//
+// Apply directly to existing shapes that already have their own
+// background (e.g. images) to add a glass-like edge highlight without
+// rebuilding the body.
+
+extension View {
+    func refractiveBorder(radius: CGFloat, accent: Color = .accentColor, isActive: Bool = false) -> some View {
+        self.overlay(
+            RoundedRectangle(cornerRadius: radius, style: .continuous)
+                .strokeBorder(
+                    LinearGradient(
+                        stops: [
+                            .init(color: isActive ? accent.opacity(0.7) : .white.opacity(0.18), location: 0),
+                            .init(color: .white.opacity(0.05), location: 0.5),
+                            .init(color: isActive ? accent.opacity(0.4) : .black.opacity(0.3), location: 1)
+                        ],
+                        startPoint: .topLeading, endPoint: .bottomTrailing
+                    ),
+                    lineWidth: isActive ? 1 : 0.6
+                )
+        )
+    }
+}

--- a/src/Wallnetic/Views/Components/WallneticButton.swift
+++ b/src/Wallnetic/Views/Components/WallneticButton.swift
@@ -1,13 +1,13 @@
 import SwiftUI
 
-/// Wallnetic's signature buttons. Used in sheets, onboarding, and any
-/// place a plain SwiftUI `.borderedProminent` would otherwise leak macOS
-/// chrome into the dark cinematic surfaces.
+/// 2026 Liquid Glass button family. Replaces SwiftUI's `.borderedProminent`
+/// which leaks system chrome into our dark cinematic surfaces.
 ///
 /// Three tiers:
-///  * `.primary`   — accent-glow CTA (one per surface ideally)
-///  * `.ghost`     — translucent secondary action
-///  * `.cancel`    — minimal, no chrome
+///  * `.primary`   — accent gradient + inner highlight stroke + soft glow.
+///                   One per surface; bound to ⌘↩.
+///  * `.ghost`     — liquid-glass capsule with neutral tint.
+///  * `.cancel`    — chromeless minimal; bound to ⎋.
 enum WallneticButton {
     static func primary(
         _ title: String,
@@ -17,17 +17,17 @@ enum WallneticButton {
         action: @escaping () -> Void
     ) -> some View {
         Button(action: action) {
-            HStack(spacing: 8) {
+            HStack(spacing: Space.xs) {
                 if let icon {
                     Image(systemName: icon)
                         .font(.system(size: 11, weight: .semibold))
                 }
                 Text(title)
-                    .font(.system(size: 13, weight: .semibold, design: .rounded))
-                    .tracking(0.3)
+                    .font(Typo.button)
+                    .tracking(Typo.buttonTracking)
             }
         }
-        .buttonStyle(WallneticPrimaryButtonStyle(accent: accent, isEnabled: isEnabled))
+        .buttonStyle(LiquidPrimaryButtonStyle(accent: accent, isEnabled: isEnabled))
         .disabled(!isEnabled)
         .keyboardShortcut(.return)
     }
@@ -38,7 +38,7 @@ enum WallneticButton {
         action: @escaping () -> Void
     ) -> some View {
         Button(action: action) {
-            HStack(spacing: 6) {
+            HStack(spacing: Space.xxs + 2) {
                 if let icon {
                     Image(systemName: icon)
                         .font(.system(size: 11))
@@ -47,7 +47,7 @@ enum WallneticButton {
                     .font(.system(size: 13, weight: .medium))
             }
         }
-        .buttonStyle(WallneticGhostButtonStyle())
+        .buttonStyle(LiquidGhostButtonStyle())
     }
 
     static func cancel(
@@ -64,53 +64,69 @@ enum WallneticButton {
     }
 }
 
-// MARK: - Primary (Accent Glow)
+// MARK: - Primary (Liquid Glass + accent)
 
-private struct WallneticPrimaryButtonStyle: ButtonStyle {
+private struct LiquidPrimaryButtonStyle: ButtonStyle {
     let accent: Color
     let isEnabled: Bool
 
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .foregroundColor(isEnabled ? .black : .white.opacity(0.35))
-            .padding(.horizontal, 18)
-            .padding(.vertical, 9)
+            .padding(.horizontal, Space.lg)
+            .padding(.vertical, 10)
             .background(
                 ZStack {
-                    Capsule()
+                    Capsule(style: .continuous)
                         .fill(isEnabled
                               ? AnyShapeStyle(LinearGradient(
-                                    colors: [accent, accent.opacity(0.85)],
+                                    colors: [accent, accent.opacity(0.75)],
                                     startPoint: .topLeading, endPoint: .bottomTrailing))
                               : AnyShapeStyle(Color.white.opacity(0.06)))
-                    Capsule()
-                        .stroke(isEnabled ? accent.opacity(0.55) : .white.opacity(0.08), lineWidth: 0.5)
+
+                    // Top inner highlight — light catching the lens edge
+                    Capsule(style: .continuous)
+                        .strokeBorder(LinearGradient(
+                            stops: [
+                                .init(color: .white.opacity(isEnabled ? 0.55 : 0.10), location: 0),
+                                .init(color: .white.opacity(0), location: 0.55),
+                                .init(color: .black.opacity(isEnabled ? 0.20 : 0.05), location: 1)
+                            ],
+                            startPoint: .top, endPoint: .bottom
+                        ), lineWidth: 0.75)
                 }
             )
             .shadow(
-                color: isEnabled ? accent.opacity(configuration.isPressed ? 0.15 : 0.45) : .clear,
-                radius: configuration.isPressed ? 4 : 10,
-                y: configuration.isPressed ? 1 : 4
+                color: isEnabled ? accent.opacity(configuration.isPressed ? 0.20 : 0.55) : .clear,
+                radius: configuration.isPressed ? 4 : 12,
+                y: configuration.isPressed ? 1 : 5
             )
             .scaleEffect(configuration.isPressed ? 0.97 : 1.0)
             .animation(.easeOut(duration: 0.12), value: configuration.isPressed)
     }
 }
 
-// MARK: - Ghost (Glass Secondary)
+// MARK: - Ghost (Liquid Glass neutral)
 
-private struct WallneticGhostButtonStyle: ButtonStyle {
+private struct LiquidGhostButtonStyle: ButtonStyle {
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .foregroundColor(.white.opacity(0.85))
-            .padding(.horizontal, 16)
+            .padding(.horizontal, Space.md)
             .padding(.vertical, 9)
             .background(
                 ZStack {
-                    Capsule()
-                        .fill(Color.white.opacity(configuration.isPressed ? 0.05 : 0.08))
-                    Capsule()
-                        .stroke(Color.white.opacity(0.18), lineWidth: 0.5)
+                    Capsule(style: .continuous)
+                        .fill(Color.white.opacity(configuration.isPressed ? 0.06 : 0.09))
+                    Capsule(style: .continuous)
+                        .strokeBorder(LinearGradient(
+                            stops: [
+                                .init(color: .white.opacity(0.20), location: 0),
+                                .init(color: .white.opacity(0.05), location: 0.5),
+                                .init(color: .black.opacity(0.25), location: 1)
+                            ],
+                            startPoint: .top, endPoint: .bottom
+                        ), lineWidth: 0.6)
                 }
             )
             .scaleEffect(configuration.isPressed ? 0.97 : 1.0)
@@ -118,10 +134,9 @@ private struct WallneticGhostButtonStyle: ButtonStyle {
     }
 }
 
-// MARK: - Wallnetic Text Field
+// MARK: - Liquid Glass Text Field
 
-/// Dark glass text field — replaces `.textFieldStyle(.roundedBorder)` which
-/// renders macOS chrome.
+/// Replaces `.textFieldStyle(.roundedBorder)` which renders macOS chrome.
 struct WallneticTextField: View {
     let placeholder: String
     @Binding var text: String
@@ -132,33 +147,37 @@ struct WallneticTextField: View {
     @FocusState private var focused: Bool
 
     var body: some View {
-        HStack(spacing: 10) {
+        HStack(spacing: Space.xs + 2) {
             if let icon {
                 Image(systemName: icon)
                     .font(.system(size: 11, weight: .medium))
-                    .foregroundColor(.white.opacity(0.4))
+                    .foregroundColor(focused ? accent : .white.opacity(0.4))
             }
             TextField("", text: $text, prompt: Text(placeholder).foregroundColor(.white.opacity(0.3)))
                 .textFieldStyle(.plain)
                 .foregroundColor(.white)
-                .font(.system(size: 13))
+                .font(Typo.body)
                 .focused($focused)
                 .onSubmit { onSubmit?() }
         }
-        .padding(.horizontal, 12)
+        .padding(.horizontal, Space.sm)
         .padding(.vertical, 10)
         .background(
             ZStack {
-                RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .fill(Color.white.opacity(focused ? 0.07 : 0.04))
-                RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .stroke(
-                        focused ? accent.opacity(0.5) : Color.white.opacity(0.1),
-                        lineWidth: focused ? 1 : 0.5
-                    )
+                RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
+                    .fill(Color.white.opacity(focused ? 0.08 : 0.04))
+                RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
+                    .strokeBorder(LinearGradient(
+                        stops: [
+                            .init(color: focused ? accent.opacity(0.55) : .white.opacity(0.18), location: 0),
+                            .init(color: focused ? accent.opacity(0.25) : .white.opacity(0.04), location: 0.5),
+                            .init(color: focused ? accent.opacity(0.45) : .black.opacity(0.3), location: 1)
+                        ],
+                        startPoint: .top, endPoint: .bottom
+                    ), lineWidth: focused ? 1 : 0.6)
             }
         )
-        .shadow(color: focused ? accent.opacity(0.25) : .clear, radius: focused ? 6 : 0)
-        .animation(.easeOut(duration: 0.15), value: focused)
+        .shadow(color: focused ? accent.opacity(0.35) : .clear, radius: focused ? 10 : 0, y: focused ? 4 : 0)
+        .animation(.easeOut(duration: 0.16), value: focused)
     }
 }

--- a/src/Wallnetic/Views/Components/WallneticSheet.swift
+++ b/src/Wallnetic/Views/Components/WallneticSheet.swift
@@ -1,17 +1,17 @@
 import SwiftUI
 
-/// Cinematic-dark sheet chrome used by every modal across Wallnetic.
-/// Replaces SwiftUI's default sheet look (white background, system chrome)
-/// with the app's signature: deep navy gradient + ultraThinMaterial veil +
-/// hairline accent border + soft neon corner glow.
+/// 2026 Liquid Glass sheet chrome. Uses the `LiquidGlass` primitive for
+/// the actual surface (refractive edges, multi-layer shadow, accent
+/// tint), and applies concentric inner radii to anything nested inside.
 ///
 /// Usage:
 ///
 ///     .sheet(isPresented: $showing) {
-///         WallneticSheet(title: "Rename Collection", icon: "folder.fill") {
+///         WallneticSheet(title: "Rename", icon: "pencil") {
 ///             // content
 ///         } footer: {
 ///             WallneticButton.cancel { dismiss() }
+///             Spacer()
 ///             WallneticButton.primary("Save", isEnabled: canSave) { commit() }
 ///         }
 ///     }
@@ -19,72 +19,75 @@ struct WallneticSheet<Content: View, Footer: View>: View {
     let title: String
     var icon: String? = nil
     var accent: Color = .accentColor
-    var width: CGFloat = 360
+    var width: CGFloat = 380
     @ViewBuilder let content: () -> Content
     @ViewBuilder let footer: () -> Footer
 
     var body: some View {
         VStack(spacing: 0) {
             header
-            Divider()
-                .overlay(LinearGradient(
-                    colors: [.clear, accent.opacity(0.35), .clear],
-                    startPoint: .leading, endPoint: .trailing
-                ))
-                .frame(height: 0.5)
+            divider
 
-            VStack(alignment: .leading, spacing: 16) {
+            VStack(alignment: .leading, spacing: Space.md) {
                 content()
             }
-            .padding(.horizontal, 24)
-            .padding(.vertical, 20)
+            .padding(.horizontal, Space.lg)
+            .padding(.vertical, Space.md)
 
-            HStack(spacing: 10) {
+            HStack(spacing: Space.xs) {
                 footer()
             }
-            .padding(.horizontal, 24)
-            .padding(.bottom, 20)
+            .padding(.horizontal, Space.lg)
+            .padding(.bottom, Space.md)
         }
         .frame(width: width)
-        .background(WallneticSheetBackground(accent: accent))
-        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
-        .overlay(
-            RoundedRectangle(cornerRadius: 16, style: .continuous)
-                .stroke(LinearGradient(
-                    colors: [accent.opacity(0.35), .white.opacity(0.06), accent.opacity(0.15)],
-                    startPoint: .topLeading, endPoint: .bottomTrailing
-                ), lineWidth: 0.5)
-        )
-        .shadow(color: accent.opacity(0.25), radius: 28, x: 0, y: 12)
-        .shadow(color: .black.opacity(0.55), radius: 14, x: 0, y: 4)
+        .liquidGlass(LiquidGlassStyle(
+            radius: Radius.panel,
+            accent: accent,
+            accentStrength: 0.14,
+            tone: .prominent
+        ))
         .preferredColorScheme(.dark)
     }
 
+    // MARK: - Header
+
     private var header: some View {
-        HStack(spacing: 12) {
+        HStack(spacing: Space.sm) {
             if let icon {
                 ZStack {
                     Circle()
-                        .fill(accent.opacity(0.18))
-                        .frame(width: 30, height: 30)
+                        .fill(accent.opacity(0.20))
+                    Circle()
+                        .strokeBorder(accent.opacity(0.4), lineWidth: 0.5)
                     Image(systemName: icon)
-                        .font(.system(size: 13, weight: .semibold))
+                        .font(.system(size: 12, weight: .semibold))
                         .foregroundStyle(accent)
-                        .shadow(color: accent.opacity(0.7), radius: 4)
+                        .shadow(color: accent.opacity(0.75), radius: 4)
                 }
+                .frame(width: 30, height: 30)
             }
 
-            VStack(alignment: .leading, spacing: 2) {
-                Text(title)
-                    .font(.system(size: 14, weight: .bold, design: .rounded))
-                    .foregroundColor(.white)
-                    .tracking(0.2)
-            }
+            Text(title)
+                .font(Typo.title2)
+                .tracking(Typo.title2Tracking)
+                .foregroundColor(.white)
 
             Spacer()
         }
-        .padding(.horizontal, 24)
-        .padding(.vertical, 16)
+        .padding(.horizontal, Space.lg)
+        .padding(.vertical, Space.md)
+    }
+
+    // MARK: - Divider (gradient hairline)
+
+    private var divider: some View {
+        Rectangle()
+            .fill(LinearGradient(
+                colors: [.clear, accent.opacity(0.35), .clear],
+                startPoint: .leading, endPoint: .trailing
+            ))
+            .frame(height: 0.5)
     }
 }
 
@@ -94,7 +97,7 @@ extension WallneticSheet where Footer == EmptyView {
         title: String,
         icon: String? = nil,
         accent: Color = .accentColor,
-        width: CGFloat = 360,
+        width: CGFloat = 380,
         @ViewBuilder content: @escaping () -> Content
     ) {
         self.title = title
@@ -103,72 +106,5 @@ extension WallneticSheet where Footer == EmptyView {
         self.width = width
         self.content = content
         self.footer = { EmptyView() }
-    }
-}
-
-// MARK: - Background
-
-private struct WallneticSheetBackground: View {
-    let accent: Color
-
-    var body: some View {
-        ZStack {
-            // Deep base
-            Color(red: 0.04, green: 0.05, blue: 0.09)
-
-            // Subtle radial top-left tint
-            RadialGradient(
-                colors: [accent.opacity(0.16), .clear],
-                center: .topLeading,
-                startRadius: 5,
-                endRadius: 240
-            )
-
-            // Bottom-right vignette
-            RadialGradient(
-                colors: [Color(red: 0.10, green: 0.06, blue: 0.16).opacity(0.55), .clear],
-                center: .bottomTrailing,
-                startRadius: 5,
-                endRadius: 260
-            )
-
-            // Glass veil
-            Rectangle()
-                .fill(.ultraThinMaterial)
-                .opacity(0.20)
-
-            // Grain (CoreImage noise via blendmode)
-            WallneticGrain()
-                .opacity(0.05)
-                .blendMode(.overlay)
-                .allowsHitTesting(false)
-        }
-    }
-}
-
-/// Static stochastic grain — tiles a tiny pseudo-random pattern via
-/// Canvas. Cheap to render once per sheet appearance.
-private struct WallneticGrain: View {
-    var body: some View {
-        Canvas { ctx, size in
-            // Coarse blue-noise approximation: 600 dots, deterministic seed.
-            var rng = SeedableRNG(seed: 1337)
-            for _ in 0..<600 {
-                let x = Double(rng.nextUInt() % UInt32(size.width))
-                let y = Double(rng.nextUInt() % UInt32(size.height))
-                let a = 0.04 + Double(rng.nextUInt() % 60) / 1000
-                let rect = CGRect(x: x, y: y, width: 1, height: 1)
-                ctx.fill(Path(rect), with: .color(.white.opacity(a)))
-            }
-        }
-    }
-
-    struct SeedableRNG {
-        var state: UInt32
-        init(seed: UInt32) { state = seed | 1 }
-        mutating func nextUInt() -> UInt32 {
-            state = state &* 1664525 &+ 1013904223
-            return state
-        }
     }
 }

--- a/src/Wallnetic/Views/Main/HomeView.swift
+++ b/src/Wallnetic/Views/Main/HomeView.swift
@@ -132,11 +132,12 @@ struct HomeView: View {
     private func heroInfo(_ wp: Wallpaper, wallpapers: [Wallpaper]) -> some View {
         VStack(alignment: .leading, spacing: 14) {
             Text(wp.name)
-                .font(.system(size: 34, weight: .bold, design: .rounded))
+                .font(Typo.display)
+                .tracking(Typo.displayTracking)
                 .foregroundColor(.white)
                 .lineLimit(2)
                 .truncationMode(.tail)
-                .shadow(color: .black.opacity(0.5), radius: 8)
+                .shadow(color: .black.opacity(0.55), radius: 8, y: 2)
 
             // Metadata pills
             HStack(spacing: 8) {
@@ -161,48 +162,19 @@ struct HomeView: View {
             }
 
             // Action buttons
-            HStack(spacing: 10) {
-                // Play button with glow
-                Button {
+            HStack(spacing: Space.xs + 2) {
+                WallneticButton.primary("Use", icon: "play.fill", accent: .white) {
                     wallpaperManager.setWallpaper(wp)
-                } label: {
-                    HStack(spacing: 6) {
-                        Image(systemName: "play.fill")
-                        Text("Use")
-                            .fontWeight(.bold)
-                    }
-                    .font(.system(size: 14))
-                    .foregroundColor(.black)
-                    .padding(.horizontal, 24)
-                    .padding(.vertical, 10)
-                    .background(
-                        Capsule().fill(Color.white)
-                    )
                 }
-                .buttonStyle(.plain)
 
-                // My List button
-                Button {
+                WallneticButton.ghost(
+                    "My List",
+                    icon: wp.isFavorite ? "checkmark" : "plus"
+                ) {
                     withAnimation(.spring(response: Anim.medium, dampingFraction: 0.5)) {
                         wallpaperManager.toggleFavorite(wp)
                     }
-                } label: {
-                    HStack(spacing: 6) {
-                        Image(systemName: wp.isFavorite ? "checkmark" : "plus")
-                        Text("My List")
-                            .fontWeight(.semibold)
-                    }
-                    .font(.system(size: 14))
-                    .foregroundColor(.white)
-                    .padding(.horizontal, 20)
-                    .padding(.vertical, 10)
-                    .background(
-                        Capsule()
-                            .fill(Color.white.opacity(0.1))
-                            .overlay(Capsule().stroke(Color.white.opacity(0.2), lineWidth: 0.5))
-                    )
                 }
-                .buttonStyle(.plain)
 
                 Spacer()
 

--- a/src/Wallnetic/Views/Main/SettingsView.swift
+++ b/src/Wallnetic/Views/Main/SettingsView.swift
@@ -29,19 +29,18 @@ struct SettingsView: View {
 
     private var sidebar: some View {
         VStack(alignment: .leading, spacing: 0) {
-            HStack(spacing: 10) {
+            HStack(spacing: Space.xs + 2) {
                 Image(systemName: "gearshape.2.fill")
                     .font(.system(size: 14, weight: .semibold))
                     .foregroundColor(.accentColor)
+                    .shadow(color: .accentColor.opacity(0.55), radius: 5)
                 Text("SETTINGS")
-                    .font(.system(size: 10, weight: .heavy, design: .monospaced))
-                    .tracking(2.4)
-                    .foregroundColor(.white.opacity(0.45))
+                    .styledKicker(color: .white.opacity(0.55))
                 Spacer()
             }
-            .padding(.horizontal, 22)
-            .padding(.top, 24)
-            .padding(.bottom, 16)
+            .padding(.horizontal, Space.lg + 2)
+            .padding(.top, Space.lg + 4)
+            .padding(.bottom, Space.md)
 
             ScrollView(showsIndicators: false) {
                 VStack(alignment: .leading, spacing: 2) {
@@ -69,19 +68,43 @@ struct SettingsView: View {
             Spacer(minLength: 0)
 
             // Version badge
-            HStack(spacing: 6) {
+            HStack(spacing: Space.xxs + 2) {
                 Circle()
                     .fill(.green)
                     .frame(width: 5, height: 5)
-                    .shadow(color: .green.opacity(0.6), radius: 3)
+                    .shadow(color: .green.opacity(0.65), radius: 3)
                 Text("v\(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?")")
-                    .font(.system(size: 10, weight: .medium, design: .monospaced))
-                    .foregroundColor(.white.opacity(0.45))
+                    .styledData(color: .white.opacity(0.5))
+                Spacer()
+                Image(systemName: "lock.shield.fill")
+                    .font(.system(size: 9))
+                    .foregroundColor(.white.opacity(0.3))
             }
-            .padding(.horizontal, 22)
-            .padding(.bottom, 18)
+            .padding(.horizontal, Space.lg + 2)
+            .padding(.bottom, Space.md + 2)
         }
-        .frame(width: 220)
+        .frame(width: 224)
+        .background(
+            // Translucent over content — Liquid Glass sidebar
+            ZStack {
+                Rectangle().fill(.ultraThinMaterial)
+                Rectangle().fill(Color.black.opacity(0.32))
+                // Inner accent wash
+                LinearGradient(
+                    colors: [Color.accentColor.opacity(0.08), .clear],
+                    startPoint: .topLeading, endPoint: .center
+                )
+            }
+        )
+        .overlay(alignment: .trailing) {
+            // Right-edge refractive hairline
+            Rectangle()
+                .fill(LinearGradient(
+                    colors: [.white.opacity(0.04), .white.opacity(0.12), .white.opacity(0.04)],
+                    startPoint: .top, endPoint: .bottom
+                ))
+                .frame(width: 0.5)
+        }
     }
 
     // MARK: - Detail Pane
@@ -229,19 +252,27 @@ private struct SidebarRow: View {
 
     var body: some View {
         Button(action: action) {
-            HStack(spacing: 10) {
-                Image(systemName: section.icon)
-                    .font(.system(size: 11, weight: .semibold))
-                    .foregroundColor(isSelected ? section.accent : .white.opacity(hover ? 0.7 : 0.45))
-                    .frame(width: 22, height: 22)
-                    .background(
-                        RoundedRectangle(cornerRadius: 6)
-                            .fill(isSelected ? section.accent.opacity(0.18) : Color.clear)
-                    )
+            HStack(spacing: Space.xs + 2) {
+                ZStack {
+                    if isSelected {
+                        RoundedRectangle(cornerRadius: Radius.accent, style: .continuous)
+                            .fill(section.accent.opacity(0.22))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: Radius.accent, style: .continuous)
+                                    .strokeBorder(section.accent.opacity(0.4), lineWidth: 0.5)
+                            )
+                            .shadow(color: section.accent.opacity(0.45), radius: 4)
+                    }
+                    Image(systemName: section.icon)
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundColor(isSelected ? .white : .white.opacity(hover ? 0.75 : 0.45))
+                }
+                .frame(width: 22, height: 22)
 
                 Text(section.title)
                     .font(.system(size: 12, weight: isSelected ? .semibold : .medium))
                     .foregroundColor(isSelected ? .white : .white.opacity(hover ? 0.85 : 0.6))
+                    .tracking(isSelected ? 0.2 : 0)
 
                 Spacer()
 
@@ -249,17 +280,30 @@ private struct SidebarRow: View {
                     Circle()
                         .fill(section.accent)
                         .frame(width: 4, height: 4)
-                        .shadow(color: section.accent.opacity(0.7), radius: 3)
+                        .shadow(color: section.accent.opacity(0.8), radius: 4)
                 }
             }
-            .padding(.horizontal, 10)
-            .padding(.vertical, 7)
+            .padding(.horizontal, Space.sm - 2)
+            .padding(.vertical, Space.xs - 1)
             .background(
-                RoundedRectangle(cornerRadius: 8)
-                    .fill(isSelected ? Color.white.opacity(0.06) : (hover ? Color.white.opacity(0.03) : .clear))
+                ZStack {
+                    if isSelected {
+                        RoundedRectangle(cornerRadius: Radius.tag, style: .continuous)
+                            .fill(Color.white.opacity(0.07))
+                        RoundedRectangle(cornerRadius: Radius.tag, style: .continuous)
+                            .strokeBorder(LinearGradient(
+                                colors: [.white.opacity(0.16), .white.opacity(0.02)],
+                                startPoint: .top, endPoint: .bottom
+                            ), lineWidth: 0.5)
+                    } else if hover {
+                        RoundedRectangle(cornerRadius: Radius.tag, style: .continuous)
+                            .fill(Color.white.opacity(0.04))
+                    }
+                }
             )
         }
         .buttonStyle(.plain)
+        .contentShape(Rectangle())
         .onHover { hover = $0 }
         .animation(.easeOut(duration: 0.12), value: hover)
         .animation(.easeOut(duration: 0.18), value: isSelected)

--- a/src/Wallnetic/Views/Main/TopNavigationBar.swift
+++ b/src/Wallnetic/Views/Main/TopNavigationBar.swift
@@ -90,33 +90,11 @@ struct TopNavigationBar: View {
                 }
             }
         }
-        .padding(.horizontal, 18)
-        .padding(.vertical, 9)
-        .background(navBackground)
-        .overlay(alignment: .bottom) {
-            Rectangle()
-                .fill(
-                    LinearGradient(
-                        colors: [.clear, .accentColor.opacity(isScrolled ? 0.25 : 0.05), .clear],
-                        startPoint: .leading, endPoint: .trailing
-                    )
-                )
-                .frame(height: 0.5)
-        }
-    }
-
-    // MARK: - Background
-
-    private var navBackground: some View {
-        ZStack {
-            // Frosted glass — stronger when content scrolls under
-            Rectangle()
-                .fill(.ultraThinMaterial)
-                .opacity(isScrolled ? 0.85 : 0.5)
-            // Dark tint underneath material so it never goes light
-            Color.black.opacity(isScrolled ? 0.35 : 0.18)
-        }
-        .animation(.easeInOut(duration: Anim.medium), value: isScrolled)
+        .padding(.horizontal, Space.md)
+        .padding(.vertical, Space.xs + 2)
+        .liquidGlassHUD(radius: Radius.panel, accent: .accentColor)
+        .padding(.horizontal, Space.sm)
+        .padding(.top, Space.xs)
     }
 
     // MARK: - Tab Button
@@ -255,26 +233,34 @@ private struct ActionChip: View {
         Image(systemName: icon)
             .font(.system(size: 11, weight: .semibold))
             .foregroundColor(.white.opacity(hover ? 1.0 : 0.75))
-            .frame(width: 28, height: 28)
+            .frame(width: 30, height: 30)
             .background(
                 ZStack {
-                    Circle().fill(
-                        accent && hover
-                            ? AnyShapeStyle(LinearGradient(
-                                colors: [Color.accentColor.opacity(0.4), Color.accentColor.opacity(0.18)],
-                                startPoint: .topLeading, endPoint: .bottomTrailing))
-                            : AnyShapeStyle(Color.white.opacity(hover ? 0.12 : 0.06))
-                    )
-                    Circle().stroke(
-                        accent && hover ? Color.accentColor.opacity(0.55) : Color.white.opacity(0.12),
-                        lineWidth: 0.5
-                    )
+                    Circle()
+                        .fill(
+                            accent && hover
+                                ? AnyShapeStyle(LinearGradient(
+                                    colors: [Color.accentColor.opacity(0.55), Color.accentColor.opacity(0.2)],
+                                    startPoint: .topLeading, endPoint: .bottomTrailing))
+                                : AnyShapeStyle(Color.white.opacity(hover ? 0.10 : 0.05))
+                        )
+                    // Refractive stroke
+                    Circle()
+                        .strokeBorder(LinearGradient(
+                            stops: [
+                                .init(color: accent && hover ? Color.accentColor.opacity(0.75) : Color.white.opacity(0.22), location: 0),
+                                .init(color: .white.opacity(0.04), location: 0.55),
+                                .init(color: .black.opacity(0.30), location: 1)
+                            ],
+                            startPoint: .top, endPoint: .bottom
+                        ), lineWidth: 0.75)
                 }
             )
             .shadow(
-                color: accent && hover ? Color.accentColor.opacity(0.45) : .clear,
-                radius: 8
+                color: accent && hover ? Color.accentColor.opacity(0.55) : .clear,
+                radius: 12, y: 4
             )
+            .scaleEffect(hover ? 1.04 : 1.0)
             .onHover { hover = $0 }
             .animation(.easeOut(duration: Anim.normal), value: hover)
     }

--- a/src/Wallnetic/Views/Main/WallpaperGridView.swift
+++ b/src/Wallnetic/Views/Main/WallpaperGridView.swift
@@ -382,32 +382,41 @@ struct SelectedWallpaperBar: View {
     let wallpaper: Wallpaper
 
     var body: some View {
-        HStack {
-            // Preview thumbnail
-            AsyncThumbnailView(wallpaper: wallpaper, size: CGSize(width: 80, height: 45))
-                .cornerRadius(4)
+        HStack(spacing: Space.sm) {
+            AsyncThumbnailView(
+                wallpaper: wallpaper,
+                size: CGSize(width: 84, height: 47),
+                cornerRadius: Radius.tag
+            )
+            .refractiveBorder(radius: Radius.tag)
 
-            VStack(alignment: .leading) {
+            VStack(alignment: .leading, spacing: 2) {
                 Text(wallpaper.displayName)
-                    .fontWeight(.medium)
-                Text("\(wallpaper.formattedResolution) • \(wallpaper.formattedDuration)")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
+                    .font(.system(size: 13, weight: .semibold, design: .rounded))
+                    .foregroundColor(.white)
+                    .tracking(-0.1)
+                    .lineLimit(1)
+                HStack(spacing: 6) {
+                    Text(wallpaper.formattedResolution)
+                    Text("·").foregroundColor(.white.opacity(0.2))
+                    Text(wallpaper.formattedDuration)
+                }
+                .font(Typo.data)
+                .tracking(Typo.dataTracking)
+                .foregroundColor(.white.opacity(0.5))
             }
 
             Spacer()
 
-            // Apply button
-            Button {
+            WallneticButton.primary("Apply", icon: "play.fill") {
                 wallpaperManager.setWallpaper(wallpaper)
-            } label: {
-                Text("Apply Wallpaper")
             }
-            .buttonStyle(.borderedProminent)
-            .controlSize(.large)
         }
-        .padding()
-        .background(.bar)
+        .padding(.horizontal, Space.md)
+        .padding(.vertical, Space.sm)
+        .liquidGlassHUD(radius: Radius.panel)
+        .padding(.horizontal, Space.md)
+        .padding(.bottom, Space.sm)
     }
 }
 

--- a/src/Wallnetic/Wallnetic.xcodeproj/project.pbxproj
+++ b/src/Wallnetic/Wallnetic.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		61B1EC0DBC85801311FA1F2F /* MenuBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B106464A071BF6E736C3272 /* MenuBarView.swift */; };
 		61B8431DE4EA724F4E55C7B2 /* OllamaVisionTagger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FD3DFBD42A5D9B294784C5F /* OllamaVisionTagger.swift */; };
 		6A650CD75C4B32AB9889A6A7 /* SharedWidgetModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDFCAB2A636011BB543DD1B5 /* SharedWidgetModels.swift */; };
+		6ACA2AC7AD0702CFEFA50E1B /* DesignTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFF460340111975F4DA40C32 /* DesignTokens.swift */; };
 		6ADBCB967C34EB7B36825043 /* WallpaperMetadataCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 941B25667F75E00393C7E895 /* WallpaperMetadataCacheTests.swift */; };
 		6B3FA8945F430A067CC4DB4D /* WallpaperLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F557952B625823A2689EBE7 /* WallpaperLibrary.swift */; };
 		6FDE90B9E751CC319C45BA54 /* MusicReactiveManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F48518E41B9C56DFE5EB099 /* MusicReactiveManager.swift */; };
@@ -60,6 +61,7 @@
 		725E4F9BF3A84F458A306BDF /* WallpaperModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 388D852D79939F22C5EF801C /* WallpaperModelTests.swift */; };
 		72F4CF08714A41746B6A0258 /* AIProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7021318E82664A8754F5FF1 /* AIProvider.swift */; };
 		73849203691B6B9B27EF0384 /* CollectionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1849D0D4B8C207540818A7E8 /* CollectionManager.swift */; };
+		782ADAB3D0278AD8028A151C /* LiquidGlass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BD359DF3443AB6E3242CA90 /* LiquidGlass.swift */; };
 		7B8DE2A0443E6DC55D750FCB /* WallpaperManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 532FE0E3069C64B6236A343C /* WallpaperManager.swift */; };
 		7CB0D6C70AC6586289801B6C /* DisplaySettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 658D24C439FCC30FFDEBC73C /* DisplaySettingsView.swift */; };
 		7CD2350BE3D4A9216B849C69 /* MediumWidgetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7053DA494AD1DB578C10447 /* MediumWidgetView.swift */; };
@@ -199,6 +201,7 @@
 		43A9F2E051E3DDAA18ACAC9D /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		4662279ADB65DBA3957578B7 /* VideoFormatConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoFormatConverter.swift; sourceTree = "<group>"; };
 		48513382BB8B61A6DD8431DC /* UpdateChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateChecker.swift; sourceTree = "<group>"; };
+		4BD359DF3443AB6E3242CA90 /* LiquidGlass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiquidGlass.swift; sourceTree = "<group>"; };
 		4C428B5A76D12B2D39EB866E /* SlideshowGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlideshowGeneratorTests.swift; sourceTree = "<group>"; };
 		4C70B541C6297E485FF1E0AF /* ExceptionCatcher.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ExceptionCatcher.h; sourceTree = "<group>"; };
 		4D9A31C3562655D7C27A30B1 /* WallneticApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallneticApp.swift; sourceTree = "<group>"; };
@@ -280,6 +283,7 @@
 		DE3820804804CF982B3EAD9E /* AIGenerateViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIGenerateViewModelTests.swift; sourceTree = "<group>"; };
 		DE3FD865C09D4CE6C4025020 /* Wallpaper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Wallpaper.swift; sourceTree = "<group>"; };
 		DFC7F5C372D751F46660FA5C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		DFF460340111975F4DA40C32 /* DesignTokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignTokens.swift; sourceTree = "<group>"; };
 		E0187521E8CC2C0BB29CE90D /* BatteryPromptService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatteryPromptService.swift; sourceTree = "<group>"; };
 		EA19F4DBD0636536454696F3 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		ED806BD7E0913BCDF1142604 /* MetalVideoRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetalVideoRenderer.swift; sourceTree = "<group>"; };
@@ -489,6 +493,8 @@
 		6D154AD72514800F57D7A3AE /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				DFF460340111975F4DA40C32 /* DesignTokens.swift */,
+				4BD359DF3443AB6E3242CA90 /* LiquidGlass.swift */,
 				5FD8494A42E5AA356A35BA25 /* StrikingEffects.swift */,
 				07818DDC6C7B04DED71808AA /* WallneticButton.swift */,
 				B5803846B0B2BB84A1FDEE4E /* WallneticSheet.swift */,
@@ -768,6 +774,7 @@
 				D95869079F717BD8B2BB26D0 /* ContentView.swift in Sources */,
 				502AEDE09B50668E7154DC6E /* CreateFromPhotosView.swift in Sources */,
 				2445819EF402088E3689C8CD /* DeepLinkHandler.swift in Sources */,
+				6ACA2AC7AD0702CFEFA50E1B /* DesignTokens.swift in Sources */,
 				5E298128B4AE9AB89B656E86 /* DesktopOverlayController.swift in Sources */,
 				0BDACCA44A26C7459739D96B /* DesktopWindowController.swift in Sources */,
 				8EFAE3E67407537EC1B9A705 /* DiscoverView.swift in Sources */,
@@ -784,6 +791,7 @@
 				8BED6ED6D599D3F3C32821D5 /* HistoryView.swift in Sources */,
 				131EDF3DA15DA0EEA84918A4 /* HomeView.swift in Sources */,
 				1CA1504E421EAE5C547DF122 /* KeychainManager.swift in Sources */,
+				782ADAB3D0278AD8028A151C /* LiquidGlass.swift in Sources */,
 				42AF0F91E2BE36A155243433 /* LockScreenManager.swift in Sources */,
 				4BC3BA52E3938E15E6BC7AAA /* Log.swift in Sources */,
 				EA0AA7318BCBE3C944FF48ED /* MLWDecryptor.swift in Sources */,


### PR DESCRIPTION
macOS 26 Tahoe's Liquid Glass design language ported to a `macOS 13+` deployment target. Native `.glassEffect()` requires macOS 26, so this PR builds the visual language with stable APIs (`.regularMaterial`, gradient strokes, multi-layer shadows, continuous-style RoundedRectangles).

## Foundations
- **DesignTokens.swift**
  - `Radius` — concentric scale (window 18 → panel 16 → card 12 → control 10 → tag 8 → accent 6) with `nested(in:inset:)` helper enforcing `inner = outer − padding`
  - `Space` — 4-pt grid (`micro 2` → `xxl 40`)
  - `Typo` — full type scale with explicit tracking (display: -0.6, title1: -0.4, kicker: +2.5, button: +0.3, data: +0.2)
  - `Text.styledKicker()`, `styledData()` shortcuts
- **LiquidGlass.swift**
  - `LiquidGlassStyle` (radius / accent / accentStrength / tone of `.standard`/`.prominent`/`.control`)
  - `.liquidGlass()`, `.liquidGlassHUD()`, `.liquidGlassControl()`, `.refractiveBorder()` modifiers
  - Surface stack: `regularMaterial` blur → base tint → accent gradient (plusLighter) → refractive top/bottom strokes → inner highlight ring → ambient+accent shadows

## Refactored to Liquid Glass
- **WallneticSheet** — `.prominent` tone with 0.14 accent strength; concentric inner spacing throughout
- **WallneticButton** — new `LiquidPrimaryButtonStyle` (top-bright / bottom-dim refractive stroke + accent gradient) and `LiquidGhostButtonStyle` (neutral glass capsule)
- **WallneticTextField** — focus stroke is a vertical gradient (top accent / bottom dim) + glow shadow
- **Settings sidebar** — `ultraThinMaterial` + accent wash + right-edge refractive hairline; sidebar rows use concentric radii (tag → accent) and a glass icon chip on selection
- **TopNavigationBar** — floating glass capsule (`.liquidGlassHUD`) detached from window edges
- **ActionChip** — refractive circle stroke + accent gradient hover + 1.04× scale
- **HomeView hero** — "Use" / "My List" now use `WallneticButton.primary/.ghost`; hero title uses `Typo.display` with -0.6 tracking
- **SelectedWallpaperBar** — floating `liquidGlassHUD` HUD instead of `.bar`; thumbnail gets a `refractiveBorder`; Apply is `WallneticButton.primary`

## Test plan
- [x] Debug build SUCCEEDED
- [x] Release build SUCCEEDED
- [x] 76/76 tests pass
- [ ] Manual: open every modal (Rename, Create Collection, Icon Picker, Rename Wallpaper) — refractive top stroke + accent shadow visible
- [ ] Manual: scroll Home — TopNav floats above content with concentric margins
- [ ] Manual: Settings sidebar — translucent over backdrop; selected row has glow chip
- [ ] Manual: hero CTA / SelectedWallpaperBar — buttons match sheet button language

🤖 Generated with [Claude Code](https://claude.com/claude-code)