### PR TITLE
Ambient pass — content-driven accent, Ken Burns, button physics

### DIFF
--- a/src/Wallnetic/Services/DynamicAccent.swift
+++ b/src/Wallnetic/Services/DynamicAccent.swift
@@ -1,0 +1,136 @@
+import SwiftUI
+import AppKit
+import Combine
+
+/// 2026 Apple-style content-derived accent. Reads the active wallpaper's
+/// dominant color and derives a small palette (primary, secondary, on-color,
+/// glow strength) that the chrome consumes everywhere it would otherwise
+/// hard-code `.accentColor`.
+///
+/// Differs from `ThemeManager.accentColor` in two ways:
+///   1. Always-on (it's part of the design language now, not a user toggle).
+///   2. Publishes a full **AccentTheme** struct, not just one color — so a
+///      sheet header can use `.primary` for its icon orb while the lensing
+///      stroke samples `.secondary`.
+///
+/// Falls back to a Wallnetic signature palette when no wallpaper is active
+/// or its dominant color has not been extracted yet.
+@MainActor
+final class DynamicAccent: ObservableObject {
+    static let shared = DynamicAccent()
+
+    @Published private(set) var theme: AccentTheme = .signature
+
+    private var observer: Any?
+
+    private init() {
+        observer = NotificationCenter.default.addObserver(
+            forName: .wallpaperDidChange,
+            object: nil,
+            queue: .main
+        ) { [weak self] note in
+            guard let wp = note.object as? Wallpaper else { return }
+            Task { @MainActor in
+                self?.applyFrom(wallpaper: wp)
+            }
+        }
+    }
+
+    deinit {
+        if let observer { NotificationCenter.default.removeObserver(observer) }
+    }
+
+    func applyFrom(wallpaper: Wallpaper?) {
+        guard let wp = wallpaper else {
+            withAnimation(.easeInOut(duration: 0.8)) { theme = .signature }
+            return
+        }
+
+        if let hex = wp.dominantColorHex, let ns = NSColor(hex: hex) {
+            withAnimation(.easeInOut(duration: 0.8)) {
+                theme = AccentTheme.derive(from: ns)
+            }
+            return
+        }
+
+        // Extract on demand, then apply once available.
+        Task { [weak self] in
+            if let hex = await wp.extractDominantColor(), let ns = NSColor(hex: hex) {
+                await MainActor.run {
+                    withAnimation(.easeInOut(duration: 0.8)) {
+                        self?.theme = AccentTheme.derive(from: ns)
+                    }
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Accent Theme
+
+struct AccentTheme: Equatable {
+    let primary: Color
+    let secondary: Color
+    /// Color that sits *on top* of the primary fill (text/icon over an
+    /// accent-colored button) — high-contrast counterpart.
+    let on: Color
+    /// 0–1 scalar for shadow/glow intensity. Pastel/light palettes get a
+    /// stronger glow because they need it to read; saturated palettes
+    /// already pop.
+    let glow: Double
+
+    /// Wallnetic's fallback when no wallpaper accent is available.
+    static let signature = AccentTheme(
+        primary: Color(red: 0.36, green: 0.78, blue: 1.00),       // signature cyan-blue
+        secondary: Color(red: 0.68, green: 0.45, blue: 1.00),     // electric violet
+        on: .black,
+        glow: 0.65
+    )
+
+    static func derive(from nsColor: NSColor) -> AccentTheme {
+        let rgb = nsColor.usingColorSpace(.sRGB) ?? nsColor
+        var h: CGFloat = 0, s: CGFloat = 0, b: CGFloat = 0
+        rgb.getHue(&h, saturation: &s, brightness: &b, alpha: nil)
+
+        // Lift muddy/dim wallpaper colors into a vivid usable accent.
+        let liftedS = max(s, 0.55)
+        let liftedB = min(max(b, 0.55), 0.92)
+
+        let primaryNS = NSColor(hue: h, saturation: liftedS, brightness: liftedB, alpha: 1)
+        // Secondary: 32° hue rotation toward complementary — keeps it
+        // harmonic rather than clashing.
+        let secondaryNS = NSColor(
+            hue: (h + 32.0 / 360.0).truncatingRemainder(dividingBy: 1),
+            saturation: min(1, liftedS * 0.9),
+            brightness: min(1, liftedB * 1.05),
+            alpha: 1
+        )
+
+        let on: Color = liftedB > 0.6 ? .black : .white
+        let glow = 0.45 + Double(1 - liftedS) * 0.4  // pastel → more glow
+
+        return AccentTheme(
+            primary: Color(nsColor: primaryNS),
+            secondary: Color(nsColor: secondaryNS),
+            on: on,
+            glow: min(1, glow)
+        )
+    }
+}
+
+// MARK: - Environment plumbing
+//
+// Most chrome can read the accent off `@EnvironmentObject DynamicAccent`,
+// but for sub-views that don't have it injected we also expose an
+// environment key so call sites stay short.
+
+private struct AccentThemeKey: EnvironmentKey {
+    static let defaultValue: AccentTheme = .signature
+}
+
+extension EnvironmentValues {
+    var accentTheme: AccentTheme {
+        get { self[AccentThemeKey.self] }
+        set { self[AccentThemeKey.self] = newValue }
+    }
+}

--- a/src/Wallnetic/Views/Components/AmbientStage.swift
+++ b/src/Wallnetic/Views/Components/AmbientStage.swift
@@ -1,0 +1,134 @@
+import SwiftUI
+
+/// 2026 Apple-style ambient lighting for the whole window. Three layers:
+///
+///   1. **Drift** — a slow radial wash that travels along an ellipse over
+///      ~22 s. Gives the entire UI the feel of standing in a room with one
+///      moving light source.
+///   2. **Vignette** — soft edge darkening so the eye always returns to
+///      center content.
+///   3. **Cursor spotlight** — a faint accent-colored soft light that
+///      follows the pointer across the window. Like the highlight Vision
+///      Pro applies to whatever you're looking at — except mouse-driven
+///      because we are on macOS.
+///
+/// Costs: one continuous low-cadence animation + one onContinuousHover
+/// observer at the root. Both are cheap.
+struct AmbientStage: ViewModifier {
+    @Environment(\.accentTheme) private var accent
+    @State private var driftPhase: Double = 0
+    @State private var cursor: CGPoint = .init(x: 0.5, y: 0.5)
+    @State private var cursorInside: Bool = false
+
+    func body(content: Content) -> some View {
+        ZStack {
+            content
+            ambientOverlay
+                .allowsHitTesting(false)
+                .blendMode(.plusLighter)
+        }
+        .background(stageFloor.ignoresSafeArea())
+        .onAppear {
+            withAnimation(.linear(duration: 22).repeatForever(autoreverses: true)) {
+                driftPhase = 1
+            }
+        }
+        .overlay(
+            // Cursor tracker
+            GeometryReader { geo in
+                Color.clear
+                    .contentShape(Rectangle())
+                    .onContinuousHover { phase in
+                        switch phase {
+                        case .active(let p):
+                            cursor = CGPoint(
+                                x: min(max(p.x / geo.size.width, 0), 1),
+                                y: min(max(p.y / geo.size.height, 0), 1)
+                            )
+                            cursorInside = true
+                        case .ended:
+                            cursorInside = false
+                        }
+                    }
+                    .allowsHitTesting(false)
+            }
+        )
+    }
+
+    // MARK: - Floor (behind content)
+
+    /// Subtle base wash so the whole window is never pure black, even
+    /// before content fades in.
+    private var stageFloor: some View {
+        ZStack {
+            Color(red: 0.02, green: 0.025, blue: 0.05)
+            // Inverted radial — darker at corners
+            RadialGradient(
+                colors: [accent.primary.opacity(0.05 * accent.glow), .clear],
+                center: .init(x: 0.5, y: 0.4),
+                startRadius: 100,
+                endRadius: 700
+            )
+            .opacity(0.7)
+        }
+    }
+
+    // MARK: - Overlay (in front of content)
+
+    private var ambientOverlay: some View {
+        GeometryReader { geo in
+            let driftX = 0.30 + driftPhase * 0.40
+            let driftY = 0.18 + sin(driftPhase * .pi) * 0.10
+
+            ZStack {
+                // 1) Drifting accent wash
+                RadialGradient(
+                    colors: [
+                        accent.primary.opacity(0.16 * accent.glow),
+                        accent.primary.opacity(0.06 * accent.glow),
+                        .clear
+                    ],
+                    center: UnitPoint(x: driftX, y: driftY),
+                    startRadius: 20,
+                    endRadius: 500
+                )
+
+                // 2) Secondary drift (counter direction)
+                RadialGradient(
+                    colors: [accent.secondary.opacity(0.10 * accent.glow), .clear],
+                    center: UnitPoint(x: 1.0 - driftX, y: 0.85 - driftY * 0.6),
+                    startRadius: 20,
+                    endRadius: 420
+                )
+
+                // 3) Vignette
+                RadialGradient(
+                    colors: [.clear, .black.opacity(0.35)],
+                    center: .center,
+                    startRadius: min(geo.size.width, geo.size.height) * 0.35,
+                    endRadius: max(geo.size.width, geo.size.height) * 0.75
+                )
+                .blendMode(.multiply)
+
+                // 4) Cursor spotlight
+                if cursorInside {
+                    RadialGradient(
+                        colors: [accent.primary.opacity(0.13 * accent.glow), .clear],
+                        center: UnitPoint(x: cursor.x, y: cursor.y),
+                        startRadius: 4,
+                        endRadius: 180
+                    )
+                    .animation(.easeOut(duration: 0.18), value: cursor)
+                }
+            }
+        }
+    }
+}
+
+extension View {
+    /// Wraps the view in the global ambient stage. Apply once near the
+    /// app's root.
+    func ambientStage() -> some View {
+        modifier(AmbientStage())
+    }
+}

--- a/src/Wallnetic/Views/Components/FocusHalo.swift
+++ b/src/Wallnetic/Views/Components/FocusHalo.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+/// A soft accent halo that follows keyboard focus. Apple's 2026 design
+/// adds a literal glow around the focused interactive element (whatever
+/// the user would activate if they hit ⏎). Apply via `.focusHalo()` on
+/// any view paired with `@FocusState`.
+///
+/// We don't reuse SwiftUI's `.focused()` glow because the system version
+/// is too subtle on dark cinematic surfaces — easy to lose focus state.
+struct FocusHalo: ViewModifier {
+    let isFocused: Bool
+    let radius: CGFloat
+    var accent: Color = .accentColor
+
+    @Environment(\.accentTheme) private var accentTheme
+
+    func body(content: Content) -> some View {
+        let color = (accent == .accentColor) ? accentTheme.primary : accent
+
+        content
+            .overlay(
+                RoundedRectangle(cornerRadius: radius, style: .continuous)
+                    .strokeBorder(color.opacity(isFocused ? 0.85 : 0), lineWidth: isFocused ? 1.5 : 0)
+                    .blur(radius: 0.4)
+            )
+            .shadow(color: color.opacity(isFocused ? 0.55 : 0), radius: isFocused ? 16 : 0)
+            .shadow(color: color.opacity(isFocused ? 0.30 : 0), radius: isFocused ? 4 : 0)
+            .animation(.easeOut(duration: 0.18), value: isFocused)
+    }
+}
+
+extension View {
+    func focusHalo(_ isFocused: Bool, radius: CGFloat = Radius.control, accent: Color = .accentColor) -> some View {
+        modifier(FocusHalo(isFocused: isFocused, radius: radius, accent: accent))
+    }
+}

--- a/src/Wallnetic/Views/Components/WallneticButton.swift
+++ b/src/Wallnetic/Views/Components/WallneticButton.swift
@@ -69,6 +69,7 @@ enum WallneticButton {
 private struct LiquidPrimaryButtonStyle: ButtonStyle {
     let accent: Color
     let isEnabled: Bool
+    @State private var wobble: CGFloat = 1.0
 
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
@@ -101,8 +102,20 @@ private struct LiquidPrimaryButtonStyle: ButtonStyle {
                 radius: configuration.isPressed ? 4 : 12,
                 y: configuration.isPressed ? 1 : 5
             )
-            .scaleEffect(configuration.isPressed ? 0.97 : 1.0)
-            .animation(.easeOut(duration: 0.12), value: configuration.isPressed)
+            // Press: compress to 0.96. Release: bouncy spring back through
+            // 1.0 → ~1.025 → 1.0. Wobble is purely visual; the action
+            // already fired on touch-up.
+            .scaleEffect(configuration.isPressed ? 0.96 : wobble)
+            .onChange(of: configuration.isPressed) { newPressed in
+                guard isEnabled else { return }
+                if !newPressed {
+                    wobble = 1.025
+                    withAnimation(.spring(response: 0.32, dampingFraction: 0.55)) {
+                        wobble = 1.0
+                    }
+                }
+            }
+            .animation(.easeOut(duration: 0.10), value: configuration.isPressed)
     }
 }
 
@@ -177,7 +190,7 @@ struct WallneticTextField: View {
                     ), lineWidth: focused ? 1 : 0.6)
             }
         )
-        .shadow(color: focused ? accent.opacity(0.35) : .clear, radius: focused ? 10 : 0, y: focused ? 4 : 0)
+        .focusHalo(focused, radius: Radius.control, accent: accent)
         .animation(.easeOut(duration: 0.16), value: focused)
     }
 }

--- a/src/Wallnetic/Views/Main/ContentView.swift
+++ b/src/Wallnetic/Views/Main/ContentView.swift
@@ -5,6 +5,7 @@ struct ContentView: View {
     @EnvironmentObject var wallpaperManager: WallpaperManager
     @ObservedObject private var downloadManager = DownloadManager.shared
     @ObservedObject private var errorReporter = ErrorReporter.shared
+    @StateObject private var dynamicAccent = DynamicAccent.shared
     @State private var selectedTab: NavigationTab = .home
     @State private var isImporting = false
     @State private var showingPhotosImport = false
@@ -16,9 +17,6 @@ struct ContentView: View {
 
     var body: some View {
         ZStack {
-            // Animated gradient background
-            AnimatedGradientBackground()
-
             VStack(spacing: 0) {
                 TopNavigationBar(
                     selectedTab: $selectedTab,
@@ -57,6 +55,7 @@ struct ContentView: View {
                 }
             }
         }
+        .ambientStage()
         .preferredColorScheme(.dark)
         .fileImporter(
             isPresented: $isImporting,
@@ -92,11 +91,16 @@ struct ContentView: View {
             CreateFromPhotosView()
                 .environmentObject(wallpaperManager)
         }
+        .environment(\.accentTheme, dynamicAccent.theme)
         .onAppear {
             if !hasCompletedOnboarding {
                 showingOnboarding = true
                 hasCompletedOnboarding = true
             }
+            dynamicAccent.applyFrom(wallpaper: wallpaperManager.currentWallpaper)
+        }
+        .onChange(of: wallpaperManager.currentWallpaper) { newWp in
+            dynamicAccent.applyFrom(wallpaper: newWp)
         }
     }
 

--- a/src/Wallnetic/Views/Main/HomeView.swift
+++ b/src/Wallnetic/Views/Main/HomeView.swift
@@ -241,6 +241,7 @@ struct HomeView: View {
 struct HeroBannerCard: View {
     let wallpaper: Wallpaper
     @State private var thumbnail: NSImage?
+    @State private var kenBurnsPhase: Double = 0
 
     var body: some View {
         Group {
@@ -248,12 +249,23 @@ struct HeroBannerCard: View {
                 Image(nsImage: thumbnail)
                     .resizable()
                     .aspectRatio(contentMode: .fill)
+                    // Ken Burns: scale 1.06 → 1.12, pan ±18pt over 14s
+                    .scaleEffect(1.06 + kenBurnsPhase * 0.06)
+                    .offset(
+                        x: (kenBurnsPhase - 0.5) * 36,
+                        y: (kenBurnsPhase - 0.5) * 22
+                    )
             } else {
                 Color.black
             }
         }
         .task {
             thumbnail = await wallpaper.generateThumbnail(size: CGSize(width: 1280, height: 720))
+        }
+        .onAppear {
+            withAnimation(.linear(duration: 14).repeatForever(autoreverses: true)) {
+                kenBurnsPhase = 1
+            }
         }
     }
 }
@@ -330,6 +342,14 @@ struct CarouselCard: View {
         return pointer.x  // 0..1 follows pointer
     }
 
+    /// Specular intensity scales with tilt magnitude — like a real lens
+    /// reflecting more light when angled.
+    private var specularIntensity: Double {
+        guard isHovering else { return 0 }
+        let mag = sqrt(tiltX * tiltX + tiltY * tiltY)
+        return min(0.22, 0.06 + mag / 60)
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
             ZStack(alignment: .bottom) {
@@ -391,14 +411,18 @@ struct CarouselCard: View {
             }
             .frame(width: cardWidth, height: cardHeight)
             .overlay(
-                // Glare strip — follows pointer
+                // Specular highlight — follows pointer, intensifies with
+                // tilt magnitude. The gradient angle subtly tracks the
+                // y-axis rotation so it looks like a real light source
+                // staying overhead as the card tilts.
                 LinearGradient(
                     stops: [
-                        .init(color: .white.opacity(0), location: max(0, glareOffset - 0.25)),
-                        .init(color: .white.opacity(isHovering ? 0.14 : 0), location: glareOffset),
-                        .init(color: .white.opacity(0), location: min(1, glareOffset + 0.25))
+                        .init(color: .white.opacity(0), location: max(0, glareOffset - 0.28)),
+                        .init(color: .white.opacity(specularIntensity), location: glareOffset),
+                        .init(color: .white.opacity(0), location: min(1, glareOffset + 0.28))
                     ],
-                    startPoint: .leading, endPoint: .trailing
+                    startPoint: UnitPoint(x: 0.5 - tiltY / 50, y: 0),
+                    endPoint: UnitPoint(x: 0.5 + tiltY / 50, y: 1)
                 )
                 .blendMode(.plusLighter)
                 .allowsHitTesting(false)

--- a/src/Wallnetic/Views/Main/TopNavigationBar.swift
+++ b/src/Wallnetic/Views/Main/TopNavigationBar.swift
@@ -31,6 +31,7 @@ struct TopNavigationBar: View {
     @State private var isSearching = false
     @State private var hoveredTab: NavigationTab?
     @FocusState private var searchFocused: Bool
+    @Namespace private var tabUnderlineNS
     var isScrolled: Bool = false
 
     var body: some View {
@@ -105,7 +106,7 @@ struct TopNavigationBar: View {
         let isHovered = hoveredTab == tab
 
         Button {
-            withAnimation(.spring(response: Anim.enter, dampingFraction: 0.8)) {
+            withAnimation(.spring(response: 0.5, dampingFraction: 0.72, blendDuration: 0.2)) {
                 selectedTab = tab
             }
         } label: {
@@ -119,18 +120,24 @@ struct TopNavigationBar: View {
                 }
                 .foregroundColor(isSelected ? .white : .white.opacity(isHovered ? 0.85 : 0.55))
 
-                // Active gradient underline
-                Capsule()
-                    .fill(
-                        isSelected
-                            ? AnyShapeStyle(LinearGradient(
+                // Active gradient underline — matched-geometry slide with
+                // stretch on transit. The capsule animates between tab
+                // positions instead of appearing/disappearing per tab.
+                ZStack {
+                    if isSelected {
+                        Capsule(style: .continuous)
+                            .fill(LinearGradient(
                                 colors: [.accentColor, .accentColor.opacity(0.6)],
                                 startPoint: .leading, endPoint: .trailing
                             ))
-                            : AnyShapeStyle(Color.clear)
-                    )
-                    .frame(width: isSelected ? 28 : 0, height: 2)
-                    .shadow(color: .accentColor.opacity(0.6), radius: 4)
+                            .matchedGeometryEffect(id: "tabUnderline", in: tabUnderlineNS)
+                            .shadow(color: .accentColor.opacity(0.65), radius: 5)
+                    } else {
+                        Capsule(style: .continuous)
+                            .fill(Color.clear)
+                    }
+                }
+                .frame(width: 28, height: 2)
             }
             .padding(.horizontal, 12)
             .padding(.vertical, 6)

--- a/src/Wallnetic/Wallnetic.xcodeproj/project.pbxproj
+++ b/src/Wallnetic/Wallnetic.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		2124DE0A8E8717475F30D34C /* WallpaperGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D76E5D0AB6B966E492D0342 /* WallpaperGridView.swift */; };
 		2445819EF402088E3689C8CD /* DeepLinkHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2833332B3174CD94D7D62CBB /* DeepLinkHandler.swift */; };
 		2509E976AE0675786B3C248A /* SmallWidgetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 134AA54986991D7480CC4CD8 /* SmallWidgetView.swift */; };
+		27E8C6194A802AD6C3726D0A /* AmbientStage.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA26B4DDB98EF77D98CE5821 /* AmbientStage.swift */; };
 		284D0925EA9AEC2B302910D1 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BF36E216B5F900C62E824B59 /* Assets.xcassets */; };
 		29D5A45CA0BA3716AFA45522 /* WallneticButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07818DDC6C7B04DED71808AA /* WallneticButton.swift */; };
 		2C5619331688457B6A844B93 /* CollectionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31C51D17BDBBADCDF4D5CB43 /* CollectionsView.swift */; };
@@ -51,6 +52,7 @@
 		61773D343F4EBEEB12FF8AFB /* BatteryPromptService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0187521E8CC2C0BB29CE90D /* BatteryPromptService.swift */; };
 		61B1EC0DBC85801311FA1F2F /* MenuBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B106464A071BF6E736C3272 /* MenuBarView.swift */; };
 		61B8431DE4EA724F4E55C7B2 /* OllamaVisionTagger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FD3DFBD42A5D9B294784C5F /* OllamaVisionTagger.swift */; };
+		64369FBB9497637963EC2B4C /* DynamicAccent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6581C17705CF0F9650F91F07 /* DynamicAccent.swift */; };
 		6A650CD75C4B32AB9889A6A7 /* SharedWidgetModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDFCAB2A636011BB543DD1B5 /* SharedWidgetModels.swift */; };
 		6ACA2AC7AD0702CFEFA50E1B /* DesignTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFF460340111975F4DA40C32 /* DesignTokens.swift */; };
 		6ADBCB967C34EB7B36825043 /* WallpaperMetadataCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 941B25667F75E00393C7E895 /* WallpaperMetadataCacheTests.swift */; };
@@ -102,6 +104,7 @@
 		B61FA302398523F6F9AFE321 /* SpaceWallpaperManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE3320FF526E744247F3B5BE /* SpaceWallpaperManager.swift */; };
 		BAC40D45BA2B2C148C66259E /* DeepLinkHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A9660F71829E6C2D5F2B5E6 /* DeepLinkHandlerTests.swift */; };
 		BED9A1AD659C124D26D37355 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA8E25061D17472552507DF7 /* OnboardingView.swift */; };
+		C1489B79C3339AE81BA61D13 /* FocusHalo.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6E13A8C8EF384BF16EDF962 /* FocusHalo.swift */; };
 		C45BE528ECCD2D35E95ED1C4 /* WallpaperTimelineProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6730B13258B7FB98C75E2BD6 /* WallpaperTimelineProvider.swift */; };
 		C5C2637200252363B44EEBC3 /* WallpaperMetadataStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC1C9FEA53FC924608F4B3DC /* WallpaperMetadataStoreTests.swift */; };
 		C703D713F68746183202C7DE /* AIStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B98ABE56A3B186B1C7AFA43 /* AIStyle.swift */; };
@@ -222,6 +225,7 @@
 		5FD8494A42E5AA356A35BA25 /* StrikingEffects.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StrikingEffects.swift; sourceTree = "<group>"; };
 		60D80208B9C31066D6C112FB /* ThemeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeManager.swift; sourceTree = "<group>"; };
 		632C30C0743E0B8691AFD923 /* VideoPreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoPreviewView.swift; sourceTree = "<group>"; };
+		6581C17705CF0F9650F91F07 /* DynamicAccent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicAccent.swift; sourceTree = "<group>"; };
 		658D24C439FCC30FFDEBC73C /* DisplaySettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplaySettingsView.swift; sourceTree = "<group>"; };
 		65B960F4D2BFD36368F336A4 /* PexelsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PexelsService.swift; sourceTree = "<group>"; };
 		6730B13258B7FB98C75E2BD6 /* WallpaperTimelineProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperTimelineProvider.swift; sourceTree = "<group>"; };
@@ -263,6 +267,7 @@
 		B6272C35871A69060C41EFEC /* AIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIService.swift; sourceTree = "<group>"; };
 		B7021318E82664A8754F5FF1 /* AIProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIProvider.swift; sourceTree = "<group>"; };
 		BA2392B868E0D5B6994FF657 /* EffectsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EffectsSettingsView.swift; sourceTree = "<group>"; };
+		BA26B4DDB98EF77D98CE5821 /* AmbientStage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmbientStage.swift; sourceTree = "<group>"; };
 		BA4D12B25631A66EDCB10593 /* PhotosLibraryService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotosLibraryService.swift; sourceTree = "<group>"; };
 		BB036BA69CC6D00731C1D273 /* DiscoverView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverView.swift; sourceTree = "<group>"; };
 		BC8F63EBF5F78663165C4697 /* CreateFromPhotosView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateFromPhotosView.swift; sourceTree = "<group>"; };
@@ -289,6 +294,7 @@
 		ED806BD7E0913BCDF1142604 /* MetalVideoRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetalVideoRenderer.swift; sourceTree = "<group>"; };
 		F3D3A43BF60BFD2ADD5853F5 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		F62ADB679C576DF4637BA6C9 /* Log.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Log.swift; sourceTree = "<group>"; };
+		F6E13A8C8EF384BF16EDF962 /* FocusHalo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusHalo.swift; sourceTree = "<group>"; };
 		F9534BF578FB9EFE92050C52 /* TimeOfDayManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeOfDayManager.swift; sourceTree = "<group>"; };
 		F9960B917192178D2217E668 /* iCloudSyncManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iCloudSyncManager.swift; sourceTree = "<group>"; };
 		FA624026F461BCF47C3E39D5 /* UsageTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageTracker.swift; sourceTree = "<group>"; };
@@ -365,6 +371,7 @@
 				1849D0D4B8C207540818A7E8 /* CollectionManager.swift */,
 				2833332B3174CD94D7D62CBB /* DeepLinkHandler.swift */,
 				543E1B92A4536DE1415BD91E /* DownloadManager.swift */,
+				6581C17705CF0F9650F91F07 /* DynamicAccent.swift */,
 				73A3E9458476683E0230677D /* ErrorReporter.swift */,
 				B3E0F02714B57C6B710BFA04 /* FavoriteStylesManager.swift */,
 				F9960B917192178D2217E668 /* iCloudSyncManager.swift */,
@@ -493,7 +500,9 @@
 		6D154AD72514800F57D7A3AE /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				BA26B4DDB98EF77D98CE5821 /* AmbientStage.swift */,
 				DFF460340111975F4DA40C32 /* DesignTokens.swift */,
+				F6E13A8C8EF384BF16EDF962 /* FocusHalo.swift */,
 				4BD359DF3443AB6E3242CA90 /* LiquidGlass.swift */,
 				5FD8494A42E5AA356A35BA25 /* StrikingEffects.swift */,
 				07818DDC6C7B04DED71808AA /* WallneticButton.swift */,
@@ -757,6 +766,7 @@
 				72F4CF08714A41746B6A0258 /* AIProvider.swift in Sources */,
 				FF16323D780FDC2A4404D5BA /* AIService.swift in Sources */,
 				C703D713F68746183202C7DE /* AIStyle.swift in Sources */,
+				27E8C6194A802AD6C3726D0A /* AmbientStage.swift in Sources */,
 				E3721D2B68E6322EA1D6E408 /* AnalyticsManager.swift in Sources */,
 				53984128C8EBA3CD0BDEB573 /* AppDelegate.swift in Sources */,
 				0D161367E2348177677DEAD0 /* AppShortcuts.swift in Sources */,
@@ -780,6 +790,7 @@
 				8EFAE3E67407537EC1B9A705 /* DiscoverView.swift in Sources */,
 				7CB0D6C70AC6586289801B6C /* DisplaySettingsView.swift in Sources */,
 				2082CED0A15F59CAEEDB57F8 /* DownloadManager.swift in Sources */,
+				64369FBB9497637963EC2B4C /* DynamicAccent.swift in Sources */,
 				D57F15D4DC64658E22A29341 /* DynamicIslandController.swift in Sources */,
 				EAB040DBE1DBA4A2060A349D /* DynamicIslandView.swift in Sources */,
 				A2FD8BF6EF09FC0B086E2261 /* EffectsSettingsView.swift in Sources */,
@@ -787,6 +798,7 @@
 				E8B9B335A9706D2398DC72A2 /* ExceptionCatcher.m in Sources */,
 				5C0AAD3B25B3DCB797AF2959 /* ExploreView.swift in Sources */,
 				CE93C5919FE1E7FAC086C58E /* FavoriteStylesManager.swift in Sources */,
+				C1489B79C3339AE81BA61D13 /* FocusHalo.swift in Sources */,
 				E670DC0DFE3A0970082E73EF /* GenerationHistory.swift in Sources */,
 				8BED6ED6D599D3F3C32821D5 /* HistoryView.swift in Sources */,
 				131EDF3DA15DA0EEA84918A4 /* HomeView.swift in Sources */,


### PR DESCRIPTION
Liquid Glass materyali tamamdı ama altındaki sahne ölüydü. Bu sweep onu canlandırıyor.

## Why
Apple 2026'da Liquid Glass'in altinda yatan asil sey materyal degil, **icerik-tepkili ortam**. Aksan aktif wallpaper'dan dogar; pencerede yavas akan isik vardir; butonlar fizik tasir; focus belli olur.

## What's new
- **DynamicAccent** (`Services/`) — `@MainActor` singleton listens for `.wallpaperDidChange` and publishes an `AccentTheme` (primary, secondary, on-color, glow). HSB-rotated complementary derivation; pastel palettes get a stronger glow. Plumbed through `.environment(\.accentTheme)`.
- **AmbientStage** (`Views/Components/`, `.ambientStage()`) — window-level three-layer ambient lighting: a 22-second drifting accent radial, a soft vignette, and a cursor-following spotlight. Replaces the static `AnimatedGradientBackground`.
- **FocusHalo** (`.focusHalo(isFocused:)`) — accent halo around keyboard-focused elements (Apple Tahoe's "spotlight on focus" behavior). Pulls accent from environment.

## Physics & motion
- **HeroBannerCard** — endless Ken Burns drift (14s, autoreverses): scale 1.06 → 1.12 + ±18pt pan. Hero is alive even when idle.
- **TopNavigationBar** — active tab underline uses `matchedGeometryEffect`; sliding between tabs gives the capsule visible **mass** via `spring(response: 0.5, dampingFraction: 0.72)`.
- **CarouselCard** — specular highlight intensity now scales with tilt magnitude; the gradient angle subtly tracks y-axis rotation so the light source feels stationary while the card rotates.
- **WallneticButton.primary** — press squash to 0.96, release spring overshoot through 1.025 back to 1.0. Pure visual; action fires on touch-up unchanged.

## Wired everywhere
- ContentView root → `.ambientStage()` + `@StateObject DynamicAccent` + `.onChange(currentWallpaper)`.
- WallneticTextField focus state → `.focusHalo()` (replaces old static shadow).

## Test plan
- [x] Debug + Release builds SUCCEEDED
- [x] 76/76 tests pass
- [ ] Manual: change wallpaper — entire chrome subtly retones to new accent
- [ ] Manual: move cursor across window — soft spotlight follows
- [ ] Manual: switch tabs — underline slides with springy stretch
- [ ] Manual: press a primary button — feel the overshoot
- [ ] Manual: hover a CarouselCard — specular tracks tilt
- [ ] Manual: focus a TextField — accent halo glows

🤖 Generated with [Claude Code](https://claude.com/claude-code)