### PR TITLE
Release prep v1.3.0 — CHANGELOG consolidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,81 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] — 2026-05-17
+
+> First release on the v1.3 track. Bundles the entire May development cycle
+> (#129 → #204): new Photos slideshow generator, App Store hardening (sandbox
+> + privacy manifest), full Light theme support, Dynamic Island multi-monitor,
+> security + performance sweeps, and the new design language (Liquid Glass
+> polyfill + ambient stage + theme-aware Surface tokens).
+
+### Added
+- **Photos slideshow generator** (#137): Create wallpapers from your Apple Photos
+  library. Multi-select grid, Ken Burns pan/zoom, crossfade transitions, three
+  resolution presets (1080p / 1440p / 4K), 50-photo cap.
+- **Battery prompt with override toggle** (#172): When the Mac switches to battery
+  (or launches on battery), users see a prompt offering to keep the live wallpaper
+  running. New `Playback → Always play on battery` Settings toggle makes the
+  choice permanent; `Reset battery prompt` brings the dialog back.
+- **Global hotkeys**: `⌘⇧→` next, `⌘⇧←` previous, `⌘⇧P` play/pause, `⌘⇧R` random.
+- **Light theme support** (#202, #203): Full System / Light / Dark appearance
+  modes. New `Surface` design-token palette (11 tokens) with `NSColor` dynamic
+  providers tracks `NSApp.appearance` in real time across all main views,
+  settings panes, sheets, top navigation, and tab content. Liquid Glass surface
+  fills, lensing strokes, and grain overlay all adapt to the active mode.
+- **Dynamic Island on every display** (#201): When more than one monitor is
+  connected, the island renders on each screen with a shared expand/collapse
+  state. Hot-plug observer (`NSApplication.didChangeScreenParametersNotification`)
+  adds/removes panels as displays are attached, detached, or mirrored.
+- **2026 design language (Liquid Glass + ambient stage)** (#187 → #198): A new
+  cinematic chrome built on stable APIs — `.regularMaterial` blur layered with
+  accent gradient, lensing strokes, inner highlight ring, and multi-layer
+  shadows. Concentric-radius scale (`Radius.window` → `Radius.accent`),
+  4-pt spacing grid (`Space`), and a tracked typography scale (`Typo`).
+- **DynamicAccent**: Window-wide accent color derives from the active wallpaper's
+  dominant tone, threaded through the SwiftUI environment so every chrome
+  surface re-tints when wallpapers change.
+- **AmbientStage**: Drifting accent radial + cursor spotlight + vignette
+  applied once at the window root; rasterized grain overlay defeats SwiftUI's
+  8-bit gradient banding.
+- **Cinematic onboarding** (4 steps): Animated gradient orbs per step, glow
+  blob, sequential title/kicker/description reveal, capsule progress.
+- **3D perspective wallpaper carousel** (#127): New Carousel3DGallery component
+  with rotation3DEffect + scaleEffect tied to scroll position.
+- **SQLite metadata cache** (#115): Local SQLite index (libsqlite3, no SwiftPM
+  dep). Wallpaper title/tag search routes through this index for libraries
+  with more than 200 entries, with the in-memory store as a fallback.
+- **Privacy Manifest** (#164): `PrivacyInfo.xcprivacy` declares required-reason
+  APIs (`NSUserDefaults` CA92.1, `NSFileTimestamp` C617.1) with no tracking
+  domains and no collected data types.
+- **App sandbox enabled**: Hardened runtime + sandbox + capability entitlements
+  for network, file picker, photos, scripting (Music.app), audio input,
+  application groups.
+- **ViewModel layer** (#166): New `ViewModels/` directory with reference
+  implementation (`AIGenerateViewModel`) and pattern guide. AI generation
+  pipeline lifted out of the view, dependency-injectable for testing.
+- **Window chrome** (#190 → #195): Settings migrated from `Settings { }` to
+  `WindowGroup(id: "settings")` with manual `⌘,` wiring so `.hiddenTitleBar`
+  actually applies; compact wordmark inhabits the title-bar zone; macOS focus
+  rings on dark glass are suppressed via `.focusEffectDisabled()` (macOS 14+).
+
+### Bug Fixes
+- **Appearance toggle now actually takes effect** (#200): `ThemeManager` was
+  setting `NSApp.appearance` correctly but five places forced `.dark` /
+  `.darkAqua` overrides, masking the change. All five sites now defer to
+  `ThemeManager.appearanceMode.{swiftUIColorScheme,nsAppearance}`. Existing
+  open windows pick up the change via a new `.appAppearanceDidChange`
+  notification observed by `WindowChrome`.
+- **Audio Visualizer disabled** (#199): The Settings entry and menu-bar
+  toggle were removed prior to release because the ScreenCaptureKit /
+  microphone permission flow surfaced repeatedly with poor UX. The
+  implementation files are retained for a future re-enable; an AppStorage
+  migration clears the persisted `enabled` flag on upgrade.
+- **Smart Tags hidden** (#204): Ollama Vision auto-tagging is opt-in and
+  was hidden from the Settings sidebar for the App Store submission. The
+  feature, including SSRF hardening below, remains in the codebase for
+  future enablement.
+
 ### Security
 - **SSRF hardening** (H1, M2): Ollama Vision endpoint is now hard-restricted
   to loopback (`localhost`, `127.0.0.1`, `::1`) or `*.local` mDNS hosts. Non-
@@ -20,8 +95,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Window chrome guard** (M3): `cinematicWindowChrome()` now skips
   non-`.titled` windows (popovers, sheets, panels) so the modifier can't
   accidentally corrupt unrelated NSWindow chrome if misapplied.
+- **Deep link `import` action** now requires HTTPS and prompts the user before
+  downloading. Was an arbitrary-URL vector.
+- **WKWebView in Discover** refuses JS-driven popup auto-open and rejects
+  non-HTTP(S) schemes (`file://`, `javascript:`, custom).
+- **URLImporter** validates HTTPS scheme + response Content-Type against a
+  video MIME allowlist before importing.
+- **Deep link logging** strips query parameters from the public `os.log`
+  channel.
 
 ### Changed
+- **MRMediaRemote gated to `#if DEBUG`** (#165): Release builds ship without
+  private framework references; `DistributedNotificationCenter` (Apple Music +
+  Spotify) remains the public-API fallback.
+- **Centralized `os.log` logging** (#169): 93 `print` / `NSLog` calls across 34
+  files replaced with a `Log` registry covering 32 categories. `.debug` entries
+  are stripped from Release builds automatically.
+- **WallpaperManager decomposition** (#149): 808 → 462 lines. New
+  `WallpaperLibrary`, `WallpaperMetadataStore`, `WidgetSyncService` peers.
+- **Notification → delegate refactor** (#170): Playback flows now use a typed
+  `PlaybackDelegate` protocol; broadcast consumers (widget) still use
+  notifications.
+- **Centralized error surfacing** (#167): New `ErrorReporter` for non-fatal
+  failures the user should see. Cache decode/encode failures in
+  `WallpaperManager`, `WallpaperMetadataStore`, `CollectionManager`,
+  `SpaceWallpaperManager` now log and reset corrupt blobs instead of swallowing.
+  Drag-drop import + Discover WKDownload import now show alerts on failure.
 - File-system paths in `WallpaperMetadataCache` logs now use `privacy(.private)`
   (L1).
 - `OllamaVisionTagger.parseTags` caps results at 8 tags (L3) — bounds
@@ -57,40 +156,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   call's critical section (duplicate-check + file move + array append) runs
   through a serial `ImportGate` actor — concurrent identical drops can no
   longer race past duplicate detection.
+- **FFT hot-path** (#163): Pre-allocated vDSP buffers and pointer arithmetic
+  eliminate ~280 allocations/sec on the visualizer path.
+- **`CGWindowListCopyWindowInfo`** moved off the main thread (#168).
+- **Idle CPU**: Instruments sample with the app idle measured 4.1–4.4 % CPU
+  (vs. ~15–25 % before the perf sweep).
 
 ### Tests
-- +5 unit tests covering endpoint allowlist (loopback / `*.local` / public /
-  non-http) and parseTags cap.
-- +5 unit tests covering SlideshowGenerator.totalFrames (YUKSEK-2): empty
-  input, crossfade math, no-transition mode.
-- Total 84/84 pass.
+- 86/86 unit tests pass.
+- +5 covering Ollama endpoint allowlist (loopback / `*.local` / public /
+  non-http) and `parseTags` cap.
+- +5 covering `SlideshowGenerator.totalFrames` (YUKSEK-2): empty input,
+  crossfade math, no-transition mode.
+- +7 covering `WallpaperMetadataCache` SQLite roundtrip.
 
-## [1.3.0] — 2026-05-02
-
-### Added
-- **Audio Visualizer overlay** (#129): Desktop overlay showing a 64-column FFT spectrum.
-  Center-out horizontal burst with an accent-to-white color gradient; captures
-  microphone or system audio via ScreenCaptureKit.
-- **Audio Visualizer customization** (#159, #160, #161, #162): Sensitivity slider
-  (0.3x – 3.0x), three render styles (Bars / Waveform / Dots), six on-screen
-  positions (4 corners + 2 centers), three size presets (S / M / L).
-- **Battery prompt with override toggle** (#172): When the Mac switches to battery
-  (or launches on battery), users see a prompt offering to keep the live wallpaper
-  running. New `Playback → Always play on battery` Settings toggle makes the
-  choice permanent; `Reset battery prompt` brings the dialog back.
-- **Global hotkeys**: `⌘⇧→` next, `⌘⇧←` previous, `⌘⇧P` play/pause, `⌘⇧R` random.
-- **Photos slideshow generator** (#137): Create wallpapers from your Apple Photos
-  library. Multi-select grid, Ken Burns pan/zoom, crossfade transitions, three
-  resolution presets (1080p / 1440p / 4K), 50-photo cap.
-- **Privacy Manifest** (#164): `PrivacyInfo.xcprivacy` declares required-reason
-  APIs (`NSUserDefaults` CA92.1, `NSFileTimestamp` C617.1) with no tracking
-  domains and no collected data types.
-- **App sandbox enabled**: Hardened runtime + sandbox + capability entitlements
-  for network, file picker, photos, scripting (Music.app), audio input,
-  application groups.
-- **ViewModel layer** (#166): New `ViewModels/` directory with reference
-  implementation (`AIGenerateViewModel`) and pattern guide. AI generation
-  pipeline lifted out of the view, dependency-injectable for testing.
+### Removed prior to release
+- **Audio Visualizer overlay** (#129, #159, #160, #161, #162): UI entry
+  points and lazy initialization removed. Implementation files retained.
+- **Smart Tags (Ollama Vision)** (#116): Settings sidebar entry removed.
+  Service + view + tests retained.
 
 ### Changed
 - **MRMediaRemote gated to `#if DEBUG`** (#165): Release builds ship without


### PR DESCRIPTION
## Summary
- CHANGELOG.md: [Unreleased] + Mayis ayinin tum 22 PR'i tek
  v1.3.0 — 2026-05-17 release entry'sinde toplandi
- Eski "1.3.0 - 2026-05-02" entry'si yerine bugunku tarih ile birlestirildi
- Audio Visualizer ve Smart Tags "Removed prior to release" altinda
  dokumante edildi

## Why
v1.3.0 hicbir zaman App Store'a gonderilmemisti (archive bekliyordu).
Tum Mayis isleri bu release'in icine giriyor.

## Release-ready durum
- Build: 7
- Version: 1.3.0
- Sandbox: aktif
- Privacy manifest: var
- Hardened runtime: aktif
- Tests: 86/86 pass
- Idle CPU: %4 (Instruments)
- Build SUCCEEDED (Debug + ad-hoc)

## Bekleyen kullanici aksiyonu
Bu PR merge'den sonra:
1. Xcode'da Team ayari + signing -> Archive
2. App Store Connect upload + release notes
3. Submit for review

Detayli release kit `.claude/workspace/v1.3.0-release.md`'de
(gitignored, lokal calisma alani).

Co-Authored-By: Claude Opus 4.7