### PR TITLE
Audio visualizer soft remove — TCC/SCStream UX sorunlari

### DIFF
--- a/src/Wallnetic/App/AppDelegate.swift
+++ b/src/Wallnetic/App/AppDelegate.swift
@@ -38,9 +38,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // Setup global hotkeys
         setupGlobalHotkeys()
 
-        // Initialize desktop overlays (they self-restore from AppStorage)
-        // NowPlayingOverlayController disabled until proper code signing is set up
-        _ = AudioVisualizerOverlayController.shared
+        // Audio visualizer overlay disabled in v1.3.1 — TCC/SCStream UX issues.
+        // Files retained for future re-enable; init is gated to skip the
+        // lazy singleton allocation so the overlay never auto-restores.
+        runAudioVisualizerMigration()
 
         // Battery prompt (#172) — if we launched while on battery, ask the user
         // whether to keep the live wallpaper running. Delayed so PowerManager
@@ -50,6 +51,21 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         logger.info("Wallnetic started successfully")
+    }
+
+    // MARK: - Audio Visualizer Migration (v1.3.1)
+
+    /// One-shot migration: turns off the audio visualizer overlay for users
+    /// who had it enabled before v1.3.1, where the feature is hidden from
+    /// the UI. Re-enabling is a no-op since the migration marker stops
+    /// the flag from being touched on subsequent launches.
+    private func runAudioVisualizerMigration() {
+        let key = "audioVisualizer.migrated.v1.3.1"
+        let defaults = UserDefaults.standard
+        guard !defaults.bool(forKey: key) else { return }
+        defaults.set(false, forKey: "audioVisualizer.overlayEnabled")
+        defaults.set(false, forKey: "audioVisualizer.enabled")
+        defaults.set(true, forKey: key)
     }
 
     // MARK: - Global Hotkeys

--- a/src/Wallnetic/Views/Main/MenuBarView.swift
+++ b/src/Wallnetic/Views/Main/MenuBarView.swift
@@ -139,16 +139,6 @@ struct MenuBarView: View {
                 )
             }
 
-            // Audio Visualizer toggle
-            Button {
-                AudioVisualizerOverlayController.shared.toggle()
-            } label: {
-                Label(
-                    AudioVisualizerOverlayController.shared.isVisible ? "Hide Audio Visualizer" : "Show Audio Visualizer",
-                    systemImage: "waveform"
-                )
-            }
-
             Divider()
 
             // About & Quit

--- a/src/Wallnetic/Views/Settings/SettingsSubViews.swift
+++ b/src/Wallnetic/Views/Settings/SettingsSubViews.swift
@@ -114,7 +114,6 @@ struct GeneralSettingsView: View {
     @AppStorage("island.enabled") private var islandEnabled = false
     @AppStorage("globalHotkeysEnabled") private var globalHotkeysEnabled = false
     @AppStorage("nowPlayingOverlay.enabled") private var nowPlayingEnabled = false
-    @AppStorage("audioVisualizer.overlayEnabled") private var audioVisualizerEnabled = false
 
     var body: some View {
         Form {
@@ -139,17 +138,6 @@ struct GeneralSettingsView: View {
                     .help("Show wallpaper controls in a floating pill at the top of the screen")
                 Toggle("Global Hotkeys", isOn: $globalHotkeysEnabled)
                     .help("⌘⇧→ Next, ⌘⇧← Prev, ⌘⇧P Play/Pause, ⌘⇧R Random (restart required)")
-            }
-            Section("Desktop Overlays") {
-                Toggle("Audio visualizer", isOn: $audioVisualizerEnabled)
-                    .onChange(of: audioVisualizerEnabled) { newValue in
-                        if newValue { AudioVisualizerOverlayController.shared.show() }
-                        else { AudioVisualizerOverlayController.shared.hide() }
-                    }
-                    .help("Frequency bars driven by system audio or the microphone")
-                if audioVisualizerEnabled {
-                    AudioVisualizerSourcePicker()
-                }
             }
             Section("Library") {
                 LabeledContent("Location") {
@@ -176,81 +164,6 @@ struct GeneralSettingsView: View {
             else { try SMAppService.mainApp.unregister() }
         } catch {
             Log.app.error("Failed to set launch at login: \(error.localizedDescription, privacy: .public)")
-        }
-    }
-}
-
-private struct AudioVisualizerSourcePicker: View {
-    @ObservedObject private var manager = AudioVisualizerManager.shared
-    @State private var source: AudioVisualizerManager.Source = .system
-    @State private var style: AudioVisualizerManager.Style = .bars
-    @State private var position: AudioVisualizerManager.Position = .bottomRight
-    @State private var sizePreset: AudioVisualizerManager.Size = .medium
-
-    var body: some View {
-        Picker("Audio source", selection: $source) {
-            ForEach(AudioVisualizerManager.Source.allCases) { s in
-                Text(s.label).tag(s)
-            }
-        }
-        .pickerStyle(.segmented)
-        .onAppear {
-            source = manager.source
-            style = manager.style
-            position = manager.position
-            sizePreset = manager.sizePreset
-        }
-        .onChange(of: source) { newValue in manager.source = newValue }
-
-        // #159 — sensitivity slider
-        VStack(alignment: .leading, spacing: 4) {
-            HStack {
-                Text("Sensitivity")
-                Spacer()
-                Text(String(format: "%.1fx", manager.sensitivity))
-                    .foregroundColor(.secondary)
-                    .monospacedDigit()
-            }
-            Slider(value: $manager.sensitivity, in: 0.3...3.0, step: 0.1)
-        }
-
-        // #160 — visual style
-        Picker("Style", selection: $style) {
-            ForEach(AudioVisualizerManager.Style.allCases) { s in
-                Text(s.label).tag(s)
-            }
-        }
-        .pickerStyle(.segmented)
-        .onChange(of: style) { newValue in manager.style = newValue }
-
-        // #162 — size preset
-        Picker("Size", selection: $sizePreset) {
-            ForEach(AudioVisualizerManager.Size.allCases) { s in
-                Text(s.label).tag(s)
-            }
-        }
-        .pickerStyle(.segmented)
-        .onChange(of: sizePreset) { newValue in manager.sizePreset = newValue }
-
-        // #161 — corner anchor
-        Picker("Position", selection: $position) {
-            ForEach(AudioVisualizerManager.Position.allCases) { p in
-                Text(p.label).tag(p)
-            }
-        }
-        .onChange(of: position) { newValue in manager.position = newValue }
-
-        if let error = manager.lastError {
-            Label(error, systemImage: "exclamationmark.triangle.fill")
-                .font(.caption)
-                .foregroundColor(.orange)
-        } else if manager.permissionDenied {
-            Label(
-                "Permission denied. Enable Screen Recording (for system audio) or Microphone access in System Settings.",
-                systemImage: "lock.fill"
-            )
-            .font(.caption)
-            .foregroundColor(.secondary)
         }
     }
 }


### PR DESCRIPTION
## Summary
- Audio visualizer UI'dan tamamen kaldirildi (Settings + MenuBar)
- AppDelegate'teki overlay init kapatildi
- v1.3.1 migration: \`audioVisualizer.overlayEnabled\` ve \`audioVisualizer.enabled\` AppStorage flag'leri otomatik \`false\`'a duser
- Manager/Controller/View dosyalari intact — v1.4'te bug fix yapilirsa hizla geri acilir

## Neden soft remove?
Hard delete yerine kod korundu cunku:
- 502 satir FFT pipeline + SCStream + AVAudioEngine implementasyonu calisiyordur
- Asil sorun TCC permission UX (Screen Recording istegi sadece audio icin), -12737 SCStream log spam, mic format=0 race condition
- Bug fix yapilabilir, sadece simdi degil

## Bilinen sorunlar (v1.4'te ele alinacak)
- SCStream audio-only icin 2x2 dummy video config gerekiyor
- \`installTapOnBus\` Objective-C exception fırlatabiliyor (USB interface hot-plug)
- \`SCShareableContent\` Screen Recording TCC sorusu yaratiyor — App Store reviewer'in dikkatini cekebilir

## Test plan
- [x] 86/86 unit test pass
- [x] Build SUCCEEDED (Debug, macOS 13.0+)
- [x] Settings → General: "Desktop Overlays" section yok
- [x] MenuBar: "Show Audio Visualizer" item yok
- [ ] \`defaults read com.wallnetic.app audioVisualizer.overlayEnabled\` migration sonrasi 0
- [ ] Eski user true degerini set etmisse migration tetiklensin

Co-Authored-By: Claude Opus 4.7