### PR TITLE
Window chrome refinement — flat structure preserved

### DIFF
--- a/src/Wallnetic/App/WallneticApp.swift
+++ b/src/Wallnetic/App/WallneticApp.swift
@@ -17,6 +17,7 @@ struct WallneticApp: App {
         WindowGroup(id: "main") {
             ContentView()
                 .environmentObject(wallpaperManager)
+                .cinematicWindowChrome()
                 .onAppear {
                     WindowManager.shared.openMainWindow = { [openWindow] in
                         openWindow(id: "main")
@@ -35,6 +36,7 @@ struct WallneticApp: App {
         Settings {
             SettingsView()
                 .environmentObject(wallpaperManager)
+                .cinematicWindowChrome()
         }
 
         // Menu Bar Extra

--- a/src/Wallnetic/Views/Components/WindowChrome.swift
+++ b/src/Wallnetic/Views/Components/WindowChrome.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+import AppKit
+
+/// Surfaces the underlying `NSWindow` so we can apply title-bar treatments
+/// SwiftUI doesn't expose declaratively. Used by Settings and the main
+/// window to extend the dark cinematic surface under the traffic lights.
+struct WindowChrome: NSViewRepresentable {
+    var configure: (NSWindow) -> Void
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView()
+        DispatchQueue.main.async {
+            if let window = view.window {
+                configure(window)
+            }
+        }
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        DispatchQueue.main.async {
+            if let window = nsView.window {
+                configure(window)
+            }
+        }
+    }
+}
+
+extension View {
+    /// Applies Wallnetic's cinematic-dark title-bar treatment:
+    ///  - hidden title text
+    ///  - transparent titlebar so content extends underneath
+    ///  - full-size content view (no reserved title-bar strip)
+    ///  - forced dark appearance
+    ///  - clear NSWindow bg so the SwiftUI ambient stage shows through
+    func cinematicWindowChrome() -> some View {
+        background(WindowChrome { window in
+            window.titleVisibility = .hidden
+            window.titlebarAppearsTransparent = true
+            window.styleMask.insert(.fullSizeContentView)
+            window.appearance = NSAppearance(named: .darkAqua)
+            window.backgroundColor = .clear
+            window.isOpaque = false
+            // Allow dragging from anywhere in the title-bar region.
+            window.isMovableByWindowBackground = false
+        })
+    }
+}

--- a/src/Wallnetic/Views/Main/SettingsView.swift
+++ b/src/Wallnetic/Views/Main/SettingsView.swift
@@ -29,17 +29,26 @@ struct SettingsView: View {
 
     private var sidebar: some View {
         VStack(alignment: .leading, spacing: 0) {
-            HStack(spacing: Space.xs + 2) {
-                Image(systemName: "gearshape.2.fill")
-                    .font(.system(size: 14, weight: .semibold))
-                    .foregroundColor(.accentColor)
-                    .shadow(color: .accentColor.opacity(0.55), radius: 5)
-                Text("SETTINGS")
-                    .styledKicker(color: .white.opacity(0.55))
+            // Traffic-light clearance — content stays under the lights, but
+            // we leave breathing room so the first row doesn't fight with
+            // the close/min/max buttons.
+            Color.clear.frame(height: 30)
+
+            // Subtle wordmark — no glowing icon, no startup-logo feel. The
+            // sidebar's purpose is obvious from context; this kicker is just
+            // a quiet anchor.
+            HStack(spacing: 0) {
+                Text("Wallnetic")
+                    .font(.system(size: 13, weight: .semibold, design: .rounded))
+                    .foregroundColor(.white.opacity(0.92))
+                    .tracking(-0.1)
+                Text(" Settings")
+                    .font(.system(size: 13, weight: .regular, design: .rounded))
+                    .foregroundColor(.white.opacity(0.45))
+                    .tracking(-0.1)
                 Spacer()
             }
-            .padding(.horizontal, Space.lg + 2)
-            .padding(.top, Space.lg + 4)
+            .padding(.horizontal, Space.lg)
             .padding(.bottom, Space.md)
 
             ScrollView(showsIndicators: false) {
@@ -111,31 +120,35 @@ struct SettingsView: View {
 
     private var detail: some View {
         VStack(alignment: .leading, spacing: 0) {
-            HStack(spacing: 12) {
+            // Traffic-light clearance matching sidebar
+            Color.clear.frame(height: 30)
+
+            HStack(spacing: Space.sm) {
                 Image(systemName: selection.icon)
-                    .font(.system(size: 14, weight: .semibold))
+                    .font(.system(size: 13, weight: .semibold))
                     .foregroundColor(selection.accent)
                     .frame(width: 26, height: 26)
                     .background(
-                        Circle()
-                            .fill(selection.accent.opacity(0.18))
+                        ZStack {
+                            Circle().fill(selection.accent.opacity(0.16))
+                            Circle().strokeBorder(selection.accent.opacity(0.30), lineWidth: 0.5)
+                        }
                     )
-                    .shadow(color: selection.accent.opacity(0.4), radius: 6)
 
                 VStack(alignment: .leading, spacing: 1) {
                     Text(selection.title)
-                        .font(.system(size: 17, weight: .bold, design: .rounded))
+                        .font(.system(size: 17, weight: .semibold, design: .rounded))
                         .foregroundColor(.white)
+                        .tracking(-0.2)
                     Text(selection.tagline)
                         .font(.system(size: 11))
-                        .foregroundColor(.white.opacity(0.45))
+                        .foregroundColor(.white.opacity(0.42))
                 }
 
                 Spacer()
             }
-            .padding(.horizontal, 32)
-            .padding(.top, 26)
-            .padding(.bottom, 18)
+            .padding(.horizontal, Space.xl + 4)
+            .padding(.bottom, Space.md + 2)
 
             Divider()
                 .overlay(LinearGradient(

--- a/src/Wallnetic/Views/Main/TopNavigationBar.swift
+++ b/src/Wallnetic/Views/Main/TopNavigationBar.swift
@@ -91,11 +91,31 @@ struct TopNavigationBar: View {
                 }
             }
         }
-        .padding(.horizontal, Space.md)
+        .padding(.leading, 84)        // reserve traffic-light real estate
+        .padding(.trailing, Space.md)
         .padding(.vertical, Space.xs + 2)
-        .liquidGlassHUD(radius: Radius.panel, accent: .accentColor)
-        .padding(.horizontal, Space.sm)
-        .padding(.top, Space.xs)
+        .background(navBackground)
+        .overlay(alignment: .bottom) {
+            Rectangle()
+                .fill(LinearGradient(
+                    colors: [.clear, .white.opacity(0.08), .clear],
+                    startPoint: .leading, endPoint: .trailing
+                ))
+                .frame(height: 0.5)
+        }
+    }
+
+    /// In-window toolbar background. Traffic lights overlay this strip;
+    /// content scrolls beneath it. Glass intensifies as user scrolls.
+    private var navBackground: some View {
+        ZStack {
+            Rectangle()
+                .fill(.ultraThinMaterial)
+                .opacity(isScrolled ? 0.92 : 0.65)
+            Rectangle()
+                .fill(Color.black.opacity(isScrolled ? 0.35 : 0.20))
+        }
+        .animation(.easeInOut(duration: Anim.medium), value: isScrolled)
     }
 
     // MARK: - Tab Button
@@ -110,41 +130,36 @@ struct TopNavigationBar: View {
                 selectedTab = tab
             }
         } label: {
-            VStack(spacing: 3) {
-                HStack(spacing: 5) {
-                    Image(systemName: tab.icon)
-                        .font(.system(size: 10))
-                    Text(tab.rawValue)
-                        .font(.system(size: 12, weight: isSelected ? .semibold : .medium))
-                        .tracking(0.1)
-                }
-                .foregroundColor(isSelected ? .white : .white.opacity(isHovered ? 0.85 : 0.55))
-
-                // Active gradient underline — matched-geometry slide with
-                // stretch on transit. The capsule animates between tab
-                // positions instead of appearing/disappearing per tab.
-                ZStack {
-                    if isSelected {
-                        Capsule(style: .continuous)
-                            .fill(LinearGradient(
-                                colors: [.accentColor, .accentColor.opacity(0.6)],
-                                startPoint: .leading, endPoint: .trailing
-                            ))
-                            .matchedGeometryEffect(id: "tabUnderline", in: tabUnderlineNS)
-                            .shadow(color: .accentColor.opacity(0.65), radius: 5)
-                    } else {
-                        Capsule(style: .continuous)
-                            .fill(Color.clear)
-                    }
-                }
-                .frame(width: 28, height: 2)
+            HStack(spacing: 5) {
+                Image(systemName: tab.icon)
+                    .font(.system(size: 10, weight: .semibold))
+                Text(tab.rawValue)
+                    .font(.system(size: 12, weight: isSelected ? .semibold : .medium))
+                    .tracking(0.1)
             }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 6)
+            .foregroundColor(isSelected ? .white : .white.opacity(isHovered ? 0.85 : 0.55))
+            .padding(.horizontal, 11)
+            .padding(.vertical, 5)
             .contentShape(Rectangle())
             .background(
-                Capsule()
-                    .fill(isHovered && !isSelected ? Color.white.opacity(0.05) : .clear)
+                ZStack {
+                    // Selected: soft glass pill with hairline stroke — no
+                    // shouty underline, no accent color screaming
+                    if isSelected {
+                        Capsule(style: .continuous)
+                            .fill(Color.white.opacity(0.10))
+                            .matchedGeometryEffect(id: "tabPill", in: tabUnderlineNS)
+                        Capsule(style: .continuous)
+                            .strokeBorder(LinearGradient(
+                                colors: [.white.opacity(0.22), .white.opacity(0.04)],
+                                startPoint: .top, endPoint: .bottom
+                            ), lineWidth: 0.5)
+                            .matchedGeometryEffect(id: "tabPillStroke", in: tabUnderlineNS)
+                    } else if isHovered {
+                        Capsule(style: .continuous)
+                            .fill(Color.white.opacity(0.04))
+                    }
+                }
             )
         }
         .buttonStyle(.plain)

--- a/src/Wallnetic/Wallnetic.xcodeproj/project.pbxproj
+++ b/src/Wallnetic/Wallnetic.xcodeproj/project.pbxproj
@@ -101,6 +101,7 @@
 		B42A0A282FC2AA2D1C21B83F /* SchedulerService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A3CC73608BAFA155E615F1B /* SchedulerService.swift */; };
 		B4A8451ADDDC53D5E76BE89D /* TimeOfDayManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9534BF578FB9EFE92050C52 /* TimeOfDayManager.swift */; };
 		B528C1F69B3CD9B3914A58A6 /* PowerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E4C04ED28406292407FFBD0 /* PowerManager.swift */; };
+		B58D37AE767BFCCAADD62CD7 /* WindowChrome.swift in Sources */ = {isa = PBXBuildFile; fileRef = C532ED2F0EA2893709BC51E7 /* WindowChrome.swift */; };
 		B61FA302398523F6F9AFE321 /* SpaceWallpaperManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE3320FF526E744247F3B5BE /* SpaceWallpaperManager.swift */; };
 		BAC40D45BA2B2C148C66259E /* DeepLinkHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A9660F71829E6C2D5F2B5E6 /* DeepLinkHandlerTests.swift */; };
 		BED9A1AD659C124D26D37355 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA8E25061D17472552507DF7 /* OnboardingView.swift */; };
@@ -275,6 +276,7 @@
 		C296AD08F207FEC3AF4CDCB9 /* AnalyticsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsManager.swift; sourceTree = "<group>"; };
 		C36C5B8FAAEBFAB779FBBB39 /* VideoRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoRenderer.swift; sourceTree = "<group>"; };
 		C46699BC859D4FABE71BB58F /* LargeWidgetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeWidgetView.swift; sourceTree = "<group>"; };
+		C532ED2F0EA2893709BC51E7 /* WindowChrome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowChrome.swift; sourceTree = "<group>"; };
 		C649839F5BB66D43BA4A499A /* AudioVisualizerOverlayController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioVisualizerOverlayController.swift; sourceTree = "<group>"; };
 		C788B7EDDB89E2E9EEB97E43 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		CC1C9FEA53FC924608F4B3DC /* WallpaperMetadataStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperMetadataStoreTests.swift; sourceTree = "<group>"; };
@@ -507,6 +509,7 @@
 				5FD8494A42E5AA356A35BA25 /* StrikingEffects.swift */,
 				07818DDC6C7B04DED71808AA /* WallneticButton.swift */,
 				B5803846B0B2BB84A1FDEE4E /* WallneticSheet.swift */,
+				C532ED2F0EA2893709BC51E7 /* WindowChrome.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -864,6 +867,7 @@
 				9C7206924D126AE38A11DD51 /* WallpaperStoreManager.swift in Sources */,
 				F6107012989E9FC5810F350E /* WeatherWallpaperManager.swift in Sources */,
 				A978B328492C6EE503BC91E3 /* WidgetSyncService.swift in Sources */,
+				B58D37AE767BFCCAADD62CD7 /* WindowChrome.swift in Sources */,
 				88C6A7F9AD19AA876CEEC465 /* iCloudSyncManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
Per screenshots: TopNav had a useless black band above it, the active-tab "red bar" looked crude under wallpaper-derived accents, and the Settings window leaked stock Aqua chrome (white titlebar + glowing red gear startup-logo).

## Changes

### New
- `Views/Components/WindowChrome.swift` — `NSViewRepresentable` that reaches the underlying `NSWindow` to apply: `titleVisibility = .hidden`, `titlebarAppearsTransparent = true`, `.fullSizeContentView`, `appearance = .darkAqua`, clear `backgroundColor`. Exposed as `.cinematicWindowChrome()`.

### Wired
- **WallneticApp** — both Main and Settings scenes now apply `.cinematicWindowChrome()`. The Settings window no longer shows "Wallnetic Settings" in white; content extends under the traffic lights.

### TopNavigationBar
- Was a floating glass capsule with `.padding(.top)` leaving a dead black band above; now an in-window toolbar at the very top with `.padding(.leading, 84)` to make room for traffic lights.
- Background switched from `liquidGlassHUD` capsule to a flatter `ultraThinMaterial + dark tint` (the bar is wall-to-wall now).
- Bottom edge gets one hairline gradient — no more outer capsule stroke.
- **Active tab indicator** — wallpaper-derived accent was making the underline shout. Replaced the gradient underline with a refined Liquid-Glass pill: `Color.white.opacity(0.10)` fill + top-bright/bottom-dim refractive stroke. `matchedGeometryEffect` keeps the springy slide. Accent-independent so it never clashes.

### Settings sidebar
- 30pt traffic-light clearance at top.
- Removed the glowing red "SETTINGS" + gear icon — felt like a startup logo. Replaced with a quiet wordmark: **Wallnetic** (semibold white) + Settings (regular muted) — same language Apple's own System Settings uses.

### Settings detail pane
- 30pt traffic-light clearance.
- Section icon orb: removed the colored glow shadow; now just a hairline stroke + 0.16 fill so the accent reads without screaming.
- Title weight bold → semibold, tracking -0.2.

## Test plan
- [x] Debug + Release builds SUCCEEDED
- [x] 76/76 tests pass
- [ ] Open main window — TopNav sits flush at top; traffic lights overlay it cleanly; no dead black band
- [ ] Click a tab — selection pill slides between tabs without "red bar" feeling
- [ ] Open Settings (⌘,) — dark window all the way to traffic lights; no "Wallnetic Settings" title; sidebar wordmark reads quietly
- [ ] Change wallpaper — chrome retones but tab indicator stays neutral (accent-independent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)