### PR TITLE
Suppress macOS focus ring on Settings sidebar rows

### DIFF
--- a/src/Wallnetic/Views/Components/FocusHalo.swift
+++ b/src/Wallnetic/Views/Components/FocusHalo.swift
@@ -33,4 +33,17 @@ extension View {
     func focusHalo(_ isFocused: Bool, radius: CGFloat = Radius.control, accent: Color = .accentColor) -> some View {
         modifier(FocusHalo(isFocused: isFocused, radius: radius, accent: accent))
     }
+
+    /// Suppresses macOS's system focus ring (the thick pink/blue rounded
+    /// rectangle that appears around a focused Button). Use on custom
+    /// list/sidebar rows whose selection is already indicated visually.
+    /// No-op on macOS < 14.
+    @ViewBuilder
+    func suppressFocusRing() -> some View {
+        if #available(macOS 14.0, *) {
+            self.focusEffectDisabled()
+        } else {
+            self
+        }
+    }
 }

--- a/src/Wallnetic/Views/Main/SettingsView.swift
+++ b/src/Wallnetic/Views/Main/SettingsView.swift
@@ -319,6 +319,7 @@ private struct SidebarRow: View {
         }
         .buttonStyle(.plain)
         .contentShape(Rectangle())
+        .suppressFocusRing()
         .onHover { hover = $0 }
         .animation(.easeOut(duration: 0.12), value: hover)
         .animation(.easeOut(duration: 0.18), value: isSelected)


### PR DESCRIPTION
Selected SidebarRow Button was getting the OS-default focus ring (thick rounded rectangle) on click. Added `View.suppressFocusRing()` helper (macOS 14+ `focusEffectDisabled()`, no-op fallback) and applied to SidebarRow. Selection is already indicated by the glass pill; the system ring was just visual noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)