### PR TITLE
hotfix: 3 crash bulgu (PR-B) — v1.3.1

### DIFF
--- a/src/Wallnetic/Services/AIService.swift
+++ b/src/Wallnetic/Services/AIService.swift
@@ -234,12 +234,23 @@ class AIService {
         let maxAttempts = 120  // 4 minutes max (2s intervals)
         var attempts = 0
 
-        // Use status URL or construct one
+        // Use status URL or construct one. Both branches must surface a
+        // throwable error if URL parsing fails — a force-unwrap here can
+        // crash the app when fal.ai returns a requestId with URL-invalid
+        // characters (spaces, brackets, unicode).
         let pollURL: URL
-        if let statusURL = statusURL, let url = URL(string: statusURL) {
+        if let statusURL, let url = URL(string: statusURL) {
             pollURL = url
         } else {
-            pollURL = URL(string: "\(statusBaseURL)/\(request.model.falEndpoint)/requests/\(requestId)/status")!
+            let escapedId = requestId.addingPercentEncoding(
+                withAllowedCharacters: .urlPathAllowed
+            ) ?? requestId
+            guard let url = URL(
+                string: "\(statusBaseURL)/\(request.model.falEndpoint)/requests/\(escapedId)/status"
+            ) else {
+                throw AIServiceError.invalidURL
+            }
+            pollURL = url
         }
 
         while attempts < maxAttempts {

--- a/src/Wallnetic/Services/PhotosLibraryService.swift
+++ b/src/Wallnetic/Services/PhotosLibraryService.swift
@@ -131,19 +131,45 @@ final class PhotosLibraryService: ObservableObject {
             options.isNetworkAccessAllowed = true
             options.isSynchronous = false
 
+            // PHImageManager can deliver the result handler twice (degraded
+            // preview + final), or zero times in error paths. A capture-by-
+            // reference flag guarantees we resume the continuation exactly
+            // once — early-returning on a degraded delivery without resuming
+            // would permanently hang the Task.
+            let resumed = ContinuationResumeFlag()
             imageManager.requestImage(
                 for: asset,
                 targetSize: PHImageManagerMaximumSize,
                 contentMode: .aspectFit,
                 options: options
             ) { image, info in
-                // Skip the low-res "opportunistic" preview if a degraded flag is set.
-                if let isDegraded = info?[PHImageResultIsDegradedKey] as? Bool, isDegraded {
-                    return
+                // Skip the low-res "opportunistic" preview if degraded — but
+                // only if we know a non-degraded delivery is still coming.
+                // Treat cancel/error (image==nil with degraded flag) as a
+                // terminal result so the Task can complete.
+                let degraded = (info?[PHImageResultIsDegradedKey] as? Bool) ?? false
+                let isError = (info?[PHImageErrorKey] != nil)
+                                || ((info?[PHImageCancelledKey] as? Bool) ?? false)
+                if degraded && image != nil && !isError {
+                    return  // wait for the final hi-res callback
                 }
-                cont.resume(returning: image)
+                if resumed.tryConsume() {
+                    cont.resume(returning: image)
+                }
             }
         }
+    }
+}
+
+/// One-shot resumption guard for callbacks that may fire 0, 1, or 2 times.
+private final class ContinuationResumeFlag {
+    private var consumed = false
+    private let lock = NSLock()
+    func tryConsume() -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        guard !consumed else { return false }
+        consumed = true
+        return true
     }
 }
 

--- a/src/Wallnetic/Services/WallpaperManager.swift
+++ b/src/Wallnetic/Services/WallpaperManager.swift
@@ -459,13 +459,23 @@ class WallpaperManager: ObservableObject {
 
     func extractMissingColors() {
         Task {
+            // Snapshot the wallpapers needing color extraction by their id;
+            // after each suspension we re-resolve the index via id so the
+            // write goes to the right wallpaper (or no-op if it was deleted
+            // during the async gap).
+            let targets: [(id: UUID, url: URL)] = wallpapers
+                .filter { $0.dominantColorHex == nil }
+                .map { ($0.id, $0.url) }
             var updatedColors = metadata.savedColors
-            for i in wallpapers.indices where wallpapers[i].dominantColorHex == nil {
-                if let hex = await wallpapers[i].extractDominantColor() {
+            for target in targets {
+                guard let snapshot = wallpapers.first(where: { $0.id == target.id }) else { continue }
+                if let hex = await snapshot.extractDominantColor() {
                     await MainActor.run {
-                        wallpapers[i].dominantColorHex = hex
+                        if let idx = wallpapers.firstIndex(where: { $0.id == target.id }) {
+                            wallpapers[idx].dominantColorHex = hex
+                        }
                     }
-                    updatedColors[wallpapers[i].url.path] = hex
+                    updatedColors[target.url.path] = hex
                 }
             }
             await MainActor.run {


### PR DESCRIPTION
## Summary

v1.3.1 hotfix serisinin 2. PR'i. /code-review xhigh modunda tespit edilen 3 Tier-1 crash/hang bulgusunu kapatıyor.

| # | Dosya | Bulgu | Çözüm |
|---|---|---|---|
| 1 | AIService.swift:242 | `URL(string:)!` requestId URL-invalid karakter ile crash | percent-encoded + guard + throw `.invalidURL` |
| 2 | PhotosLibraryService.swift:141 | `withCheckedContinuation` degraded-only delivery hang | NSLock-backed `ContinuationResumeFlag` ile exactly-once resume |
| 3 | WallpaperManager.swift:463 | `extractMissingColors` index race → renk yanlis wallpaper'a | id-tuple snapshot + re-resolve via firstIndex(where:) |

## Test Plan
- [x] `xcodebuild` SUCCEEDED
- [ ] AI generate: özel karakterli prompt → graceful error (crash yok)
- [ ] Photos slideshow: iCloud-only foto seç → timeout or completion (hang yok)
- [ ] Toplu import + dominantColor extraction sırasında wallpaper sil → wrong-color yok

## Notes
- PR #207 merge'ten sonra dev üzerinde.
- Sendable warning'leri pre-existing (Swift 6 mode), bu PR'da yeni tanıtılan yok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)