### PR TITLE
hotfix: 4 functional bulgu (PR-C) — v1.3.1

### DIFF
--- a/src/Wallnetic/Engine/DesktopWindowController.swift
+++ b/src/Wallnetic/Engine/DesktopWindowController.swift
@@ -27,7 +27,13 @@ class DesktopWindowController {
     private var renderers: [NSScreen: WallpaperRenderer] = [:]
     private var effectOverlays: [NSScreen: NSView] = [:]
     private var isPlaying = false
+    /// Last URL applied to *all* screens (uniform mode). Used to restore
+    /// new screens on hot-plug and to skip redundant uniform reapplies.
     private var currentWallpaperURL: URL?
+    /// Per-screen URL state. Lets the per-screen path skip a redundant
+    /// reload on the same screen while still allowing two screens to share
+    /// the same source URL in "different per display" mode.
+    private var screenWallpaperURLs: [NSScreen: URL] = [:]
     private var useMetalRenderer: Bool
 
     init() {
@@ -129,8 +135,22 @@ class DesktopWindowController {
 
     /// Sets the wallpaper video with animated transition
     func setWallpaper(url: URL, for screen: NSScreen? = nil) {
-        guard url != currentWallpaperURL else { return }
-        currentWallpaperURL = url
+        // Guard per scope: uniform-mode (screen=nil) skips redundant
+        // reapplies only when the URL hasn't changed at all; per-screen
+        // mode keys the skip check on the target screen so two screens
+        // can share the same source URL without one being silently dropped.
+        if let screen {
+            guard screenWallpaperURLs[screen] != url else { return }
+            screenWallpaperURLs[screen] = url
+        } else {
+            guard currentWallpaperURL != url else { return }
+            currentWallpaperURL = url
+            // Uniform reapply: reset per-screen state so hot-plug and
+            // mode transitions see a consistent picture.
+            for s in desktopWindows.keys {
+                screenWallpaperURLs[s] = url
+            }
+        }
 
         let style = WallpaperManager.shared.transitionStyle
         let duration = WallpaperManager.shared.transitionDuration
@@ -223,6 +243,7 @@ class DesktopWindowController {
             desktopWindows[screen]?.close()
             desktopWindows.removeValue(forKey: screen)
             renderers.removeValue(forKey: screen)
+            screenWallpaperURLs.removeValue(forKey: screen)
         }
 
         // Add windows for new screens

--- a/src/Wallnetic/Services/NowPlayingManager.swift
+++ b/src/Wallnetic/Services/NowPlayingManager.swift
@@ -287,14 +287,17 @@ final class NowPlayingManager: ObservableObject {
             end if
         end tell
         """
-        DispatchQueue.global(qos: .utility).async { [weak self] in
-            if let appleScript = NSAppleScript(source: script) {
-                var error: NSDictionary?
-                let result = appleScript.executeAndReturnError(&error)
-                let data = result.data
-                if let image = NSImage(data: data) {
-                    DispatchQueue.main.async { self?.artwork = image }
-                }
+        // NSAppleScript must run on the main thread; documented in the
+        // AppleScript framework reference. Off-main execution sporadically
+        // hangs the event loop or returns empty Data.
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            guard let appleScript = NSAppleScript(source: script) else { return }
+            var error: NSDictionary?
+            let result = appleScript.executeAndReturnError(&error)
+            let data = result.data
+            if let image = NSImage(data: data) {
+                self.artwork = image
             }
         }
     }

--- a/src/Wallnetic/Services/SpaceWallpaperManager.swift
+++ b/src/Wallnetic/Services/SpaceWallpaperManager.swift
@@ -11,8 +11,15 @@ class SpaceWallpaperManager: ObservableObject {
 
     @Published var currentSpaceIndex: Int = 0
     @Published var currentSpaceID: Int = 0
-    @Published var spaceAssignments: [Int: String] = [:] // spaceIndex -> wallpaper URL path
-    @Published var knownSpaceIDs: [Int] = [] // ordered list of discovered space IDs
+    // NOTE on identity: macOS does not expose a stable, App-Store-safe
+    // Space identifier. Our signature is derived from Dock/Finder window
+    // IDs (kernel-assigned, not portable across reboots), so assignments
+    // keyed by signature do *not* survive a relaunch. We deliberately key
+    // by signature anyway so a stale assignment cannot be applied to the
+    // *wrong* Space — after a restart the user simply has to re-assign,
+    // which is correct behavior in the face of unknown identity.
+    @Published var spaceAssignments: [Int: String] = [:] // spaceID (signature) -> wallpaper URL path
+    @Published var knownSpaceIDs: [Int] = [] // ordered list of discovered space IDs (current session)
 
     private var spaceObserver: Any?
 
@@ -54,24 +61,41 @@ class SpaceWallpaperManager: ObservableObject {
     // MARK: - Assignment
 
     func setWallpaper(_ wallpaper: Wallpaper, forSpace spaceIndex: Int) {
-        spaceAssignments[spaceIndex] = wallpaper.url.path
+        // spaceIndex is the position in knownSpaceIDs; resolve it to a
+        // signature so the binding survives subsequent space discoveries
+        // re-ordering the list.
+        guard spaceIndex >= 0, spaceIndex < knownSpaceIDs.count else { return }
+        let signature = knownSpaceIDs[spaceIndex]
+        spaceAssignments[signature] = wallpaper.url.path
         saveAssignments()
-        Log.space.info("Set wallpaper '\(wallpaper.name, privacy: .public)' for space \(spaceIndex)")
+        Log.space.info("Set wallpaper '\(wallpaper.name, privacy: .public)' for space signature \(signature)")
 
-        // Apply immediately if this is the current space
         if spaceIndex == currentSpaceIndex {
             WallpaperManager.shared.setWallpaper(wallpaper)
         }
     }
 
     func wallpaper(forSpace spaceIndex: Int) -> Wallpaper? {
-        guard let path = spaceAssignments[spaceIndex] else { return nil }
+        guard spaceIndex >= 0, spaceIndex < knownSpaceIDs.count else { return nil }
+        let signature = knownSpaceIDs[spaceIndex]
+        guard let path = spaceAssignments[signature] else { return nil }
         return WallpaperManager.shared.wallpapers.first { $0.url.path == path }
     }
 
     func clearAssignment(forSpace spaceIndex: Int) {
-        spaceAssignments.removeValue(forKey: spaceIndex)
+        guard spaceIndex >= 0, spaceIndex < knownSpaceIDs.count else { return }
+        let signature = knownSpaceIDs[spaceIndex]
+        spaceAssignments.removeValue(forKey: signature)
         saveAssignments()
+    }
+
+    /// Drops all per-Space assignments. UI surface should expose this so a
+    /// user whose stored signatures no longer match (after restart) can
+    /// reset state instead of seeing wallpapers go missing.
+    func resetAllAssignments() {
+        spaceAssignments.removeAll()
+        saveAssignments()
+        Log.space.info("Cleared all space assignments")
     }
 
     // MARK: - Space Detection
@@ -140,6 +164,11 @@ class SpaceWallpaperManager: ObservableObject {
         guard let data = assignmentsJSON.data(using: .utf8) else { return }
         do {
             let decoded = try JSONDecoder().decode([String: String].self, from: data)
+            // Stored keys are now space signatures, not indices. Pre-v1.3.1
+            // saved data may still contain index keys (0,1,2…) — those
+            // would never match a signature so they get harmlessly ignored,
+            // which is the correct outcome (we don't know what space they
+            // referred to).
             spaceAssignments = Dictionary(uniqueKeysWithValues: decoded.compactMap { key, value in
                 guard let intKey = Int(key) else { return nil }
                 return (intKey, value)

--- a/src/Wallnetic/Services/WallpaperManager.swift
+++ b/src/Wallnetic/Services/WallpaperManager.swift
@@ -517,6 +517,21 @@ class WallpaperManager: ObservableObject {
         playbackDelegate?.playbackSetWallpaper(url: wallpaper.url, for: screen)
         playbackDelegate?.playbackPlay()
 
+        // The active screen's wallpaper is what DynamicAccent, DynamicIsland,
+        // ThemeManager, and the widget should reflect. Without updating
+        // currentWallpaper + posting .wallpaperDidChange these consumers
+        // remain stuck on stale data whenever per-screen mode is used.
+        let activeScreen = NSScreen.main ?? screen
+        if screen == activeScreen {
+            currentWallpaper = wallpaper
+            lastWallpaperURL = wallpaper.url.path
+            NotificationCenter.default.post(name: .wallpaperDidChange, object: wallpaper)
+            Task {
+                await widgetSync.syncCurrentWallpaper(wallpaper)
+                widgetSync.syncPlaybackState(isPlaying: true)
+            }
+        }
+
         NotificationCenter.default.post(
             name: .screenWallpaperDidChange,
             object: ScreenWallpaperInfo(wallpaper: wallpaper, screen: screen)


### PR DESCRIPTION
## Summary

v1.3.1 hotfix serisinin 3. PR'i. Tier-3 functional regression'ları kapatıyor.

| # | Dosya | Bulgu | Çözüm |
|---|---|---|---|
| 1 | NowPlayingManager.swift:258 | NSAppleScript bg thread'de → sporadic hang/empty data | DispatchQueue.main.async'e taşındı |
| 2 | DesktopWindowController.swift:132 | Global URL guard, per-screen aynı wallpaper skip | screenWallpaperURLs dict + scope-aware skip |
| 3 | WallpaperManager.swift:511 | Per-screen mode currentWallpaper update etmiyor → DI/accent/widget stale | Active screen tespitiyle uniform pipeline tetikleniyor |
| 4 | SpaceWallpaperManager.swift:113 | Index-keyed assignments + unstable window-ID signatures → wallpaper'lar yanlış Space'e | Signature-keyed (old indices harmless ignore) + resetAllAssignments() |

## Test Plan
- [x] `xcodebuild` SUCCEEDED
- [ ] Apple Music: track değiştir → artwork yükleniyor (main-thread AppleScript)
- [ ] 2-monitor + per-screen mode: aynı wallpaper'ı iki ekrana ata → her ikisinde de oynuyor
- [ ] Per-screen mode + active screen wallpaper değişti → Dynamic Island + accent color refresh
- [ ] macOS spaces feature açık → Space switch → artık random wallpaper olmuyor (eski stored data ignored, user re-assign edebiliyor)

## Breaking Change Notice
Space assignment storage formatı index→signature olarak değişti. Pre-v1.3.1 saved data otomatik ignore — kullanıcı Space wallpaper'larını bir kez re-assign etmek zorunda. macOS public API stable Space ID vermediği için bu trade-off documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)