### PR TITLE
Focus rings + gradient banding fix

### DIFF
--- a/src/Wallnetic/Views/Components/AmbientStage.swift
+++ b/src/Wallnetic/Views/Components/AmbientStage.swift
@@ -26,6 +26,10 @@ struct AmbientStage: ViewModifier {
             ambientOverlay
                 .allowsHitTesting(false)
                 .blendMode(.plusLighter)
+            // Anti-banding noise — applied once over the whole stage so
+            // every radial gradient layer dithers cleanly.
+            GrainOverlay(intensity: 0.04)
+                .ignoresSafeArea()
         }
         .background(stageFloor.ignoresSafeArea())
         .onAppear {

--- a/src/Wallnetic/Views/Components/GrainOverlay.swift
+++ b/src/Wallnetic/Views/Components/GrainOverlay.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+
+/// Static stochastic grain. SwiftUI's gradients render at 8-bit color
+/// depth without dithering, so very dark/low-contrast gradients (the
+/// kind every cinematic dark UI uses) show banding as visible concentric
+/// rings. A 1-2% noise overlay destroys the banding because the eye
+/// averages noise back to the smooth gradient.
+///
+/// Canvas-rendered once on appear, deterministic seed → same texture
+/// every launch (no flicker between resizes).
+struct GrainOverlay: View {
+    var intensity: Double = 0.05
+    var dotsPerPx: Double = 0.0006  // ~600 dots in a 1000×1000 area
+
+    var body: some View {
+        Canvas { ctx, size in
+            let count = Int(Double(size.width * size.height) * dotsPerPx)
+            var rng = SeedableRNG(seed: 1337)
+            for _ in 0..<count {
+                let x = Double(rng.nextUInt() % UInt32(max(1, size.width)))
+                let y = Double(rng.nextUInt() % UInt32(max(1, size.height)))
+                let a = intensity * 0.4 + intensity * Double(rng.nextUInt() % 100) / 100.0
+                let rect = CGRect(x: x, y: y, width: 1, height: 1)
+                ctx.fill(Path(rect), with: .color(.white.opacity(a)))
+            }
+        }
+        .blendMode(.overlay)
+        .allowsHitTesting(false)
+    }
+
+    struct SeedableRNG {
+        var state: UInt32
+        init(seed: UInt32) { state = seed | 1 }
+        mutating func nextUInt() -> UInt32 {
+            state = state &* 1664525 &+ 1013904223
+            return state
+        }
+    }
+}
+
+extension View {
+    /// Adds a non-interactive grain overlay on top of the view. Apply
+    /// once per surface (window root, sheet, panel) where gradient
+    /// banding would otherwise show.
+    func grainOverlay(intensity: Double = 0.05) -> some View {
+        overlay(GrainOverlay(intensity: intensity))
+    }
+}

--- a/src/Wallnetic/Views/Components/WallneticButton.swift
+++ b/src/Wallnetic/Views/Components/WallneticButton.swift
@@ -30,6 +30,7 @@ enum WallneticButton {
         .buttonStyle(LiquidPrimaryButtonStyle(accent: accent, isEnabled: isEnabled))
         .disabled(!isEnabled)
         .keyboardShortcut(.return)
+        .suppressFocusRing()
     }
 
     static func ghost(
@@ -48,6 +49,7 @@ enum WallneticButton {
             }
         }
         .buttonStyle(LiquidGhostButtonStyle())
+        .suppressFocusRing()
     }
 
     static func cancel(
@@ -61,6 +63,7 @@ enum WallneticButton {
         }
         .buttonStyle(.plain)
         .keyboardShortcut(.escape)
+        .suppressFocusRing()
     }
 }
 

--- a/src/Wallnetic/Views/Main/SettingsView.swift
+++ b/src/Wallnetic/Views/Main/SettingsView.swift
@@ -8,9 +8,16 @@ struct SettingsView: View {
             // Full bleed dark backdrop replacing the system Form chrome
             Color(red: 0.04, green: 0.05, blue: 0.09)
                 .ignoresSafeArea()
+            // Subtle ambient tint — kept very low contrast and supported
+            // by a grain overlay below so the radial doesn't band.
             RadialGradient(
-                colors: [Color.accentColor.opacity(0.10), .clear],
-                center: .topLeading, startRadius: 5, endRadius: 360
+                colors: [
+                    Color.accentColor.opacity(0.08),
+                    Color.accentColor.opacity(0.02),
+                    .clear
+                ],
+                center: UnitPoint(x: 0.05, y: 0.05),
+                startRadius: 5, endRadius: 480
             )
             .ignoresSafeArea()
 
@@ -21,6 +28,11 @@ struct SettingsView: View {
                 detail
             }
             .ignoresSafeArea(.all, edges: .top)  // claim the title-bar zone
+
+            // Anti-banding noise — kills the concentric ring artifacts
+            // that show on dark radial gradients at 8-bit color depth.
+            GrainOverlay(intensity: 0.045)
+                .ignoresSafeArea()
         }
         .frame(width: 820, height: 540)
         .preferredColorScheme(.dark)

--- a/src/Wallnetic/Views/Main/TopNavigationBar.swift
+++ b/src/Wallnetic/Views/Main/TopNavigationBar.swift
@@ -83,6 +83,7 @@ struct TopNavigationBar: View {
                 .menuStyle(.borderlessButton)
                 .menuIndicator(.hidden)
                 .frame(width: 30, height: 30)
+                .suppressFocusRing()
 
                 Button {
                     openWindow(id: "settings")
@@ -91,6 +92,7 @@ struct TopNavigationBar: View {
                 }
                 .buttonStyle(.plain)
                 .keyboardShortcut(",", modifiers: .command)
+                .suppressFocusRing()
             }
         }
         .padding(.leading, 84)        // reserve traffic-light real estate
@@ -165,6 +167,7 @@ struct TopNavigationBar: View {
             )
         }
         .buttonStyle(.plain)
+        .suppressFocusRing()
         .onHover { h in
             withAnimation(.easeOut(duration: Anim.micro)) { hoveredTab = h ? tab : nil }
         }
@@ -201,6 +204,7 @@ struct TopNavigationBar: View {
                         .foregroundColor(.white.opacity(0.4))
                 }
                 .buttonStyle(.plain)
+                .suppressFocusRing()
             }
             .padding(.horizontal, 10)
             .padding(.vertical, 6)
@@ -242,6 +246,7 @@ struct TopNavigationBar: View {
             }
             .buttonStyle(.plain)
             .keyboardShortcut("f", modifiers: .command)
+            .suppressFocusRing()
         }
     }
 }

--- a/src/Wallnetic/Wallnetic.xcodeproj/project.pbxproj
+++ b/src/Wallnetic/Wallnetic.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		27E8C6194A802AD6C3726D0A /* AmbientStage.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA26B4DDB98EF77D98CE5821 /* AmbientStage.swift */; };
 		284D0925EA9AEC2B302910D1 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BF36E216B5F900C62E824B59 /* Assets.xcassets */; };
 		29D5A45CA0BA3716AFA45522 /* WallneticButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07818DDC6C7B04DED71808AA /* WallneticButton.swift */; };
+		2B0D5970F968D01CC1E3B8B8 /* GrainOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10E68AD45A1FAF11457CDB94 /* GrainOverlay.swift */; };
 		2C5619331688457B6A844B93 /* CollectionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31C51D17BDBBADCDF4D5CB43 /* CollectionsView.swift */; };
 		2D30EDC8BD2E940365F05AB0 /* WallneticWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69A7F21804AB5D266A239578 /* WallneticWidget.swift */; };
 		38BD342CB024693C99DB8B35 /* AudioVisualizerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 082027791B67C0B2DBD43F97 /* AudioVisualizerManager.swift */; };
@@ -179,6 +180,7 @@
 		0D76E5D0AB6B966E492D0342 /* WallpaperGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperGridView.swift; sourceTree = "<group>"; };
 		0DF980A4142FBBE468FBBD05 /* SchedulerSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchedulerSettingsView.swift; sourceTree = "<group>"; };
 		102BCD8F05208BC14E211E51 /* StoreKitManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKitManager.swift; sourceTree = "<group>"; };
+		10E68AD45A1FAF11457CDB94 /* GrainOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrainOverlay.swift; sourceTree = "<group>"; };
 		11FC204622DAABAAA4F064B4 /* ThumbnailCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThumbnailCache.swift; sourceTree = "<group>"; };
 		134AA54986991D7480CC4CD8 /* SmallWidgetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmallWidgetView.swift; sourceTree = "<group>"; };
 		140AE9B28FFA1BF12B3651C5 /* NotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManager.swift; sourceTree = "<group>"; };
@@ -505,6 +507,7 @@
 				BA26B4DDB98EF77D98CE5821 /* AmbientStage.swift */,
 				DFF460340111975F4DA40C32 /* DesignTokens.swift */,
 				F6E13A8C8EF384BF16EDF962 /* FocusHalo.swift */,
+				10E68AD45A1FAF11457CDB94 /* GrainOverlay.swift */,
 				4BD359DF3443AB6E3242CA90 /* LiquidGlass.swift */,
 				5FD8494A42E5AA356A35BA25 /* StrikingEffects.swift */,
 				07818DDC6C7B04DED71808AA /* WallneticButton.swift */,
@@ -803,6 +806,7 @@
 				CE93C5919FE1E7FAC086C58E /* FavoriteStylesManager.swift in Sources */,
 				C1489B79C3339AE81BA61D13 /* FocusHalo.swift in Sources */,
 				E670DC0DFE3A0970082E73EF /* GenerationHistory.swift in Sources */,
+				2B0D5970F968D01CC1E3B8B8 /* GrainOverlay.swift in Sources */,
 				8BED6ED6D599D3F3C32821D5 /* HistoryView.swift in Sources */,
 				131EDF3DA15DA0EEA84918A4 /* HomeView.swift in Sources */,
 				1CA1504E421EAE5C547DF122 /* KeychainManager.swift in Sources */,


### PR DESCRIPTION
Two separate window-chrome polish items.

## 1. macOS focus ring suppression (continuation of #194)
The system focus ring kept showing on every clicked Button in custom chrome — looks crude on dark cinematic surfaces. Applied \`.suppressFocusRing()\` to:
- \`WallneticButton.primary\`, \`.ghost\`, \`.cancel\`
- TopNav search placeholder, search-close, tab buttons, Import menu, Settings button

## 2. Gradient banding (concentric ring artifacts on dark radial gradients)
SwiftUI's gradients render at 8-bit color depth without dithering. Dark/low-contrast radials show visible bands. Industry fix: overlay 1-2% noise so the eye averages it back to a smooth gradient.

- New \`Views/Components/GrainOverlay.swift\` — Canvas-rendered deterministic noise (\`seed: 1337\`, ~600 dots / 1Mpx, \`.blendMode(.overlay)\`)
- Applied: \`AmbientStage\` (main window) and \`SettingsView\` backdrop
- Also softened the Settings radial gradient: 3-stop (\`0.08 → 0.02 → clear\`) instead of single-stop, slightly off-corner center

## Test plan
- [x] Debug build SUCCEEDED
- [ ] Click any button — no pink focus rectangle
- [ ] Open Settings (⌘,) — concentric rings in the backdrop are gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)