### PR TITLE
Light theme polish: tum surfaces theme-aware (Surface tokens)

### DIFF
--- a/src/Wallnetic/Views/Components/AmbientStage.swift
+++ b/src/Wallnetic/Views/Components/AmbientStage.swift
@@ -87,12 +87,12 @@ struct AmbientStage: ViewModifier {
 
     // MARK: - Floor (behind content)
 
-    /// Subtle base wash so the whole window is never pure black, even
-    /// before content fades in.
+    /// Subtle base wash so the whole window is never pure black/white, even
+    /// before content fades in. Theme-aware via `Surface.stageFloor`.
     private var stageFloor: some View {
         ZStack {
-            Color(red: 0.02, green: 0.025, blue: 0.05)
-            // Inverted radial — darker at corners
+            Surface.stageFloor
+            // Inverted radial — pulls the accent glow toward the center
             RadialGradient(
                 colors: [accent.primary.opacity(0.05 * accent.glow), .clear],
                 center: .init(x: 0.5, y: 0.4),
@@ -131,7 +131,7 @@ struct AmbientStage: ViewModifier {
                 )
 
                 RadialGradient(
-                    colors: [.clear, .black.opacity(0.35)],
+                    colors: [.clear, Surface.vignetteEdge],
                     center: .center,
                     startRadius: min(geo.size.width, geo.size.height) * 0.35,
                     endRadius: max(geo.size.width, geo.size.height) * 0.75

--- a/src/Wallnetic/Views/Components/DesignTokens.swift
+++ b/src/Wallnetic/Views/Components/DesignTokens.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import AppKit
 
 // MARK: - Concentric Radius Scale
 //
@@ -99,4 +100,91 @@ extension Text {
             .tracking(Typo.dataTracking)
             .foregroundColor(color)
     }
+}
+
+// MARK: - Adaptive Surface Palette
+//
+// One source of truth for every "this should be dark in dark mode, light
+// in light mode" color. Built on top of NSColor's dynamic provider so the
+// color tracks NSApp.appearance in real time — no @Environment plumbing.
+
+extension Color {
+    /// Returns dark on .darkAqua, light on .aqua. Tracks NSApp.appearance.
+    static func adaptive(dark: Color, light: Color) -> Color {
+        Color(NSColor(name: nil) { appearance in
+            let isDark = appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+            return isDark ? NSColor(dark) : NSColor(light)
+        })
+    }
+}
+
+/// Theme-aware surface tokens. Numbers chosen to match the existing dark
+/// stage exactly; light variants picked for contrast against `.primary`
+/// text and to keep accent gradients legible.
+enum Surface {
+    /// Deepest backdrop behind everything (ambient stage floor).
+    static var stageFloor: Color { .adaptive(
+        dark:  Color(red: 0.02, green: 0.025, blue: 0.05),
+        light: Color(red: 0.96, green: 0.965, blue: 0.98)
+    )}
+
+    /// Settings + onboarding window-fill background.
+    static var windowFill: Color { .adaptive(
+        dark:  Color(red: 0.04, green: 0.05, blue: 0.09),
+        light: Color(red: 0.97, green: 0.975, blue: 0.985)
+    )}
+
+    /// HomeView vignette / footer fade target.
+    static var deepFade: Color { .adaptive(
+        dark:  Color(red: 0.02, green: 0.02, blue: 0.06),
+        light: Color(red: 0.94, green: 0.945, blue: 0.96)
+    )}
+
+    /// Vignette darkening (or in light mode, mild edge softening).
+    static var vignetteEdge: Color { .adaptive(
+        dark:  .black.opacity(0.35),
+        light: .black.opacity(0.06)
+    )}
+
+    /// Liquid Glass base fill — standard tone.
+    static var glassStandard: Color { .adaptive(
+        dark:  .black.opacity(0.18),
+        light: .white.opacity(0.55)
+    )}
+
+    /// Liquid Glass base fill — prominent tone (denser floating chrome).
+    static var glassProminent: Color { .adaptive(
+        dark:  .black.opacity(0.32),
+        light: .white.opacity(0.70)
+    )}
+
+    /// Liquid Glass base fill — control tone (no material blur).
+    static var glassControl: Color { .adaptive(
+        dark:  .white.opacity(0.05),
+        light: .black.opacity(0.04)
+    )}
+
+    /// Top lensing stroke — bright on glass.
+    static var glassTopStroke: Color { .adaptive(
+        dark:  .white.opacity(0.16),
+        light: .white.opacity(0.85)
+    )}
+
+    /// Bottom lensing stroke — dim on glass.
+    static var glassBottomStroke: Color { .adaptive(
+        dark:  .black.opacity(0.32),
+        light: .black.opacity(0.14)
+    )}
+
+    /// Inner refraction highlight.
+    static var glassInnerHighlight: Color { .adaptive(
+        dark:  .white.opacity(0.06),
+        light: .white.opacity(0.55)
+    )}
+
+    /// Generic divider hairline color.
+    static var hairline: Color { .adaptive(
+        dark:  .white.opacity(0.06),
+        light: .black.opacity(0.08)
+    )}
 }

--- a/src/Wallnetic/Views/Components/GrainOverlay.swift
+++ b/src/Wallnetic/Views/Components/GrainOverlay.swift
@@ -9,6 +9,7 @@ import SwiftUI
 /// Canvas-rendered once on appear, deterministic seed → same texture
 /// every launch (no flicker between resizes).
 struct GrainOverlay: View {
+    @Environment(\.colorScheme) private var colorScheme
     var intensity: Double = 0.05
     var dotsPerPx: Double = 0.0006  // ~600 dots in a 1000×1000 area
 
@@ -16,19 +17,25 @@ struct GrainOverlay: View {
         Canvas { ctx, size in
             let count = Int(Double(size.width * size.height) * dotsPerPx)
             var rng = SeedableRNG(seed: 1337)
+            // Light mode: grain is much less visible against white surfaces
+            // and gradient banding is also milder on bright backgrounds, so
+            // we use darker grain dots that still scatter the bands.
+            let grainColor: Color = colorScheme == .light
+                ? .black.opacity(1)
+                : .white.opacity(1)
             for _ in 0..<count {
                 let x = Double(rng.nextUInt() % UInt32(max(1, size.width)))
                 let y = Double(rng.nextUInt() % UInt32(max(1, size.height)))
                 let a = intensity * 0.4 + intensity * Double(rng.nextUInt() % 100) / 100.0
                 let rect = CGRect(x: x, y: y, width: 1, height: 1)
-                ctx.fill(Path(rect), with: .color(.white.opacity(a)))
+                ctx.fill(Path(rect), with: .color(grainColor.opacity(a)))
             }
         }
         // P0-1: rasterize into a Metal-backed cache. Without this the
         // Canvas closure re-runs on every ambient/Ken-Burns/cursor frame,
         // burning 0.5-1.5 ms/frame for noise that never changes.
         .drawingGroup(opaque: false)
-        .blendMode(.overlay)
+        .blendMode(colorScheme == .light ? .multiply : .overlay)
         .allowsHitTesting(false)
     }
 

--- a/src/Wallnetic/Views/Components/LiquidGlass.swift
+++ b/src/Wallnetic/Views/Components/LiquidGlass.swift
@@ -35,20 +35,20 @@ struct LiquidGlassStyle {
 
     fileprivate var baseFill: Color {
         switch tone {
-        case .standard:  return Color.black.opacity(0.18)
-        case .prominent: return Color.black.opacity(0.32)
-        case .control:   return Color.white.opacity(0.05)
+        case .standard:  return Surface.glassStandard
+        case .prominent: return Surface.glassProminent
+        case .control:   return Surface.glassControl
         }
     }
 
-    fileprivate var topStroke: Color { .white.opacity(0.16) }
-    fileprivate var bottomStroke: Color { .black.opacity(0.32) }
-    fileprivate var innerHighlight: Color { .white.opacity(0.06) }
+    fileprivate var topStroke: Color { Surface.glassTopStroke }
+    fileprivate var bottomStroke: Color { Surface.glassBottomStroke }
+    fileprivate var innerHighlight: Color { Surface.glassInnerHighlight }
     fileprivate var ambientShadow: Color {
         switch tone {
-        case .prominent: return .black.opacity(0.35)
-        case .standard:  return .black.opacity(0.25)
-        case .control:   return .black.opacity(0.15)
+        case .prominent: return Color.adaptive(dark: .black.opacity(0.35), light: .black.opacity(0.12))
+        case .standard:  return Color.adaptive(dark: .black.opacity(0.25), light: .black.opacity(0.08))
+        case .control:   return Color.adaptive(dark: .black.opacity(0.15), light: .black.opacity(0.05))
         }
     }
 
@@ -154,9 +154,9 @@ extension View {
                 .strokeBorder(
                     LinearGradient(
                         stops: [
-                            .init(color: isActive ? accent.opacity(0.7) : .white.opacity(0.18), location: 0),
-                            .init(color: .white.opacity(0.05), location: 0.5),
-                            .init(color: isActive ? accent.opacity(0.4) : .black.opacity(0.3), location: 1)
+                            .init(color: isActive ? accent.opacity(0.7) : Surface.glassTopStroke, location: 0),
+                            .init(color: Surface.glassInnerHighlight, location: 0.5),
+                            .init(color: isActive ? accent.opacity(0.4) : Surface.glassBottomStroke, location: 1)
                         ],
                         startPoint: .topLeading, endPoint: .bottomTrailing
                     ),

--- a/src/Wallnetic/Views/Components/WallneticButton.swift
+++ b/src/Wallnetic/Views/Components/WallneticButton.swift
@@ -59,7 +59,7 @@ enum WallneticButton {
         Button(action: action) {
             Text(title)
                 .font(.system(size: 13, weight: .medium))
-                .foregroundColor(.white.opacity(0.55))
+                .foregroundColor(.primary.opacity(0.65))
         }
         .buttonStyle(.plain)
         .keyboardShortcut(.escape)
@@ -75,8 +75,11 @@ private struct LiquidPrimaryButtonStyle: ButtonStyle {
     @State private var wobble: CGFloat = 1.0
 
     func makeBody(configuration: Configuration) -> some View {
+        // Primary button keeps "dark text on accent fill" everywhere —
+        // the accent gradient is dense enough that white text loses
+        // contrast against it in both light and dark mode.
         configuration.label
-            .foregroundColor(isEnabled ? .black : .white.opacity(0.35))
+            .foregroundColor(isEnabled ? .black : .primary.opacity(0.45))
             .padding(.horizontal, Space.lg)
             .padding(.vertical, 10)
             .background(
@@ -86,7 +89,7 @@ private struct LiquidPrimaryButtonStyle: ButtonStyle {
                               ? AnyShapeStyle(LinearGradient(
                                     colors: [accent, accent.opacity(0.75)],
                                     startPoint: .topLeading, endPoint: .bottomTrailing))
-                              : AnyShapeStyle(Color.white.opacity(0.06)))
+                              : AnyShapeStyle(Surface.glassControl))
 
                     // Top inner highlight — light catching the lens edge
                     Capsule(style: .continuous)
@@ -127,19 +130,19 @@ private struct LiquidPrimaryButtonStyle: ButtonStyle {
 private struct LiquidGhostButtonStyle: ButtonStyle {
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
-            .foregroundColor(.white.opacity(0.85))
+            .foregroundColor(.primary.opacity(0.85))
             .padding(.horizontal, Space.md)
             .padding(.vertical, 9)
             .background(
                 ZStack {
                     Capsule(style: .continuous)
-                        .fill(Color.white.opacity(configuration.isPressed ? 0.06 : 0.09))
+                        .fill(Surface.glassControl.opacity(configuration.isPressed ? 0.6 : 1.0))
                     Capsule(style: .continuous)
                         .strokeBorder(LinearGradient(
                             stops: [
-                                .init(color: .white.opacity(0.20), location: 0),
-                                .init(color: .white.opacity(0.05), location: 0.5),
-                                .init(color: .black.opacity(0.25), location: 1)
+                                .init(color: Surface.glassTopStroke, location: 0),
+                                .init(color: Surface.glassInnerHighlight, location: 0.5),
+                                .init(color: Surface.glassBottomStroke, location: 1)
                             ],
                             startPoint: .top, endPoint: .bottom
                         ), lineWidth: 0.6)
@@ -167,11 +170,11 @@ struct WallneticTextField: View {
             if let icon {
                 Image(systemName: icon)
                     .font(.system(size: 11, weight: .medium))
-                    .foregroundColor(focused ? accent : .white.opacity(0.4))
+                    .foregroundColor(focused ? accent : .primary.opacity(0.5))
             }
-            TextField("", text: $text, prompt: Text(placeholder).foregroundColor(.white.opacity(0.3)))
+            TextField("", text: $text, prompt: Text(placeholder).foregroundColor(.primary.opacity(0.4)))
                 .textFieldStyle(.plain)
-                .foregroundColor(.white)
+                .foregroundColor(.primary)
                 .font(Typo.body)
                 .focused($focused)
                 .onSubmit { onSubmit?() }
@@ -181,13 +184,13 @@ struct WallneticTextField: View {
         .background(
             ZStack {
                 RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
-                    .fill(Color.white.opacity(focused ? 0.08 : 0.04))
+                    .fill(Surface.glassControl.opacity(focused ? 1.5 : 1.0))
                 RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
                     .strokeBorder(LinearGradient(
                         stops: [
-                            .init(color: focused ? accent.opacity(0.55) : .white.opacity(0.18), location: 0),
-                            .init(color: focused ? accent.opacity(0.25) : .white.opacity(0.04), location: 0.5),
-                            .init(color: focused ? accent.opacity(0.45) : .black.opacity(0.3), location: 1)
+                            .init(color: focused ? accent.opacity(0.55) : Surface.glassTopStroke, location: 0),
+                            .init(color: focused ? accent.opacity(0.25) : Surface.glassInnerHighlight, location: 0.5),
+                            .init(color: focused ? accent.opacity(0.45) : Surface.glassBottomStroke, location: 1)
                         ],
                         startPoint: .top, endPoint: .bottom
                     ), lineWidth: focused ? 1 : 0.6)

--- a/src/Wallnetic/Views/Main/HomeView.swift
+++ b/src/Wallnetic/Views/Main/HomeView.swift
@@ -111,12 +111,12 @@ struct HomeView: View {
                         .animation(.easeInOut(duration: Anim.hero), value: heroIndex)
                 }
 
-                // Cinematic gradient overlay
+                // Cinematic gradient overlay (fades hero into window backdrop)
                 LinearGradient(
                     stops: [
                         .init(color: .clear, location: 0.2),
-                        .init(color: Color(red: 0.02, green: 0.02, blue: 0.06).opacity(0.5), location: 0.5),
-                        .init(color: Color(red: 0.02, green: 0.02, blue: 0.06), location: 1)
+                        .init(color: Surface.deepFade.opacity(0.5), location: 0.5),
+                        .init(color: Surface.deepFade, location: 1)
                     ],
                     startPoint: .top,
                     endPoint: .bottom
@@ -126,13 +126,13 @@ struct HomeView: View {
                 // Side vignette
                 HStack {
                     LinearGradient(
-                        colors: [Color.black.opacity(0.4), .clear],
+                        colors: [Surface.vignetteEdge.opacity(1.2), .clear],
                         startPoint: .leading, endPoint: .trailing
                     )
                     .frame(width: 120)
                     Spacer()
                     LinearGradient(
-                        colors: [.clear, Color.black.opacity(0.4)],
+                        colors: [.clear, Surface.vignetteEdge.opacity(1.2)],
                         startPoint: .leading, endPoint: .trailing
                     )
                     .frame(width: 120)
@@ -156,16 +156,16 @@ struct HomeView: View {
             Text(wp.name)
                 .font(Typo.display)
                 .tracking(Typo.displayTracking)
-                .foregroundColor(.white)
+                .foregroundColor(.primary)
                 .lineLimit(2)
                 .truncationMode(.tail)
-                .shadow(color: .black.opacity(0.55), radius: 8, y: 2)
+                .shadow(color: Surface.vignetteEdge.opacity(1.6), radius: 8, y: 2)
 
             // Metadata pills
             HStack(spacing: 8) {
                 metadataPill(wp.formattedResolution, color: .green)
-                metadataPill(wp.formattedDuration, color: .white.opacity(0.6))
-                metadataPill(wp.formattedFileSize, color: .white.opacity(0.6))
+                metadataPill(wp.formattedDuration, color: .primary.opacity(0.7))
+                metadataPill(wp.formattedFileSize, color: .primary.opacity(0.7))
 
                 if wp.id == wallpaperManager.currentWallpaper?.id {
                     HStack(spacing: 4) {
@@ -204,7 +204,7 @@ struct HomeView: View {
                 HStack(spacing: 5) {
                     ForEach(0..<min(wallpapers.count, 5), id: \.self) { i in
                         Capsule()
-                            .fill(i == heroIndex ? Color.accentColor : Color.white.opacity(0.2))
+                            .fill(i == heroIndex ? Color.accentColor : Color.primary.opacity(0.25))
                             .frame(width: i == heroIndex ? 22 : 10, height: 3)
                             .neonGlow(.accentColor, isActive: i == heroIndex, radius: 4)
                             .animation(.spring(response: Anim.medium, dampingFraction: 0.7), value: heroIndex)
@@ -289,7 +289,7 @@ struct HeroBannerCard: View {
                             y: (phase - 0.5) * 22
                         )
                 } else {
-                    Color.black
+                    Surface.deepFade
                 }
             }
         }
@@ -322,11 +322,11 @@ struct CarouselSection: View {
 
                 Text(title)
                     .font(.system(size: 16, weight: .bold))
-                    .foregroundColor(.white)
+                    .foregroundColor(.primary)
 
                 Text("\(wallpapers.count)")
                     .font(.system(size: 11, weight: .medium, design: .monospaced))
-                    .foregroundColor(.white.opacity(0.3))
+                    .foregroundColor(.primary.opacity(0.4))
             }
             .padding(.horizontal, homeHorizontalInset)
 
@@ -397,14 +397,16 @@ struct CarouselCard: View {
                             .aspectRatio(contentMode: .fill)
                     } else {
                         Rectangle()
-                            .fill(Color.white.opacity(0.03))
+                            .fill(Surface.glassControl)
                             .overlay { ProgressView().scaleEffect(0.6) }
                     }
                 }
                 .frame(width: cardWidth, height: cardHeight)
                 .clipped()
 
-                // Hover overlay
+                // Hover overlay — image content always dark, so keep
+                // contrast overlay dark (not theme-aware) for legibility
+                // of the play icon over thumbnails.
                 if isHovering {
                     Color.black.opacity(0.35)
 
@@ -421,7 +423,7 @@ struct CarouselCard: View {
                     }
                 }
 
-                // Duration badge
+                // Duration badge — over thumbnail image, stays dark for contrast
                 VStack {
                     HStack {
                         Spacer()
@@ -491,7 +493,7 @@ struct CarouselCard: View {
 
             Text(wallpaper.displayName)
                 .font(.system(size: 11, weight: .medium))
-                .foregroundColor(.white.opacity(isHovering ? 0.95 : 0.7))
+                .foregroundColor(.primary.opacity(isHovering ? 0.95 : 0.75))
                 .lineLimit(2)
                 .truncationMode(.tail)
                 .frame(width: cardWidth, alignment: .leading)

--- a/src/Wallnetic/Views/Main/OnboardingView.swift
+++ b/src/Wallnetic/Views/Main/OnboardingView.swift
@@ -86,7 +86,7 @@ struct OnboardingView: View {
 
     private var backdrop: some View {
         ZStack {
-            Color(red: 0.02, green: 0.025, blue: 0.055)
+            Surface.stageFloor
 
             // Drifting accent radial
             RadialGradient(
@@ -106,12 +106,12 @@ struct OnboardingView: View {
 
             // Diagonal noise lines
             DiagonalLines()
-                .stroke(Color.white.opacity(0.02), lineWidth: 0.5)
+                .stroke(Surface.glassInnerHighlight.opacity(0.4), lineWidth: 0.5)
                 .allowsHitTesting(false)
 
             // Vignette
             RadialGradient(
-                colors: [.clear, .black.opacity(0.45)],
+                colors: [.clear, Surface.vignetteEdge.opacity(1.3)],
                 center: .center,
                 startRadius: 200,
                 endRadius: 550
@@ -189,13 +189,13 @@ struct OnboardingView: View {
 
             Text(step.title)
                 .font(.system(size: 30, weight: .bold, design: .rounded))
-                .foregroundColor(.white)
+                .foregroundColor(.primary)
                 .tracking(-0.4)
                 .multilineTextAlignment(.center)
 
             Text(step.description)
                 .font(.system(size: 13))
-                .foregroundColor(.white.opacity(0.62))
+                .foregroundColor(.primary.opacity(0.72))
                 .multilineTextAlignment(.center)
                 .lineSpacing(3)
                 .frame(maxWidth: 380)
@@ -221,7 +221,7 @@ struct OnboardingView: View {
                         .fill(i == currentStep ? AnyShapeStyle(LinearGradient(
                                 colors: [step.accent, step.secondary],
                                 startPoint: .leading, endPoint: .trailing
-                            )) : AnyShapeStyle(Color.white.opacity(0.12)))
+                            )) : AnyShapeStyle(Color.primary.opacity(0.18)))
                         .frame(width: i == currentStep ? 28 : 12, height: 4)
                         .shadow(color: i == currentStep ? step.accent.opacity(0.6) : .clear, radius: 4)
                         .animation(.spring(response: 0.4, dampingFraction: 0.75), value: currentStep)

--- a/src/Wallnetic/Views/Main/SettingsView.swift
+++ b/src/Wallnetic/Views/Main/SettingsView.swift
@@ -6,8 +6,8 @@ struct SettingsView: View {
 
     var body: some View {
         ZStack {
-            // Full bleed dark backdrop replacing the system Form chrome
-            Color(red: 0.04, green: 0.05, blue: 0.09)
+            // Full bleed theme-aware backdrop replacing the system Form chrome
+            Surface.windowFill
                 .ignoresSafeArea()
             // Subtle ambient tint — kept very low contrast and supported
             // by a grain overlay below so the radial doesn't band.
@@ -25,7 +25,7 @@ struct SettingsView: View {
             HStack(spacing: 0) {
                 sidebar
                 Divider()
-                    .overlay(Color.white.opacity(0.06))
+                    .overlay(Surface.hairline)
                 detail
             }
             .ignoresSafeArea(.all, edges: .top)  // claim the title-bar zone
@@ -50,11 +50,11 @@ struct SettingsView: View {
             HStack(spacing: 0) {
                 Text("Wallnetic")
                     .font(.system(size: 12, weight: .semibold, design: .rounded))
-                    .foregroundColor(.white.opacity(0.92))
+                    .foregroundColor(.primary.opacity(0.92))
                     .tracking(-0.1)
                 Text(" Settings")
                     .font(.system(size: 12, weight: .regular, design: .rounded))
-                    .foregroundColor(.white.opacity(0.45))
+                    .foregroundColor(.primary.opacity(0.45))
                     .tracking(-0.1)
                 Spacer()
             }
@@ -72,7 +72,7 @@ struct SettingsView: View {
                     }
 
                     Rectangle()
-                        .fill(Color.white.opacity(0.06))
+                        .fill(Surface.hairline)
                         .frame(height: 0.5)
                         .padding(.vertical, 10)
                         .padding(.horizontal, 14)
@@ -95,11 +95,11 @@ struct SettingsView: View {
                     .frame(width: 5, height: 5)
                     .shadow(color: .green.opacity(0.65), radius: 3)
                 Text("v\(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?")")
-                    .styledData(color: .white.opacity(0.5))
+                    .styledData(color: .primary.opacity(0.5))
                 Spacer()
                 Image(systemName: "lock.shield.fill")
                     .font(.system(size: 9))
-                    .foregroundColor(.white.opacity(0.3))
+                    .foregroundColor(.primary.opacity(0.3))
             }
             .padding(.horizontal, Space.lg + 2)
             .padding(.bottom, Space.md + 2)
@@ -109,7 +109,7 @@ struct SettingsView: View {
             // Translucent over content — Liquid Glass sidebar
             ZStack {
                 Rectangle().fill(.ultraThinMaterial)
-                Rectangle().fill(Color.black.opacity(0.32))
+                Rectangle().fill(Surface.glassProminent)
                 // Inner accent wash
                 LinearGradient(
                     colors: [Color.accentColor.opacity(0.08), .clear],
@@ -121,7 +121,7 @@ struct SettingsView: View {
             // Right-edge refractive hairline
             Rectangle()
                 .fill(LinearGradient(
-                    colors: [.white.opacity(0.04), .white.opacity(0.12), .white.opacity(0.04)],
+                    colors: [Surface.glassInnerHighlight, Surface.glassTopStroke, Surface.glassInnerHighlight],
                     startPoint: .top, endPoint: .bottom
                 ))
                 .frame(width: 0.5)
@@ -152,11 +152,11 @@ struct SettingsView: View {
                 VStack(alignment: .leading, spacing: 1) {
                     Text(selection.title)
                         .font(.system(size: 17, weight: .semibold, design: .rounded))
-                        .foregroundColor(.white)
+                        .foregroundColor(.primary)
                         .tracking(-0.2)
                     Text(selection.tagline)
                         .font(.system(size: 11))
-                        .foregroundColor(.white.opacity(0.42))
+                        .foregroundColor(.primary.opacity(0.42))
                 }
 
                 Spacer()
@@ -293,13 +293,13 @@ private struct SidebarRow: View {
                     }
                     Image(systemName: section.icon)
                         .font(.system(size: 11, weight: .semibold))
-                        .foregroundColor(isSelected ? .white : .white.opacity(hover ? 0.75 : 0.45))
+                        .foregroundColor(isSelected ? .white : .primary.opacity(hover ? 0.75 : 0.55))
                 }
                 .frame(width: 22, height: 22)
 
                 Text(section.title)
                     .font(.system(size: 12, weight: isSelected ? .semibold : .medium))
-                    .foregroundColor(isSelected ? .white : .white.opacity(hover ? 0.85 : 0.6))
+                    .foregroundColor(isSelected ? .primary : .primary.opacity(hover ? 0.85 : 0.7))
                     .tracking(isSelected ? 0.2 : 0)
 
                 Spacer()
@@ -317,15 +317,15 @@ private struct SidebarRow: View {
                 ZStack {
                     if isSelected {
                         RoundedRectangle(cornerRadius: Radius.tag, style: .continuous)
-                            .fill(Color.white.opacity(0.07))
+                            .fill(Surface.glassControl)
                         RoundedRectangle(cornerRadius: Radius.tag, style: .continuous)
                             .strokeBorder(LinearGradient(
-                                colors: [.white.opacity(0.16), .white.opacity(0.02)],
+                                colors: [Surface.glassTopStroke, Surface.glassInnerHighlight],
                                 startPoint: .top, endPoint: .bottom
                             ), lineWidth: 0.5)
                     } else if hover {
                         RoundedRectangle(cornerRadius: Radius.tag, style: .continuous)
-                            .fill(Color.white.opacity(0.04))
+                            .fill(Surface.glassControl)
                     }
                 }
             )

--- a/src/Wallnetic/Views/Main/TopNavigationBar.swift
+++ b/src/Wallnetic/Views/Main/TopNavigationBar.swift
@@ -102,7 +102,7 @@ struct TopNavigationBar: View {
         .overlay(alignment: .bottom) {
             Rectangle()
                 .fill(LinearGradient(
-                    colors: [.clear, .white.opacity(0.08), .clear],
+                    colors: [.clear, Surface.hairline, .clear],
                     startPoint: .leading, endPoint: .trailing
                 ))
                 .frame(height: 0.5)
@@ -117,7 +117,7 @@ struct TopNavigationBar: View {
                 .fill(.ultraThinMaterial)
                 .opacity(isScrolled ? 0.92 : 0.65)
             Rectangle()
-                .fill(Color.black.opacity(isScrolled ? 0.35 : 0.20))
+                .fill(isScrolled ? Surface.glassProminent : Surface.glassStandard)
         }
         .animation(.easeInOut(duration: Anim.medium), value: isScrolled)
     }
@@ -141,7 +141,7 @@ struct TopNavigationBar: View {
                     .font(.system(size: 12, weight: isSelected ? .semibold : .medium))
                     .tracking(0.1)
             }
-            .foregroundColor(isSelected ? .white : .white.opacity(isHovered ? 0.85 : 0.55))
+            .foregroundColor(isSelected ? .primary : .primary.opacity(isHovered ? 0.85 : 0.65))
             .padding(.horizontal, 11)
             .padding(.vertical, 5)
             .contentShape(Rectangle())
@@ -151,17 +151,17 @@ struct TopNavigationBar: View {
                     // shouty underline, no accent color screaming
                     if isSelected {
                         Capsule(style: .continuous)
-                            .fill(Color.white.opacity(0.10))
+                            .fill(Surface.glassControl)
                             .matchedGeometryEffect(id: "tabPill", in: tabUnderlineNS)
                         Capsule(style: .continuous)
                             .strokeBorder(LinearGradient(
-                                colors: [.white.opacity(0.22), .white.opacity(0.04)],
+                                colors: [Surface.glassTopStroke, Surface.glassInnerHighlight],
                                 startPoint: .top, endPoint: .bottom
                             ), lineWidth: 0.5)
                             .matchedGeometryEffect(id: "tabPillStroke", in: tabUnderlineNS)
                     } else if isHovered {
                         Capsule(style: .continuous)
-                            .fill(Color.white.opacity(0.04))
+                            .fill(Surface.glassControl)
                     }
                 }
             )
@@ -185,11 +185,11 @@ struct TopNavigationBar: View {
                     .shadow(color: .accentColor.opacity(0.6), radius: 4)
 
                 TextField("Search wallpapers…", text: $searchText, prompt:
-                    Text("Search wallpapers…").foregroundColor(.white.opacity(0.32))
+                    Text("Search wallpapers…").foregroundColor(.primary.opacity(0.42))
                 )
                 .textFieldStyle(.plain)
                 .font(.system(size: 12))
-                .foregroundColor(.white)
+                .foregroundColor(.primary)
                 .focused($searchFocused)
                 .frame(width: 170)
 
@@ -201,7 +201,7 @@ struct TopNavigationBar: View {
                 } label: {
                     Image(systemName: "xmark.circle.fill")
                         .font(.system(size: 11))
-                        .foregroundColor(.white.opacity(0.4))
+                        .foregroundColor(.primary.opacity(0.45))
                 }
                 .buttonStyle(.plain)
                 .suppressFocusRing()
@@ -210,7 +210,7 @@ struct TopNavigationBar: View {
             .padding(.vertical, 6)
             .background(
                 ZStack {
-                    Capsule().fill(Color.white.opacity(0.06))
+                    Capsule().fill(Surface.glassControl)
                     Capsule().stroke(Color.accentColor.opacity(0.45), lineWidth: 0.6)
                 }
             )
@@ -224,23 +224,23 @@ struct TopNavigationBar: View {
                 HStack(spacing: 8) {
                     Image(systemName: "magnifyingglass")
                         .font(.system(size: 11, weight: .medium))
-                        .foregroundColor(.white.opacity(0.45))
+                        .foregroundColor(.primary.opacity(0.55))
                     Text("Search")
                         .font(.system(size: 11, weight: .medium))
-                        .foregroundColor(.white.opacity(0.4))
+                        .foregroundColor(.primary.opacity(0.5))
                     Spacer(minLength: 0)
                     Text("⌘F")
                         .font(.system(size: 9, weight: .heavy, design: .monospaced))
                         .tracking(0.5)
-                        .foregroundColor(.white.opacity(0.28))
+                        .foregroundColor(.primary.opacity(0.38))
                 }
                 .padding(.horizontal, 12)
                 .padding(.vertical, 6)
                 .frame(width: 180)
                 .background(
                     ZStack {
-                        Capsule().fill(Color.white.opacity(0.04))
-                        Capsule().stroke(Color.white.opacity(0.1), lineWidth: 0.5)
+                        Capsule().fill(Surface.glassControl)
+                        Capsule().stroke(Surface.hairline, lineWidth: 0.5)
                     }
                 )
             }
@@ -261,7 +261,7 @@ private struct ActionChip: View {
     var body: some View {
         Image(systemName: icon)
             .font(.system(size: 11, weight: .semibold))
-            .foregroundColor(.white.opacity(hover ? 1.0 : 0.75))
+            .foregroundColor(accent && hover ? .white : .primary.opacity(hover ? 1.0 : 0.78))
             .frame(width: 30, height: 30)
             .background(
                 ZStack {
@@ -271,15 +271,15 @@ private struct ActionChip: View {
                                 ? AnyShapeStyle(LinearGradient(
                                     colors: [Color.accentColor.opacity(0.55), Color.accentColor.opacity(0.2)],
                                     startPoint: .topLeading, endPoint: .bottomTrailing))
-                                : AnyShapeStyle(Color.white.opacity(hover ? 0.10 : 0.05))
+                                : AnyShapeStyle(Surface.glassControl)
                         )
                     // Refractive stroke
                     Circle()
                         .strokeBorder(LinearGradient(
                             stops: [
-                                .init(color: accent && hover ? Color.accentColor.opacity(0.75) : Color.white.opacity(0.22), location: 0),
-                                .init(color: .white.opacity(0.04), location: 0.55),
-                                .init(color: .black.opacity(0.30), location: 1)
+                                .init(color: accent && hover ? Color.accentColor.opacity(0.75) : Surface.glassTopStroke, location: 0),
+                                .init(color: Surface.glassInnerHighlight, location: 0.55),
+                                .init(color: Surface.glassBottomStroke, location: 1)
                             ],
                             startPoint: .top, endPoint: .bottom
                         ), lineWidth: 0.75)


### PR DESCRIPTION
## Summary
- PR #200 sonrasinda Light moda gecince ekran okunamaz olmustu (koyu yazi/koyu zemin)
- Tum hardcoded dark surface'leri tek source-of-truth Surface tokens'a bagladim
- Color.adaptive(dark:light:) helper NSColor dynamic provider ile NSApp.appearance takip ediyor
- 9 dosya guncellendi: 4 component + 4 main view + DesignTokens

## Kapsam

### DesignTokens.swift — yeni Surface enum (11 token)
- stageFloor, windowFill, deepFade, vignetteEdge
- glassStandard, glassProminent, glassControl
- glassTopStroke, glassBottomStroke, glassInnerHighlight
- hairline

### Components
- **AmbientStage**: stageFloor + vignetteEdge adaptive
- **LiquidGlass**: baseFill (tone), 3 stroke, ambientShadow Surface'a baglandi
- **GrainOverlay**: light mode = black grain + multiply blend, dark = white + overlay
- **WallneticButton**: 4 stil (primary disabled, ghost, cancel, textfield) .primary + Surface

### Main views
- **SettingsView**: windowFill backdrop, sidebar materyali + glassProminent,
  sidebar row .primary text + glassControl pill, hairlines
- **OnboardingView**: stageFloor backdrop, diagonal lines + vignette + text adaptive
- **TopNavigationBar**: navBackground, tab pill, hover state, search bar,
  ActionChip stroke + fill hepsi Surface
- **HomeView**: hero title/metadata/page-indicators .primary, placeholder Surface,
  carousel section + label .primary

## Bilincli birakilan dark alanlar
| Alan | Sebep |
|---|---|
| CarouselCard hover overlay (Color.black.opacity(0.35)) | Thumbnail icerigi her zaman tam renkli — kontrast lazim |
| CarouselCard duration pill (Color.black.opacity(0.6)) | Yine thumbnail uzeri kontrast |
| WallneticButton primary uzerinde text siyah | Accent gradient uzerinde beyaz okunmaz |

## Test plan
- [x] 86/86 unit test pass
- [x] Build SUCCEEDED (Debug + ad-hoc)
- [ ] Settings -> Light: backdrop beyaz, tum yazilar okunabilir
- [ ] Settings -> Dark: cinematic dark korunmus (regression)
- [ ] Settings -> System: macOS Light/Dark gecislerinde takip
- [ ] Onboarding 4 step Light/Dark kontrol
- [ ] HomeView hero + carousel Light/Dark kontrol
- [ ] TopNav search bar + tab pill + Settings icon Light/Dark kontrol

Co-Authored-By: Claude Opus 4.7