### PR TITLE
Settings compact — wordmark inhabits title bar

### DIFF
--- a/src/Wallnetic/Views/Components/WindowChrome.swift
+++ b/src/Wallnetic/Views/Components/WindowChrome.swift
@@ -41,7 +41,9 @@ extension View {
             window.appearance = NSAppearance(named: .darkAqua)
             window.backgroundColor = .clear
             window.isOpaque = false
-            // Allow dragging from anywhere in the title-bar region.
+            // Remove the hairline that macOS otherwise draws between the
+            // title-bar zone and content — we have our own design.
+            window.titlebarSeparatorStyle = .none
             window.isMovableByWindowBackground = false
         })
     }

--- a/src/Wallnetic/Views/Main/SettingsView.swift
+++ b/src/Wallnetic/Views/Main/SettingsView.swift
@@ -21,7 +21,7 @@ struct SettingsView: View {
                 detail
             }
         }
-        .frame(width: 880, height: 560)
+        .frame(width: 820, height: 540)
         .preferredColorScheme(.dark)
     }
 
@@ -29,27 +29,25 @@ struct SettingsView: View {
 
     private var sidebar: some View {
         VStack(alignment: .leading, spacing: 0) {
-            // Traffic-light clearance — content stays under the lights, but
-            // we leave breathing room so the first row doesn't fight with
-            // the close/min/max buttons.
-            Color.clear.frame(height: 30)
-
-            // Subtle wordmark — no glowing icon, no startup-logo feel. The
-            // sidebar's purpose is obvious from context; this kicker is just
-            // a quiet anchor.
+            // Wordmark *inhabits* the title-bar row — no wasted clearance.
+            // Traffic lights occupy 0-66px from the leading edge; we offset
+            // the text so it never collides with them. ~28pt total height
+            // matches macOS's natural title-bar metrics.
             HStack(spacing: 0) {
                 Text("Wallnetic")
-                    .font(.system(size: 13, weight: .semibold, design: .rounded))
+                    .font(.system(size: 12, weight: .semibold, design: .rounded))
                     .foregroundColor(.white.opacity(0.92))
                     .tracking(-0.1)
                 Text(" Settings")
-                    .font(.system(size: 13, weight: .regular, design: .rounded))
+                    .font(.system(size: 12, weight: .regular, design: .rounded))
                     .foregroundColor(.white.opacity(0.45))
                     .tracking(-0.1)
                 Spacer()
             }
-            .padding(.horizontal, Space.lg)
-            .padding(.bottom, Space.md)
+            .padding(.leading, 80)  // traffic-light clearance
+            .padding(.trailing, Space.sm)
+            .frame(height: 28)
+            .padding(.bottom, Space.xs)
 
             ScrollView(showsIndicators: false) {
                 VStack(alignment: .leading, spacing: 2) {
@@ -120,8 +118,10 @@ struct SettingsView: View {
 
     private var detail: some View {
         VStack(alignment: .leading, spacing: 0) {
-            // Traffic-light clearance matching sidebar
-            Color.clear.frame(height: 30)
+            // Title-bar stripe — matches sidebar wordmark row height so the
+            // window top is one continuous horizontal band. Empty by design;
+            // gives the eye a clean rest above the section header.
+            Color.clear.frame(height: 28)
 
             HStack(spacing: Space.sm) {
                 Image(systemName: selection.icon)
@@ -148,7 +148,8 @@ struct SettingsView: View {
                 Spacer()
             }
             .padding(.horizontal, Space.xl + 4)
-            .padding(.bottom, Space.md + 2)
+            .padding(.top, Space.xs)
+            .padding(.bottom, Space.md - 2)
 
             Divider()
                 .overlay(LinearGradient(


### PR DESCRIPTION
The 30pt traffic-light clearance was wasted dead space — both sidebar and detail pane had it. Apple's own apps (Linear, Notion, Music, Mail) keep the title-bar zone *populated* with content next to the traffic lights instead of leaving it empty.

## Changes
- **Sidebar wordmark inhabits the title-bar row** at 28pt height. 80pt leading padding clears the traffic lights, then `Wallnetic` (semibold) + ` Settings` (regular muted) reads quietly beside them.
- **Detail pane** matches with a 28pt empty stripe so the top edge of the window is one continuous horizontal band. Section header starts immediately below.
- **Window size** trimmed 880×560 → 820×540 — same content, ~7% less footprint.
- **WindowChrome** sets `titlebarSeparatorStyle = .none` so macOS doesn't draw its default hairline under the title-bar zone (we have our own design there).

## Net
~30pt of vertical savings. Title-bar zone is no longer dead space; it's a content surface alongside the traffic lights.

## Test plan
- [x] Debug build SUCCEEDED
- [ ] Open Settings (⌘,) — wordmark sits beside traffic lights; no clearance band above; window feels tighter

🤖 Generated with [Claude Code](https://claude.com/claude-code)