### PR TITLE
hardening: main-thread guard for power callbacks + drop AV force-unwraps (#206)

### DIFF
--- a/src/Wallnetic/Engine/MetalVideoRenderer.swift
+++ b/src/Wallnetic/Engine/MetalVideoRenderer.swift
@@ -206,17 +206,19 @@ final class MetalVideoRenderer: NSObject {
             kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA,
             kCVPixelBufferMetalCompatibilityKey as String: true
         ]
-        videoOutput = AVPlayerItemVideoOutput(pixelBufferAttributes: outputSettings)
-        playerItem.add(videoOutput!)
+        let output = AVPlayerItemVideoOutput(pixelBufferAttributes: outputSettings)
+        videoOutput = output
+        playerItem.add(output)
 
         // Setup looping player
-        queuePlayer = AVQueuePlayer()
-        queuePlayer?.automaticallyWaitsToMinimizeStalling = false
-        queuePlayer?.preventsDisplaySleepDuringVideoPlayback = false
-        queuePlayer?.isMuted = true
+        let queue = AVQueuePlayer()
+        queue.automaticallyWaitsToMinimizeStalling = false
+        queue.preventsDisplaySleepDuringVideoPlayback = false
+        queue.isMuted = true
+        queuePlayer = queue
 
-        playerLooper = AVPlayerLooper(player: queuePlayer!, templateItem: playerItem)
-        player = queuePlayer
+        playerLooper = AVPlayerLooper(player: queue, templateItem: playerItem)
+        player = queue
 
         logger.info("Player setup complete")
     }

--- a/src/Wallnetic/Engine/PowerManager.swift
+++ b/src/Wallnetic/Engine/PowerManager.swift
@@ -374,7 +374,8 @@ class PowerManager {
     // MARK: - Notifications
 
     private func notifyPauseIfNeeded() {
-        onShouldPausePlayback?()
+        let callback = onShouldPausePlayback
+        runOnMain { callback?() }
     }
 
     private func notifyResumeIfNeeded() {
@@ -382,7 +383,21 @@ class PowerManager {
         guard !shouldBePaused else { return }
 
         if WallpaperManager.shared.shouldAutoResume {
-            onShouldResumePlayback?()
+            let callback = onShouldResumePlayback
+            runOnMain { callback?() }
+        }
+    }
+
+    /// Routes playback callbacks to the main thread before they touch
+    /// AppKit/AVKit (NSWindow, AVPlayer-on-view). Sleep/wake, screen-parameter
+    /// and IOPS battery notifications already arrive on main and run
+    /// synchronously here; only NSProcessInfoPowerStateDidChange (Low Power
+    /// Mode) is not guaranteed main-thread, so it hops via async. [#206]
+    private func runOnMain(_ work: @escaping () -> Void) {
+        if Thread.isMainThread {
+            work()
+        } else {
+            DispatchQueue.main.async(execute: work)
         }
     }
 

--- a/src/Wallnetic/Engine/VideoRenderer.swift
+++ b/src/Wallnetic/Engine/VideoRenderer.swift
@@ -97,12 +97,13 @@ class VideoRenderer: NSObject {
         // Audio disabled via player.isMuted + volume=0 below
 
         // Use AVQueuePlayer with AVPlayerLooper for seamless looping
-        queuePlayer = AVQueuePlayer()
-        queuePlayer?.automaticallyWaitsToMinimizeStalling = false  // Start immediately
-        queuePlayer?.preventsDisplaySleepDuringVideoPlayback = false  // Allow display sleep
+        let queue = AVQueuePlayer()
+        queue.automaticallyWaitsToMinimizeStalling = false  // Start immediately
+        queue.preventsDisplaySleepDuringVideoPlayback = false  // Allow display sleep
+        queuePlayer = queue
 
-        playerLooper = AVPlayerLooper(player: queuePlayer!, templateItem: playerItem)
-        player = queuePlayer
+        playerLooper = AVPlayerLooper(player: queue, templateItem: playerItem)
+        player = queue
 
         // Configure player for optimal performance
         player?.isMuted = true  // No audio needed


### PR DESCRIPTION
## Summary

Defensive hardening of the wake / power-management path, found while investigating #206 (intermittent crash on unlock, macOS 26.5 Tahoe).

**Important — this does NOT claim to fix the #206 unlock crash.** Static analysis could not reproduce or confirm it: every unlock-path notification (`screensDidWake`, `didWake`, `didChangeScreenParameters`, the IOPS battery source) is delivered on the **main thread**, so `DesktopWindowController`'s `renderers`/`desktopWindows` dictionaries are only mutated on the serial main thread during unlock — there is no data race there. A crash log from the reporter is still needed to pinpoint the actual cause. The two changes below are genuine, independently-valid hardening fixes surfaced by the investigation.

## Changes

### 1. Main-thread guard for playback callbacks (`PowerManager`)
`notifyPauseIfNeeded` / `notifyResumeIfNeeded` now route `onShouldPause/ResumePlayback` through a small `runOnMain` helper.
- **Why:** `NSProcessInfoPowerStateDidChange` (Low Power Mode) is *not* documented to post on the main thread, yet these callbacks drive AppKit/AVKit work (`NSWindow`, `AVPlayer` attached to an `NSView`). It's the one genuinely off-main path.
- **No regression:** `runOnMain` runs **synchronously** when already on main (all sleep/wake/screen-parameter paths are), so pause-before-sleep timing is unchanged. Only the LPM path defers via `DispatchQueue.main.async`.

### 2. Remove 3 AV force-unwraps (`VideoRenderer`, `MetalVideoRenderer`)
`AVQueuePlayer()` and `AVPlayerItemVideoOutput(pixelBufferAttributes:)` are **non-failable** initializers; the `!` was on freshly-assigned, non-nil values. Replaced with locals — cosmetic safety/readability, no behavior change.

## Testing
- `xcodebuild test` (scheme `Wallnetic`, Debug, `CODE_SIGNING_ALLOWED=NO`): **86/86 pass** — `** TEST SUCCEEDED **`.

## Notes
- No new files → no `project.yml` regen; `project.pbxproj` untouched (pre-commit Team-ID guard clean).
- Refs #206 (deliberately does **not** close it — Bug A still awaits a crash log; Bug B is a macOS lock-screen sandbox limitation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)