### PR TITLE
hotfix: NSPanel/NSWindow over-release on close under ARC — #206 Bug A

### DIFF
--- a/src/Wallnetic/Engine/AudioVisualizerOverlayController.swift
+++ b/src/Wallnetic/Engine/AudioVisualizerOverlayController.swift
@@ -45,6 +45,7 @@ final class AudioVisualizerOverlayController: ObservableObject {
             backing: .buffered,
             defer: true
         )
+        panel.isReleasedWhenClosed = false  // ARC owns `window`; avoid over-release on close() [#206]
         panel.level = NSWindow.Level(rawValue: Int(CGWindowLevelForKey(.desktopIconWindow)) + 1)
         panel.collectionBehavior = [.canJoinAllSpaces, .stationary, .fullScreenNone]
         panel.isOpaque = false

--- a/src/Wallnetic/Engine/DesktopOverlayController.swift
+++ b/src/Wallnetic/Engine/DesktopOverlayController.swift
@@ -38,6 +38,7 @@ class DesktopOverlayController: ObservableObject {
             defer: true
         )
 
+        window.isReleasedWhenClosed = false  // ARC owns overlayWindow; avoid over-release on close() [#206]
         window.level = NSWindow.Level(rawValue: Int(CGWindowLevelForKey(.desktopIconWindow)) + 1)
         window.collectionBehavior = [.canJoinAllSpaces, .stationary, .fullScreenNone]
         window.isOpaque = false

--- a/src/Wallnetic/Engine/DynamicIslandController.swift
+++ b/src/Wallnetic/Engine/DynamicIslandController.swift
@@ -101,6 +101,10 @@ class DynamicIslandController: ObservableObject {
             defer: true
         )
 
+        // ARC owns the panel via islandWindows; close() must NOT also release it,
+        // otherwise an in-flight animator().setFrame animation (updateWindowFrames)
+        // over-releases the freed panel during the next CA transaction flush. [#206]
+        panel.isReleasedWhenClosed = false
         panel.level = NSWindow.Level(rawValue: Int(CGWindowLevelForKey(.mainMenuWindow)) + 2)
         panel.collectionBehavior = [.canJoinAllSpaces, .stationary, .fullScreenNone]
         panel.isOpaque = false

--- a/src/Wallnetic/Engine/NowPlayingOverlayController.swift
+++ b/src/Wallnetic/Engine/NowPlayingOverlayController.swift
@@ -55,6 +55,7 @@ final class NowPlayingOverlayController: ObservableObject {
             backing: .buffered,
             defer: true
         )
+        panel.isReleasedWhenClosed = false  // ARC owns `window`; avoid over-release on close() [#206]
         panel.level = NSWindow.Level(rawValue: Int(CGWindowLevelForKey(.desktopIconWindow)) + 1)
         panel.collectionBehavior = [.canJoinAllSpaces, .stationary, .fullScreenNone]
         panel.isOpaque = false

--- a/src/Wallnetic/Services/LockScreenManager.swift
+++ b/src/Wallnetic/Services/LockScreenManager.swift
@@ -85,6 +85,8 @@ class LockScreenManager: ObservableObject {
             defer: false
         )
 
+        // ARC owns lockScreenWindow; close() must not also release it [#206]
+        window.isReleasedWhenClosed = false
         // Position above screen saver but below login window
         window.level = NSWindow.Level(rawValue: Int(CGWindowLevelForKey(.screenSaverWindow)) + 1)
         window.collectionBehavior = [.canJoinAllSpaces, .stationary]


### PR DESCRIPTION
## What the crash log showed

The reporter (@facettedtea, v1.2.0 b6, macOS 26.5) sent the `.ips`:

- **`EXC_BAD_ACCESS (SIGSEGV)`**, KERN_INVALID_ADDRESS, **Thread 0 (main)**, **~120 s after wake**
- Backtrace: `objc_release` → **`-[_NSWindowTransformAnimation dealloc]`** → `_Block_release` → `-[NSConcretePointerArray dealloc]` → autorelease-pool pop → **`CA::Transaction::commit`** (runloop observer)

That's an **over-release of an NSWindow transform-animation object** during the CoreAnimation flush — not a force-unwrap (would be `EXC_BREAKPOINT`) and not a cross-thread race (it's the main thread). This matches the earlier analysis that PR #211's power-callback path was *not* the cause.

## Root cause

Five panel/window controllers create an `NSPanel`/`NSWindow` programmatically, retain it under ARC (property or dictionary), and `close()` it — but never set `isReleasedWhenClosed`, so it defaults to **`true`**. Under ARC the owning reference is already one strong ref, and `close()` drops a second. If a panel is closed **while its `animator().setFrame` transform animation is in flight**, the panel is freed under the still-live `_NSWindowTransformAnimation`, which then over-releases it on the next CoreAnimation flush.

**`DynamicIslandController` is the proven trigger** — it's the only controller that runs `animator().setFrame` (expand/collapse, `updateWindowFrames`), and on wake `screensChanged()` `close()`s panels as displays drop/re-add (#201 made the island multi-monitor). Closing one mid-animation = this exact crash. The other four controllers (NowPlaying, DesktopOverlay, AudioVisualizer, LockScreen) carry the same latent ARC over-release.

## Fix

`isReleasedWhenClosed = false` on all five — ARC alone owns lifetime, and the in-flight animation / CA transaction keeps the panel alive until it completes. This mirrors the existing, correct `DesktopWindowController:91`. One line each, no behaviour change otherwise.

## Testing
- `xcodebuild test` (scheme `Wallnetic`, Debug, signing off): **86/86 pass**, `** TEST SUCCEEDED **`.
- Full reproduction needs sleep/wake + display-topology churn on hardware; confidence is high from the crash signature but **not** reporter-confirmed yet.

## Notes
- **Refs #206 (Bug A)** — intentionally does *not* close it. Bug A awaits reporter confirmation on a shipped build; Bug B (lock-screen wallpaper) is a separate macOS sandbox limitation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)