### PR TITLE
Tabs Light polish: Explore + Popular + Discover + Grid

### DIFF
--- a/src/Wallnetic/Views/Main/DiscoverView.swift
+++ b/src/Wallnetic/Views/Main/DiscoverView.swift
@@ -67,7 +67,7 @@ struct DiscoverView: View {
                         .neonGlow(.blue, isActive: true, radius: 6)
                     Text("Discover Wallpapers")
                         .font(.system(size: 18, weight: .bold, design: .rounded))
-                        .foregroundColor(.white)
+                        .foregroundColor(.primary)
                 }
 
                 Spacer()
@@ -78,7 +78,7 @@ struct DiscoverView: View {
                 +
                 Text(" sources")
                     .font(.system(size: 12))
-                    .foregroundColor(.white.opacity(0.4))
+                    .foregroundColor(.primary.opacity(0.55))
             }
             .padding(.horizontal, 24)
             .padding(.vertical, 16)
@@ -135,7 +135,7 @@ struct SourceCard: View {
                 HStack(spacing: 6) {
                     Text(source.name)
                         .font(.system(size: 15, weight: .semibold))
-                        .foregroundColor(.white)
+                        .foregroundColor(.primary)
 
                     if source.type == .api {
                         Text("API")
@@ -150,7 +150,7 @@ struct SourceCard: View {
 
                 Text(source.description)
                     .font(.system(size: 11))
-                    .foregroundColor(.white.opacity(0.45))
+                    .foregroundColor(.primary.opacity(0.6))
                     .lineLimit(2)
 
                 Text("\(source.estimatedCount) wallpapers")
@@ -162,7 +162,7 @@ struct SourceCard: View {
 
             Image(systemName: "chevron.right")
                 .font(.system(size: 12, weight: .semibold))
-                .foregroundColor(isHovering ? source.color.opacity(0.6) : .white.opacity(0.2))
+                .foregroundColor(isHovering ? source.color.opacity(0.6) : .primary.opacity(0.35))
                 .offset(x: isHovering ? 3 : 0)
         }
         .padding(16)
@@ -170,7 +170,7 @@ struct SourceCard: View {
         .glowCard(isHovering: isHovering, cornerRadius: 12, glowColor: source.color)
         .background(
             RoundedRectangle(cornerRadius: 12)
-                .fill(Color.white.opacity(isHovering ? 0.06 : 0.03))
+                .fill(Surface.glassControl.opacity(isHovering ? 1.5 : 1.0))
         )
         .scaleEffect(isHovering ? 1.02 : 1.0)
         .animation(.spring(response: Anim.enter, dampingFraction: 0.75), value: isHovering)
@@ -207,7 +207,7 @@ struct InAppBrowserView: View {
                     .foregroundColor(source.color)
                 Text(source.name)
                     .font(.system(size: 13, weight: .semibold))
-                    .foregroundColor(.white)
+                    .foregroundColor(.primary)
 
                 // Back / Forward
                 HStack(spacing: 2) {
@@ -216,9 +216,9 @@ struct InAppBrowserView: View {
                     } label: {
                         Image(systemName: "chevron.left")
                             .font(.system(size: 12, weight: .semibold))
-                            .foregroundColor(canGoBack ? .white.opacity(0.8) : .white.opacity(0.2))
+                            .foregroundColor(canGoBack ? .primary.opacity(0.85) : .primary.opacity(0.3))
                             .frame(width: 28, height: 28)
-                            .background(Color.white.opacity(canGoBack ? 0.1 : 0.04))
+                            .background(Surface.glassControl.opacity(canGoBack ? 2.0 : 0.8))
                             .cornerRadius(6)
                     }
                     .buttonStyle(.plain)
@@ -229,9 +229,9 @@ struct InAppBrowserView: View {
                     } label: {
                         Image(systemName: "chevron.right")
                             .font(.system(size: 12, weight: .semibold))
-                            .foregroundColor(canGoForward ? .white.opacity(0.8) : .white.opacity(0.2))
+                            .foregroundColor(canGoForward ? .primary.opacity(0.85) : .primary.opacity(0.3))
                             .frame(width: 28, height: 28)
-                            .background(Color.white.opacity(canGoForward ? 0.1 : 0.04))
+                            .background(Surface.glassControl.opacity(canGoForward ? 2.0 : 0.8))
                             .cornerRadius(6)
                     }
                     .buttonStyle(.plain)
@@ -241,12 +241,12 @@ struct InAppBrowserView: View {
                 // URL bar
                 Text(currentURL)
                     .font(.system(size: 11, design: .monospaced))
-                    .foregroundColor(.white.opacity(0.4))
+                    .foregroundColor(.primary.opacity(0.55))
                     .lineLimit(1)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.horizontal, 10)
                     .padding(.vertical, 5)
-                    .background(Color.white.opacity(0.06))
+                    .background(Surface.glassControl)
                     .cornerRadius(6)
 
                 if isLoading {
@@ -264,10 +264,10 @@ struct InAppBrowserView: View {
                         Text("Scan")
                             .font(.system(size: 11, weight: .medium))
                     }
-                    .foregroundColor(.white.opacity(0.8))
+                    .foregroundColor(.primary.opacity(0.85))
                     .padding(.horizontal, 10)
                     .padding(.vertical, 5)
-                    .background(Color.white.opacity(0.1))
+                    .background(Surface.glassControl.opacity(2.0))
                     .cornerRadius(6)
                 }
                 .buttonStyle(.plain)
@@ -294,9 +294,9 @@ struct InAppBrowserView: View {
                 } label: {
                     Image(systemName: "xmark")
                         .font(.system(size: 12, weight: .bold))
-                        .foregroundColor(.white.opacity(0.6))
+                        .foregroundColor(.primary.opacity(0.7))
                         .frame(width: 28, height: 28)
-                        .background(Color.white.opacity(0.1))
+                        .background(Surface.glassControl.opacity(2.0))
                         .clipShape(Circle())
                 }
                 .buttonStyle(.plain)
@@ -304,7 +304,7 @@ struct InAppBrowserView: View {
             }
             .padding(.horizontal, 16)
             .padding(.vertical, 10)
-            .background(Color(white: 0.12))
+            .background(Surface.glassProminent)
 
             // Active downloads bar
             if !downloadManager.downloads.filter({ [.downloading, .completed, .failed].contains($0.status) }).isEmpty {
@@ -327,7 +327,7 @@ struct InAppBrowserView: View {
 
                             Text(dl.name)
                                 .font(.system(size: 10))
-                                .foregroundColor(.white.opacity(0.7))
+                                .foregroundColor(.primary.opacity(0.8))
                                 .lineLimit(1)
 
                             if dl.status == .downloading {
@@ -336,7 +336,7 @@ struct InAppBrowserView: View {
 
                                 Text("\(Int(dl.progress * 100))%")
                                     .font(.system(size: 9, design: .monospaced))
-                                    .foregroundColor(.white.opacity(0.5))
+                                    .foregroundColor(.primary.opacity(0.6))
                                     .frame(width: 30)
                             } else if dl.status == .completed {
                                 Text("Imported")
@@ -352,7 +352,7 @@ struct InAppBrowserView: View {
                 }
                 .padding(.horizontal, 16)
                 .padding(.vertical, 6)
-                .background(Color(white: 0.08))
+                .background(Surface.glassStandard)
             }
 
             // Found videos panel
@@ -363,7 +363,7 @@ struct InAppBrowserView: View {
                             .foregroundColor(.blue)
                         Text("Found \(foundVideos.count) video\(foundVideos.count == 1 ? "" : "s") on this page")
                             .font(.system(size: 11, weight: .semibold))
-                            .foregroundColor(.white)
+                            .foregroundColor(.primary)
 
                         Spacer()
 
@@ -385,7 +385,7 @@ struct InAppBrowserView: View {
                         } label: {
                             Image(systemName: "xmark")
                                 .font(.system(size: 9))
-                                .foregroundColor(.white.opacity(0.4))
+                                .foregroundColor(.primary.opacity(0.55))
                         }
                         .buttonStyle(.plain)
                     }
@@ -397,11 +397,11 @@ struct InAppBrowserView: View {
                         HStack(spacing: 8) {
                             Image(systemName: "film")
                                 .font(.system(size: 9))
-                                .foregroundColor(.white.opacity(0.4))
+                                .foregroundColor(.primary.opacity(0.55))
 
                             Text(URL(string: urlStr)?.lastPathComponent ?? urlStr)
                                 .font(.system(size: 10, design: .monospaced))
-                                .foregroundColor(.white.opacity(0.6))
+                                .foregroundColor(.primary.opacity(0.7))
                                 .lineLimit(1)
 
                             Spacer()
@@ -421,7 +421,7 @@ struct InAppBrowserView: View {
                         .padding(.vertical, 3)
                     }
                 }
-                .background(Color(white: 0.06))
+                .background(Surface.glassStandard)
             }
 
             // WebView
@@ -434,7 +434,7 @@ struct InAppBrowserView: View {
                 canGoForward: $canGoForward
             )
         }
-        .background(Color.black)
+        .background(Surface.windowFill)
     }
 
     /// Scans current page for video URLs using JavaScript

--- a/src/Wallnetic/Views/Main/ExploreView.swift
+++ b/src/Wallnetic/Views/Main/ExploreView.swift
@@ -77,11 +77,11 @@ struct ExploreView: View {
                     } label: {
                         Text("All")
                             .font(.system(size: 10, weight: selectedColor == nil ? .bold : .medium))
-                            .foregroundColor(selectedColor == nil ? .white : .white.opacity(0.5))
+                            .foregroundColor(selectedColor == nil ? .primary : .primary.opacity(0.6))
                             .padding(.horizontal, 10)
                             .padding(.vertical, 5)
                             .background(
-                                Capsule().fill(selectedColor == nil ? Color.white.opacity(0.12) : Color.white.opacity(0.04))
+                                Capsule().fill(selectedColor == nil ? Surface.glassControl.opacity(2.4) : Surface.glassControl)
                             )
                     }
                     .buttonStyle(.plain)
@@ -96,7 +96,7 @@ struct ExploreView: View {
                                 .fill(cat.color)
                                 .frame(width: 18, height: 18)
                                 .overlay(
-                                    Circle().stroke(.white.opacity(selectedColor == cat ? 0.8 : 0.15), lineWidth: selectedColor == cat ? 2 : 0.5)
+                                    Circle().stroke(Color.primary.opacity(selectedColor == cat ? 0.8 : 0.2), lineWidth: selectedColor == cat ? 2 : 0.5)
                                 )
                                 .scaleEffect(selectedColor == cat ? 1.2 : 1.0)
                         }
@@ -125,7 +125,7 @@ struct ExploreView: View {
                 +
                 Text(" wallpapers")
                     .font(.system(size: 12))
-                    .foregroundColor(.white.opacity(0.4))
+                    .foregroundColor(.primary.opacity(0.55))
 
                 Spacer()
 
@@ -194,11 +194,11 @@ struct ExploreView: View {
         } label: {
             Image(systemName: icon)
                 .font(.system(size: 11))
-                .foregroundColor(viewMode == mode ? .white : .white.opacity(0.3))
+                .foregroundColor(viewMode == mode ? .primary : .primary.opacity(0.45))
                 .frame(width: 24, height: 24)
                 .background(
                     RoundedRectangle(cornerRadius: 5)
-                        .fill(viewMode == mode ? Color.white.opacity(0.1) : .clear)
+                        .fill(viewMode == mode ? Surface.glassControl.opacity(2.0) : .clear)
                 )
         }
         .buttonStyle(.plain)
@@ -218,7 +218,7 @@ struct ExploreView: View {
         } label: {
             Text(category)
                 .font(.system(size: 12, weight: isSelected ? .bold : .medium))
-                .foregroundColor(isSelected ? .white : .white.opacity(isHovered ? 0.8 : 0.6))
+                .foregroundColor(isSelected ? .primary : .primary.opacity(isHovered ? 0.85 : 0.7))
                 .padding(.horizontal, 14)
                 .padding(.vertical, 7)
                 .background(
@@ -227,10 +227,10 @@ struct ExploreView: View {
                             Capsule().fill(Color.accentColor.opacity(0.25))
                             Capsule().stroke(Color.accentColor.opacity(0.4), lineWidth: 0.5)
                         } else if isHovered {
-                            Capsule().fill(Color.white.opacity(0.06))
+                            Capsule().fill(Surface.glassControl.opacity(1.5))
                         } else {
-                            Capsule().fill(Color.white.opacity(0.03))
-                            Capsule().stroke(Color.white.opacity(0.06), lineWidth: 0.5)
+                            Capsule().fill(Surface.glassControl)
+                            Capsule().stroke(Surface.hairline, lineWidth: 0.5)
                         }
                     }
                 )
@@ -268,7 +268,7 @@ struct ExploreCard: View {
                                     .aspectRatio(contentMode: .fill)
                             } else {
                                 Rectangle()
-                                    .fill(Color.white.opacity(0.03))
+                                    .fill(Surface.glassControl)
                                     .overlay { ProgressView().scaleEffect(0.6) }
                             }
                         }
@@ -325,13 +325,13 @@ struct ExploreCard: View {
             VStack(alignment: .leading, spacing: 2) {
                 Text(wallpaper.displayName)
                     .font(.system(size: 12, weight: .medium))
-                    .foregroundColor(.white.opacity(isHovering ? 0.95 : 0.75))
+                    .foregroundColor(.primary.opacity(isHovering ? 0.95 : 0.8))
                     .lineLimit(2)
                     .truncationMode(.tail)
 
                 Text("\(wallpaper.formattedResolution) \u{2022} \(wallpaper.formattedFileSize)")
                     .font(.system(size: 10, design: .monospaced))
-                    .foregroundColor(.white.opacity(0.35))
+                    .foregroundColor(.primary.opacity(0.5))
             }
         }
         .animation(.spring(response: Anim.enter, dampingFraction: 0.75), value: isHovering)
@@ -372,7 +372,7 @@ struct ExploreListRow: View {
                     .clipShape(RoundedRectangle(cornerRadius: 6))
             } else {
                 RoundedRectangle(cornerRadius: 6)
-                    .fill(Color.white.opacity(0.05))
+                    .fill(Surface.glassControl)
                     .frame(width: 80, height: 45)
                     .overlay { ProgressView().scaleEffect(0.5) }
             }
@@ -381,7 +381,7 @@ struct ExploreListRow: View {
             VStack(alignment: .leading, spacing: 2) {
                 Text(wallpaper.displayName)
                     .font(.system(size: 13, weight: .medium))
-                    .foregroundColor(.white.opacity(0.9))
+                    .foregroundColor(.primary.opacity(0.95))
                     .lineLimit(1)
 
                 HStack(spacing: 8) {
@@ -390,7 +390,7 @@ struct ExploreListRow: View {
                     Text(wallpaper.formattedFileSize)
                 }
                 .font(.system(size: 11, design: .monospaced))
-                .foregroundColor(.white.opacity(0.4))
+                .foregroundColor(.primary.opacity(0.55))
             }
 
             Spacer()
@@ -409,9 +409,9 @@ struct ExploreListRow: View {
                 } label: {
                     Image(systemName: "play.fill")
                         .font(.system(size: 11))
-                        .foregroundColor(.white.opacity(0.8))
+                        .foregroundColor(.primary.opacity(0.85))
                         .frame(width: 28, height: 28)
-                        .background(Circle().fill(.white.opacity(0.1)))
+                        .background(Circle().fill(Surface.glassControl.opacity(1.5)))
                 }
                 .buttonStyle(.plain)
             }
@@ -420,7 +420,7 @@ struct ExploreListRow: View {
         .padding(.vertical, 6)
         .background(
             RoundedRectangle(cornerRadius: 8)
-                .fill(isHovering ? Color.white.opacity(0.04) : .clear)
+                .fill(isHovering ? Surface.glassControl : Color.clear)
         )
         .onHover { h in withAnimation(Anim.hover) { isHovering = h } }
         .onTapGesture(count: 2) { wallpaperManager.setWallpaper(wallpaper) }

--- a/src/Wallnetic/Views/Main/PopularView.swift
+++ b/src/Wallnetic/Views/Main/PopularView.swift
@@ -47,7 +47,7 @@ struct PopularView: View {
                 HStack(spacing: 4) {
                     Image(systemName: "arrow.up.arrow.down")
                         .font(.system(size: 10))
-                        .foregroundColor(.white.opacity(0.4))
+                        .foregroundColor(.primary.opacity(0.55))
 
                     Picker("", selection: $sortOption) {
                         ForEach(SortOption.allCases, id: \.self) { option in
@@ -63,7 +63,7 @@ struct PopularView: View {
                 +
                 Text(" wallpapers")
                     .font(.system(size: 12))
-                    .foregroundColor(.white.opacity(0.4))
+                    .foregroundColor(.primary.opacity(0.55))
             }
             .padding(.horizontal, 20)
             .padding(.vertical, 12)
@@ -114,7 +114,7 @@ struct PopularCard: View {
         case 1: return .orange
         case 2: return Color(red: 0.85, green: 0.65, blue: 0.1)
         case 3: return Color(red: 0.7, green: 0.45, blue: 0.15)
-        default: return .white.opacity(0.4)
+        default: return .primary.opacity(0.5)
         }
     }
 
@@ -132,7 +132,7 @@ struct PopularCard: View {
                                     .aspectRatio(contentMode: .fill)
                             } else {
                                 Rectangle()
-                                    .fill(Color.white.opacity(0.03))
+                                    .fill(Surface.glassControl)
                                     .overlay { ProgressView().scaleEffect(0.6) }
                             }
                         }
@@ -172,13 +172,13 @@ struct PopularCard: View {
                 VStack(alignment: .leading, spacing: 2) {
                     Text(wallpaper.displayName)
                         .font(.system(size: 13, weight: .medium))
-                        .foregroundColor(.white.opacity(isHovering ? 0.95 : 0.75))
+                        .foregroundColor(.primary.opacity(isHovering ? 0.95 : 0.8))
                         .lineLimit(2)
                         .truncationMode(.tail)
 
                     Text("\(wallpaper.formattedResolution) \u{2022} \(wallpaper.formattedDuration)")
                         .font(.system(size: 10, design: .monospaced))
-                        .foregroundColor(.white.opacity(0.35))
+                        .foregroundColor(.primary.opacity(0.5))
                 }
 
                 Spacer()

--- a/src/Wallnetic/Views/Main/WallpaperGridView.swift
+++ b/src/Wallnetic/Views/Main/WallpaperGridView.swift
@@ -252,16 +252,16 @@ struct WallpaperCard: View {
     private var backView: some View {
         ZStack {
             Rectangle()
-                .fill(Color(white: 0.12))
+                .fill(Surface.glassProminent)
                 .aspectRatio(16/9, contentMode: .fit)
 
             VStack(alignment: .leading, spacing: 8) {
                 Text(wallpaper.displayName)
                     .font(.system(size: 13, weight: .bold))
-                    .foregroundColor(.white)
+                    .foregroundColor(.primary)
                     .lineLimit(2)
 
-                Divider().background(.white.opacity(0.1))
+                Divider().background(Surface.hairline)
 
                 metadataRow("Resolution", value: wallpaper.formattedResolution)
                 metadataRow("Duration", value: wallpaper.formattedDuration)
@@ -287,11 +287,11 @@ struct WallpaperCard: View {
         HStack {
             Text(label)
                 .font(.system(size: 10))
-                .foregroundColor(.white.opacity(0.4))
+                .foregroundColor(.primary.opacity(0.55))
             Spacer()
             Text(value)
                 .font(.system(size: 10, weight: .medium, design: .monospaced))
-                .foregroundColor(.white.opacity(0.8))
+                .foregroundColor(.primary.opacity(0.85))
         }
     }
 }
@@ -393,17 +393,17 @@ struct SelectedWallpaperBar: View {
             VStack(alignment: .leading, spacing: 2) {
                 Text(wallpaper.displayName)
                     .font(.system(size: 13, weight: .semibold, design: .rounded))
-                    .foregroundColor(.white)
+                    .foregroundColor(.primary)
                     .tracking(-0.1)
                     .lineLimit(1)
                 HStack(spacing: 6) {
                     Text(wallpaper.formattedResolution)
-                    Text("·").foregroundColor(.white.opacity(0.2))
+                    Text("·").foregroundColor(.primary.opacity(0.3))
                     Text(wallpaper.formattedDuration)
                 }
                 .font(Typo.data)
                 .tracking(Typo.dataTracking)
-                .foregroundColor(.white.opacity(0.5))
+                .foregroundColor(.primary.opacity(0.6))
             }
 
             Spacer()
@@ -502,7 +502,7 @@ struct RenameWallpaperSheet: View {
                 Text("DISPLAY NAME")
                     .font(.system(size: 9, weight: .heavy, design: .monospaced))
                     .tracking(2)
-                    .foregroundColor(.white.opacity(0.35))
+                    .foregroundColor(.primary.opacity(0.5))
 
                 WallneticTextField(
                     placeholder: wallpaper.name,
@@ -522,7 +522,7 @@ struct RenameWallpaperSheet: View {
                             Text("Reset to original filename")
                                 .font(.system(size: 11))
                         }
-                        .foregroundColor(.white.opacity(0.5))
+                        .foregroundColor(.primary.opacity(0.6))
                     }
                     .buttonStyle(.plain)
                     .padding(.top, 4)


### PR DESCRIPTION
## Summary
PR #202'de Home + Settings + Onboarding Light moda tasinmisti ama
3 tab (Explore/Popular/Discover) + WallpaperGridView'in hardcoded dark
renkleri kalmisti. Hepsini Surface tokens'a + .primary text'e bagladim.

## Dokunulan dosyalar
- src/Wallnetic/Views/Main/ExploreView.swift
- src/Wallnetic/Views/Main/PopularView.swift
- src/Wallnetic/Views/Main/DiscoverView.swift
- src/Wallnetic/Views/Main/WallpaperGridView.swift

## Test plan
- [x] 86/86 unit test pass
- [x] Build SUCCEEDED
- [ ] Explore tab Light: kategoriler + view mode toggle okunabilir
- [ ] Popular tab Light: rank + metadata okunabilir
- [ ] Discover tab Light: source kartlari + InAppBrowser toolbar okunabilir
- [ ] Grid view (any tab) flip-to-back metadata panel Light'ta okunabilir
- [ ] Dark mode regression: 4 tab eski cinematic dark gorunum korunmus

Co-Authored-By: Claude Opus 4.7