### PR TITLE
Settings: real compact (ignoresSafeArea + WindowAwareView)

### DIFF
--- a/src/Wallnetic/Views/Components/WindowChrome.swift
+++ b/src/Wallnetic/Views/Components/WindowChrome.swift
@@ -8,20 +8,35 @@ struct WindowChrome: NSViewRepresentable {
     var configure: (NSWindow) -> Void
 
     func makeNSView(context: Context) -> NSView {
-        let view = NSView()
-        DispatchQueue.main.async {
-            if let window = view.window {
-                configure(window)
-            }
-        }
+        let view = WindowAwareView(onWindow: configure)
         return view
     }
 
     func updateNSView(_ nsView: NSView, context: Context) {
-        DispatchQueue.main.async {
-            if let window = nsView.window {
-                configure(window)
-            }
+        if let aware = nsView as? WindowAwareView {
+            aware.onWindow = configure
+            if let w = nsView.window { configure(w) }
+        }
+    }
+}
+
+/// NSView that fires its callback the moment it's attached to a window.
+/// More reliable than dispatch-async because that races the window's own
+/// configuration.
+private final class WindowAwareView: NSView {
+    var onWindow: ((NSWindow) -> Void)
+
+    init(onWindow: @escaping (NSWindow) -> Void) {
+        self.onWindow = onWindow
+        super.init(frame: .zero)
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        if let w = window {
+            onWindow(w)
         }
     }
 }

--- a/src/Wallnetic/Views/Main/SettingsView.swift
+++ b/src/Wallnetic/Views/Main/SettingsView.swift
@@ -20,6 +20,7 @@ struct SettingsView: View {
                     .overlay(Color.white.opacity(0.06))
                 detail
             }
+            .ignoresSafeArea(.all, edges: .top)  // claim the title-bar zone
         }
         .frame(width: 820, height: 540)
         .preferredColorScheme(.dark)


### PR DESCRIPTION
The previous compact attempt didn't actually put the wordmark next to the traffic lights — it still rendered visibly below them. Two root causes:

1. **SwiftUI Settings scene auto-inset** — even with `titlebarAppearsTransparent` + `.fullSizeContentView`, SwiftUI's Settings scene applies a `safeAreaInset` for the title-bar region. `.ignoresSafeArea(.all, edges: .top)` on the HStack reclaims it.

2. **WindowChrome race** — `.background(WindowChrome { ... })` used `DispatchQueue.main.async` from `makeNSView`, which could fire before the NSWindow finished its own setup. Window flags would then get overwritten back to defaults. Replaced with a `WindowAwareView` (NSView subclass) that overrides `viewDidMoveToWindow()` — guaranteed to run after the window is fully attached.

## Test plan
- [x] Debug build SUCCEEDED
- [ ] Open Settings (⌘,) — wordmark on same Y as traffic lights, no clearance band

🤖 Generated with [Claude Code](https://claude.com/claude-code)