### PR TITLE
hotfix: 4 security/privacy bulgu (PR-A) — v1.3.1

### DIFF
--- a/src/Wallnetic/Resources/Info.plist
+++ b/src/Wallnetic/Resources/Info.plist
@@ -41,13 +41,9 @@
 	<false/>
 	<key>NSHighResolutionCapable</key>
 	<true/>
-	<key>NSMicrophoneUsageDescription</key>
-	<string>Wallnetic uses microphone audio to drive the on-desktop audio visualizer.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Wallnetic reads selected photos from your library to generate slideshow wallpapers. Nothing is uploaded or shared.</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
-	<key>NSScreenCaptureUsageDescription</key>
-	<string>Wallnetic captures system audio (via ScreenCaptureKit) to drive the on-desktop audio visualizer. No screen imagery is recorded.</string>
 </dict>
 </plist>

--- a/src/Wallnetic/Resources/Wallnetic.entitlements
+++ b/src/Wallnetic/Resources/Wallnetic.entitlements
@@ -14,8 +14,6 @@
 	<true/>
 	<key>com.apple.security.files.downloads.read-write</key>
 	<true/>
-	<key>com.apple.security.device.audio-input</key>
-	<true/>
 	<key>com.apple.security.personal-information.photos-library</key>
 	<true/>
 	<key>com.apple.security.scripting-targets</key>

--- a/src/Wallnetic/Services/AuthManager.swift
+++ b/src/Wallnetic/Services/AuthManager.swift
@@ -39,6 +39,9 @@ class AuthManager: NSObject, ObservableObject {
         isAuthenticated = false
         userEmail = nil
         userId = nil
+        KeychainManager.shared.setSecureString(nil, forKey: "auth.userEmail")
+        KeychainManager.shared.setSecureString(nil, forKey: "auth.userId")
+        // Clean up legacy UserDefaults storage (pre-v1.3.1 stored PII here)
         UserDefaults.standard.removeObject(forKey: "auth.userEmail")
         UserDefaults.standard.removeObject(forKey: "auth.userId")
         Log.auth.info("Signed out")
@@ -47,11 +50,26 @@ class AuthManager: NSObject, ObservableObject {
     // MARK: - Session
 
     private func restoreSession() {
-        userEmail = UserDefaults.standard.string(forKey: "auth.userEmail")
-        userId = UserDefaults.standard.string(forKey: "auth.userId")
+        // Read from Keychain first (v1.3.1+). One-shot migrate any legacy
+        // UserDefaults values then wipe them.
+        migrateLegacyAuthStorageIfNeeded()
+        userEmail = KeychainManager.shared.secureString(forKey: "auth.userEmail")
+        userId = KeychainManager.shared.secureString(forKey: "auth.userId")
         isAuthenticated = true
         let email = userEmail ?? "unknown"
         Log.auth.info("Session restored for: \(email, privacy: .private)")
+    }
+
+    private func migrateLegacyAuthStorageIfNeeded() {
+        let defaults = UserDefaults.standard
+        if let legacyEmail = defaults.string(forKey: "auth.userEmail") {
+            KeychainManager.shared.setSecureString(legacyEmail, forKey: "auth.userEmail")
+            defaults.removeObject(forKey: "auth.userEmail")
+        }
+        if let legacyId = defaults.string(forKey: "auth.userId") {
+            KeychainManager.shared.setSecureString(legacyId, forKey: "auth.userId")
+            defaults.removeObject(forKey: "auth.userId")
+        }
     }
 
     private func handleSignIn(idToken: String, email: String?) {
@@ -81,8 +99,8 @@ class AuthManager: NSObject, ObservableObject {
                         self.userEmail = userEmail
                         self.isLoading = false
 
-                        UserDefaults.standard.set(userEmail, forKey: "auth.userEmail")
-                        UserDefaults.standard.set(uid, forKey: "auth.userId")
+                        KeychainManager.shared.setSecureString(userEmail, forKey: "auth.userEmail")
+                        KeychainManager.shared.setSecureString(uid, forKey: "auth.userId")
 
                         Log.auth.info("Signed in: \(userEmail ?? "unknown", privacy: .private)")
                     }

--- a/src/Wallnetic/Services/KeychainManager.swift
+++ b/src/Wallnetic/Services/KeychainManager.swift
@@ -85,4 +85,54 @@ class KeychainManager {
     func hasAPIKey(for provider: APIProvider) -> Bool {
         return getAPIKey(for: provider) != nil
     }
+
+    // MARK: - Generic Secure String Storage
+    //
+    // For PII like signed-in user identifiers we use the same Keychain
+    // service but a dedicated account namespace so they're segregated from
+    // API keys and survive App Group changes.
+
+    private static let securePrefix = "secure."
+
+    @discardableResult
+    func setSecureString(_ value: String?, forKey key: String) -> Bool {
+        let account = Self.securePrefix + key
+        // Always delete first so update is idempotent.
+        let deleteQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account
+        ]
+        SecItemDelete(deleteQuery as CFDictionary)
+
+        guard let value, let data = value.data(using: .utf8) else {
+            return true  // nil/empty → just delete
+        }
+        let addQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlocked
+        ]
+        return SecItemAdd(addQuery as CFDictionary, nil) == errSecSuccess
+    }
+
+    func secureString(forKey key: String) -> String? {
+        let account = Self.securePrefix + key
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+        var result: AnyObject?
+        guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess,
+              let data = result as? Data,
+              let str = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+        return str
+    }
 }

--- a/src/Wallnetic/Services/NowPlayingManager.swift
+++ b/src/Wallnetic/Services/NowPlayingManager.swift
@@ -235,10 +235,45 @@ final class NowPlayingManager: ObservableObject {
         hasTrack = true
         appName = "Spotify"
 
-        if titleChanged, let artURL = info["Album Art URL"] as? String ?? info["artUrl"] as? String,
-           let url = URL(string: artURL) {
+        if titleChanged,
+           let artURL = info["Album Art URL"] as? String ?? info["artUrl"] as? String,
+           let url = sanitizeRemoteArtworkURL(artURL) {
             fetchArtwork(from: url)
         }
+    }
+
+    // DistributedNotificationCenter delivers userInfo from ANY local process,
+    // so the artwork URL is untrusted. Reject file://, schemes other than
+    // https, and loopback/RFC1918 hosts to prevent SSRF reads of local files
+    // or internal services.
+    private func sanitizeRemoteArtworkURL(_ raw: String) -> URL? {
+        guard let url = URL(string: raw),
+              url.scheme?.lowercased() == "https",
+              let host = url.host?.lowercased(),
+              !host.isEmpty,
+              !isLoopbackOrPrivate(host: host)
+        else { return nil }
+        return url
+    }
+
+    private func isLoopbackOrPrivate(host: String) -> Bool {
+        if host == "localhost" || host == "127.0.0.1" || host == "::1" || host == "[::1]" {
+            return true
+        }
+        if host.hasSuffix(".local") || host == "local" {
+            return true
+        }
+        // RFC 1918: 10.x.x.x, 172.16-31.x.x, 192.168.x.x
+        if host.hasPrefix("10.") || host.hasPrefix("192.168.") {
+            return true
+        }
+        if host.hasPrefix("172.") {
+            let parts = host.split(separator: ".")
+            if parts.count >= 2, let octet = Int(parts[1]), (16...31).contains(octet) {
+                return true
+            }
+        }
+        return false
     }
 
     // MARK: - Artwork helpers

--- a/src/Wallnetic/Views/Main/BrowserWebView.swift
+++ b/src/Wallnetic/Views/Main/BrowserWebView.swift
@@ -53,6 +53,37 @@ struct WebViewWrapper: NSViewRepresentable {
         private var pendingDownloads: [WKDownload: (dest: URL, name: String, trackingID: UUID)] = [:]
         private var progressObservations: [WKDownload: NSKeyValueObservation] = [:]
 
+        // Saved-file extension allowlist. Anything not in this set is rewritten to
+        // ".zip" so a hostile server cannot land a binary like `video.mp4.dylib`.
+        static let allowedDownloadExtensions: Set<String> =
+            ["mp4", "mov", "m4v", "webm", "mkv", "zip", "mlw"]
+
+        /// Extracts the file extension from a Content-Disposition header by
+        /// parsing the `filename=` (or `filename*=`) parameter and applying
+        /// `pathExtension`. Returns lowercased extension or nil if no valid
+        /// filename parameter is found.
+        static func extensionFromContentDisposition(_ header: String) -> String? {
+            // RFC 6266 filename parameter. Accept filename="x.mp4", filename=x.mp4,
+            // and filename*=UTF-8''x.mp4 forms.
+            let patterns = [
+                #"filename\*=[^']*''([^;]+)"#,
+                #"filename="([^"]+)""#,
+                #"filename=([^;]+)"#
+            ]
+            for pattern in patterns {
+                guard let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive) else { continue }
+                let range = NSRange(header.startIndex..<header.endIndex, in: header)
+                if let match = regex.firstMatch(in: header, range: range), match.numberOfRanges > 1,
+                   let r = Range(match.range(at: 1), in: header) {
+                    let raw = header[r].trimmingCharacters(in: .whitespacesAndNewlines)
+                    let decoded = raw.removingPercentEncoding ?? String(raw)
+                    let ext = (decoded as NSString).pathExtension.lowercased()
+                    if !ext.isEmpty { return ext }
+                }
+            }
+            return nil
+        }
+
         init(_ parent: WebViewWrapper) { self.parent = parent }
 
         func observeNavigation(of webView: WKWebView) {
@@ -136,14 +167,15 @@ struct WebViewWrapper: NSViewRepresentable {
 
             // application/octet-stream — check Content-Disposition for video filename
             // Sites like moewalls.com serve video as octet-stream with filename=...mp4
+            // Parse the actual `filename=` value rather than substring-matching the
+            // raw header — a hostile filename like "video.mp4.dylib" would pass a
+            // naive `.contains(".mp4")` check.
             if mimeType == "application/octet-stream" {
                 let disposition = (navigationResponse.response as? HTTPURLResponse)?
                     .value(forHTTPHeaderField: "Content-Disposition") ?? ""
-                let videoExts = ["mp4", "mov", "m4v", "webm", "mkv", "zip", "mlw"]
-                let hasVideoFilename = videoExts.contains { disposition.lowercased().contains(".\($0)") }
-
-                if hasVideoFilename {
-                    Log.browser.info("Starting WKDownload for octet-stream: \(url?.absoluteString ?? "?", privacy: .public) (disposition: \(disposition, privacy: .public))")
+                let parsedExt = Self.extensionFromContentDisposition(disposition)
+                if let ext = parsedExt, Self.allowedDownloadExtensions.contains(ext) {
+                    Log.browser.info("Starting WKDownload for octet-stream: \(url?.absoluteString ?? "?", privacy: .public) (ext: \(ext, privacy: .public))")
                     decisionHandler(.download)
                     return
                 }
@@ -175,8 +207,11 @@ struct WebViewWrapper: NSViewRepresentable {
                       suggestedFilename: String,
                       completionHandler: @escaping (URL?) -> Void) {
             let name = (suggestedFilename as NSString).deletingPathExtension
-            let ext = (suggestedFilename as NSString).pathExtension.lowercased()
-            let destExt = ext.isEmpty ? "zip" : ext
+            let rawExt = (suggestedFilename as NSString).pathExtension.lowercased()
+            // Lock the saved file's extension to the allowlist so a hostile
+            // server cannot land a binary like `video.mp4.dylib` on disk via
+            // a crafted suggestedFilename.
+            let destExt = Self.allowedDownloadExtensions.contains(rawExt) ? rawExt : "zip"
             let dest = FileManager.default.temporaryDirectory
                 .appendingPathComponent(UUID().uuidString)
                 .appendingPathExtension(destExt)

--- a/src/Wallnetic/project.yml
+++ b/src/Wallnetic/project.yml
@@ -54,8 +54,6 @@ targets:
         NSHighResolutionCapable: true
         NSPrincipalClass: NSApplication
         LSApplicationCategoryType: public.app-category.utilities
-        NSMicrophoneUsageDescription: "Wallnetic uses microphone audio to drive the on-desktop audio visualizer."
-        NSScreenCaptureUsageDescription: "Wallnetic captures system audio (via ScreenCaptureKit) to drive the on-desktop audio visualizer. No screen imagery is recorded."
         NSPhotoLibraryUsageDescription: "Wallnetic reads selected photos from your library to generate slideshow wallpapers. Nothing is uploaded or shared."
         CFBundleURLTypes:
           - CFBundleTypeRole: Editor


### PR DESCRIPTION
## Summary

v1.3.1 hotfix serisinin ilk PR'i. /code-review xhigh modunda tespit edilen 4 App Store engelleyici güvenlik/gizlilik bulgusunu kapatıyor.

| # | Dosya | Bulgu | Çözüm |
|---|---|---|---|
| 1 | NowPlayingManager.swift | DistributedNotificationCenter Spotify artUrl SSRF | https-only allowlist + loopback/RFC1918 reddi |
| 2 | BrowserWebView.swift | Content-Disposition substring match `.mp4.dylib` injection | Regex ile gerçek filename= parametresi + saved ext allowlist |
| 3 | AuthManager.swift + KeychainManager.swift | userEmail/userId UserDefaults'ta plaintext (PII leak, App Group geniş erişim) | Keychain'e taşıdı + legacy migrate + cleanup |
| 4 | Wallnetic.entitlements + Info.plist + project.yml | PR #199 sonrası audio-input entitlement + mic/screen-capture descriptions hâlâ varken UI yok | 3'ü de silindi |

## Test Plan

- [x] `xcodebuild` ad-hoc build SUCCEEDED
- [ ] Spotify: account ile track değiştir → artwork yine yükleniyor (https CDN trafiği)
- [ ] Browser: moewalls.com'dan video indir → mp4 olarak kaydediliyor
- [ ] Sign In with Apple → sign out → re-sign in → email görünüyor (Keychain üzerinden)
- [ ] App Store Connect Build #8 archive sırasında "audio-input" entitlement uyarısı yok

## Notes

Test coverage:
- 86 mevcut test bu PR'da etkilenmiyor.
- Manual smoke yeterli (security yüzeyi).

🤖 Generated with [Claude Code](https://claude.com/claude-code)