### PR TITLE
Settings: WindowGroup migration — true hiddenTitleBar

### DIFF
--- a/src/Wallnetic/App/WallneticApp.swift
+++ b/src/Wallnetic/App/WallneticApp.swift
@@ -29,15 +29,27 @@ struct WallneticApp: App {
         .defaultPosition(.center)
         .commands {
             CommandGroup(replacing: .newItem) { }
+            CommandGroup(replacing: .appSettings) {
+                Button("Settings…") {
+                    openWindow(id: "settings")
+                }
+                .keyboardShortcut(",", modifiers: .command)
+            }
         }
         .handlesExternalEvents(matching: [])
 
-        // Settings Window
-        Settings {
+        // Settings Window — own WindowGroup so .windowStyle(.hiddenTitleBar)
+        // actually applies (`Settings {}` scene resists it). We wire ⌘,
+        // manually so the keyboard shortcut and menu item still work.
+        WindowGroup(id: "settings") {
             SettingsView()
                 .environmentObject(wallpaperManager)
                 .cinematicWindowChrome()
         }
+        .windowStyle(.hiddenTitleBar)
+        .windowResizability(.contentSize)
+        .defaultPosition(.center)
+        .handlesExternalEvents(matching: [])
 
         // Menu Bar Extra
         MenuBarExtra {

--- a/src/Wallnetic/Views/Main/TopNavigationBar.swift
+++ b/src/Wallnetic/Views/Main/TopNavigationBar.swift
@@ -32,6 +32,7 @@ struct TopNavigationBar: View {
     @State private var hoveredTab: NavigationTab?
     @FocusState private var searchFocused: Bool
     @Namespace private var tabUnderlineNS
+    @Environment(\.openWindow) private var openWindow
     var isScrolled: Bool = false
 
     var body: some View {
@@ -83,12 +84,13 @@ struct TopNavigationBar: View {
                 .menuIndicator(.hidden)
                 .frame(width: 30, height: 30)
 
-                if #available(macOS 14.0, *) {
-                    SettingsLink {
-                        ActionChip(icon: "gearshape.fill", accent: false)
-                    }
-                    .buttonStyle(.plain)
+                Button {
+                    openWindow(id: "settings")
+                } label: {
+                    ActionChip(icon: "gearshape.fill", accent: false)
                 }
+                .buttonStyle(.plain)
+                .keyboardShortcut(",", modifiers: .command)
             }
         }
         .padding(.leading, 84)        // reserve traffic-light real estate


### PR DESCRIPTION
SwiftUI's `Settings {}` scene resists `.windowStyle(.hiddenTitleBar)` and `.ignoresSafeArea(.top)` — the wordmark kept rendering visibly below the traffic lights despite multiple attempts. Root cause: the Settings scene applies its own non-overridable `safeAreaInset` for the title bar.

## Change
- `Settings { SettingsView() }` → `WindowGroup(id: "settings") { SettingsView() }` with `.windowStyle(.hiddenTitleBar)`. Now `.fullSizeContentView` actually takes effect.
- `⌘,` wired manually via `CommandGroup(replacing: .appSettings) { Button { openWindow(id: "settings") } }`.
- `TopNavigationBar`'s `SettingsLink` (which only targets a real `Settings {}` scene) → `Button { openWindow(id: "settings") }` with the same `⌘,` shortcut.

## Net
Content now reaches `y=0`, traffic lights overlay it, wordmark inhabits the title-bar zone alongside them. Compact for real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)