### PR TITLE
Theme: Appearance (System/Light/Dark) cift override fix

### DIFF
--- a/src/Wallnetic/Services/ThemeManager.swift
+++ b/src/Wallnetic/Services/ThemeManager.swift
@@ -13,6 +13,36 @@ enum AppearanceMode: String, CaseIterable, Codable {
         case .dark: return "moon.fill"
         }
     }
+
+    /// SwiftUI color scheme override — `nil` means "follow system".
+    /// Used in place of hardcoded `.preferredColorScheme(.dark)` so the
+    /// Appearance setting actually takes effect.
+    var swiftUIColorScheme: ColorScheme? {
+        switch self {
+        case .system: return nil
+        case .light:  return .light
+        case .dark:   return .dark
+        }
+    }
+
+    /// AppKit NSAppearance — `nil` means "follow NSApp/system".
+    /// Used by WindowChrome so traffic lights + scrollbars match the
+    /// SwiftUI color scheme instead of being permanently dark.
+    var nsAppearance: NSAppearance? {
+        switch self {
+        case .system: return nil
+        case .light:  return NSAppearance(named: .aqua)
+        case .dark:   return NSAppearance(named: .darkAqua)
+        }
+    }
+}
+
+extension Notification.Name {
+    /// Fired by ThemeManager whenever appearanceMode changes so AppKit
+    /// chrome (WindowChrome) can re-apply NSAppearance to already-open
+    /// windows. Without this, only newly-created windows pick up the
+    /// new appearance.
+    static let appAppearanceDidChange = Notification.Name("appAppearanceDidChange")
 }
 
 /// Manager for app theme/appearance settings
@@ -96,14 +126,15 @@ class ThemeManager: ObservableObject {
 
     func applyAppearance() {
         DispatchQueue.main.async {
-            switch self.appearanceMode {
-            case .system:
-                NSApp.appearance = nil
-            case .light:
-                NSApp.appearance = NSAppearance(named: .aqua)
-            case .dark:
-                NSApp.appearance = NSAppearance(named: .darkAqua)
+            let appearance = self.appearanceMode.nsAppearance
+            NSApp.appearance = appearance
+            // Already-open titled windows don't re-read NSApp.appearance,
+            // so we have to push the change down to each one. Sheets,
+            // popovers and panels keep their own chrome.
+            for window in NSApp.windows where window.styleMask.contains(.titled) {
+                window.appearance = appearance
             }
+            NotificationCenter.default.post(name: .appAppearanceDidChange, object: nil)
         }
     }
 }

--- a/src/Wallnetic/Views/Components/WallneticSheet.swift
+++ b/src/Wallnetic/Views/Components/WallneticSheet.swift
@@ -22,6 +22,7 @@ struct WallneticSheet<Content: View, Footer: View>: View {
     var width: CGFloat = 380
     @ViewBuilder let content: () -> Content
     @ViewBuilder let footer: () -> Footer
+    @ObservedObject private var themeManager = ThemeManager.shared
 
     var body: some View {
         VStack(spacing: 0) {
@@ -47,7 +48,7 @@ struct WallneticSheet<Content: View, Footer: View>: View {
             accentStrength: 0.14,
             tone: .prominent
         ))
-        .preferredColorScheme(.dark)
+        .preferredColorScheme(themeManager.appearanceMode.swiftUIColorScheme)
     }
 
     // MARK: - Header

--- a/src/Wallnetic/Views/Components/WindowChrome.swift
+++ b/src/Wallnetic/Views/Components/WindowChrome.swift
@@ -20,18 +20,33 @@ struct WindowChrome: NSViewRepresentable {
     }
 }
 
-/// NSView that fires its callback the moment it's attached to a window.
-/// More reliable than dispatch-async because that races the window's own
-/// configuration.
+/// NSView that fires its callback the moment it's attached to a window,
+/// and again whenever the app appearance changes — so an already-mounted
+/// chrome view picks up Light/Dark toggles without recreating the scene.
 private final class WindowAwareView: NSView {
     var onWindow: ((NSWindow) -> Void)
+    private var appearanceObserver: NSObjectProtocol?
 
     init(onWindow: @escaping (NSWindow) -> Void) {
         self.onWindow = onWindow
         super.init(frame: .zero)
+        appearanceObserver = NotificationCenter.default.addObserver(
+            forName: .appAppearanceDidChange,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            guard let self, let w = self.window else { return }
+            self.onWindow(w)
+        }
     }
 
     required init?(coder: NSCoder) { fatalError() }
+
+    deinit {
+        if let appearanceObserver {
+            NotificationCenter.default.removeObserver(appearanceObserver)
+        }
+    }
 
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
@@ -62,7 +77,11 @@ extension View {
             window.titleVisibility = .hidden
             window.titlebarAppearsTransparent = true
             window.styleMask.insert(.fullSizeContentView)
-            window.appearance = NSAppearance(named: .darkAqua)
+            // Theme-aware: nil means "follow NSApp.appearance / system",
+            // so System/Light/Dark from Settings actually takes effect.
+            // WindowAwareView listens for .appAppearanceDidChange and
+            // re-runs this closure when the user toggles.
+            window.appearance = ThemeManager.shared.appearanceMode.nsAppearance
             window.backgroundColor = .clear
             window.isOpaque = false
             // Remove the hairline that macOS otherwise draws between the

--- a/src/Wallnetic/Views/Main/ContentView.swift
+++ b/src/Wallnetic/Views/Main/ContentView.swift
@@ -5,6 +5,7 @@ struct ContentView: View {
     @EnvironmentObject var wallpaperManager: WallpaperManager
     @ObservedObject private var downloadManager = DownloadManager.shared
     @ObservedObject private var errorReporter = ErrorReporter.shared
+    @ObservedObject private var themeManager = ThemeManager.shared
     @StateObject private var dynamicAccent = DynamicAccent.shared
     @State private var selectedTab: NavigationTab = .home
     @State private var isImporting = false
@@ -56,7 +57,7 @@ struct ContentView: View {
             }
         }
         .ambientStage()
-        .preferredColorScheme(.dark)
+        .preferredColorScheme(themeManager.appearanceMode.swiftUIColorScheme)
         .fileImporter(
             isPresented: $isImporting,
             allowedContentTypes: [.movie, .mpeg4Movie, .quickTimeMovie],

--- a/src/Wallnetic/Views/Main/OnboardingView.swift
+++ b/src/Wallnetic/Views/Main/OnboardingView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 /// orb, staggered typography reveal, custom progress capsule.
 struct OnboardingView: View {
     @Binding var isPresented: Bool
+    @ObservedObject private var themeManager = ThemeManager.shared
     @State private var currentStep = 0
     @State private var orbPhase: Double = 0
 
@@ -73,7 +74,7 @@ struct OnboardingView: View {
             }
         }
         .frame(width: 640, height: 520)
-        .preferredColorScheme(.dark)
+        .preferredColorScheme(themeManager.appearanceMode.swiftUIColorScheme)
         .onAppear {
             withAnimation(.linear(duration: 16).repeatForever(autoreverses: true)) {
                 orbPhase = 1

--- a/src/Wallnetic/Views/Main/SettingsView.swift
+++ b/src/Wallnetic/Views/Main/SettingsView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct SettingsView: View {
+    @ObservedObject private var themeManager = ThemeManager.shared
     @State private var selection: SettingsSection = .general
 
     var body: some View {
@@ -35,7 +36,7 @@ struct SettingsView: View {
                 .ignoresSafeArea()
         }
         .frame(width: 820, height: 540)
-        .preferredColorScheme(.dark)
+        .preferredColorScheme(themeManager.appearanceMode.swiftUIColorScheme)
     }
 
     // MARK: - Sidebar


### PR DESCRIPTION
## Summary
- ThemeManager.applyAppearance() artik gercekten gorsele yansiyor
- 5 hardcoded \`.preferredColorScheme(.dark)\` ve \`NSAppearance(named: .darkAqua)\` override'i kaldirildi
- Toggle anlik yansiyor (WindowAwareView observer)

## Root cause
Toggle dogru calisiyordu (NSApp.appearance set ediliyordu) ama:
1. SwiftUI \`.preferredColorScheme(.dark)\` -> tum window'lar dark zorlu
2. AppKit \`window.appearance = .darkAqua\` -> traffic light + scrollbar dark zorlu

Bu ikisi NSApp.appearance'i override ediyordu.

## Fix
- \`AppearanceMode\` icin computed \`swiftUIColorScheme\` ve \`nsAppearance\` eklendi
- 4 SwiftUI view (ContentView, SettingsView, OnboardingView, WallneticSheet) artik ThemeManager'dan okuyor
- WindowChrome.swift: WindowAwareView .appAppearanceDidChange observer ekledi - toggle anlik aktif
- ThemeManager.applyAppearance() acik window'lari da iterate ediyor

## Bilinen tradeoff
Liquid Glass + AmbientStage dark icin tonlanmis. Light mode'da bazi yuzeyler
(grain overlay, sheet header tint) silik gorunur. v1.4'te light-tone variant
sweep yapilacak.

## Test plan
- [x] 86/86 unit test pass
- [x] Build SUCCEEDED
- [ ] Settings -> Appearance: System/Light/Dark her uci toggle gorsele yansisin
- [ ] Sistem appearance degistiginde System modu otomatik takip etsin
- [ ] Onboarding ve sheet light/dark gozetim
- [ ] Traffic light + scrollbar dogru renkte gozuksun

Co-Authored-By: Claude Opus 4.7