### PR TITLE
refactor: OverlayWindowFactory + deep-link consolidation (review findings)

### DIFF
--- a/src/Wallnetic/App/AppDelegate.swift
+++ b/src/Wallnetic/App/AppDelegate.swift
@@ -172,14 +172,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     // MARK: - URL Handling
 
     func application(_ application: NSApplication, open urls: [URL]) {
+        // Single entry point: every wallnetic:// URL (widget links AND external
+        // deep links) flows through DeepLinkHandler, which centralizes scheme
+        // validation, action routing, and the gated/HTTPS-only import path.
         for url in urls {
-            guard url.scheme == "wallnetic" else { continue }
-            let host = url.host ?? ""
-            if host == "open" {
-                showMainWindow()
-            } else if host == "playPause" || host == "nextWallpaper" || host == "setWallpaper" {
-                WallpaperManager.shared.handleWidgetURL(url)
-            }
+            DeepLinkHandler.shared.handle(url)
         }
     }
 

--- a/src/Wallnetic/Engine/AudioVisualizerOverlayController.swift
+++ b/src/Wallnetic/Engine/AudioVisualizerOverlayController.swift
@@ -39,19 +39,11 @@ final class AudioVisualizerOverlayController: ObservableObject {
             }
         }
 
-        let panel = NSPanel(
+        let panel = OverlayWindowFactory.makeOverlayPanel(
             contentRect: NSRect(origin: .zero, size: AudioVisualizerManager.shared.sizePreset.dimensions),
-            styleMask: [.borderless, .nonactivatingPanel],
-            backing: .buffered,
-            defer: true
+            clickThrough: true
         )
-        panel.isReleasedWhenClosed = false  // ARC owns `window`; avoid over-release on close() [#206]
         panel.level = NSWindow.Level(rawValue: Int(CGWindowLevelForKey(.desktopIconWindow)) + 1)
-        panel.collectionBehavior = [.canJoinAllSpaces, .stationary, .fullScreenNone]
-        panel.isOpaque = false
-        panel.backgroundColor = .clear
-        panel.hasShadow = false
-        panel.ignoresMouseEvents = true  // click-through
 
         panel.contentView = NSHostingView(
             rootView: AudioVisualizerOverlayView()

--- a/src/Wallnetic/Engine/DesktopOverlayController.swift
+++ b/src/Wallnetic/Engine/DesktopOverlayController.swift
@@ -31,20 +31,11 @@ class DesktopOverlayController: ObservableObject {
 
         let hostingView = NSHostingView(rootView: content)
 
-        let window = NSPanel(
+        let window = OverlayWindowFactory.makeOverlayPanel(
             contentRect: NSRect(x: posX, y: posY, width: 320, height: 120),
-            styleMask: [.borderless, .nonactivatingPanel],
-            backing: .buffered,
-            defer: true
+            movableByBackground: true
         )
-
-        window.isReleasedWhenClosed = false  // ARC owns overlayWindow; avoid over-release on close() [#206]
         window.level = NSWindow.Level(rawValue: Int(CGWindowLevelForKey(.desktopIconWindow)) + 1)
-        window.collectionBehavior = [.canJoinAllSpaces, .stationary, .fullScreenNone]
-        window.isOpaque = false
-        window.backgroundColor = .clear
-        window.hasShadow = false
-        window.isMovableByWindowBackground = true
         window.contentView = hostingView
 
         window.orderFront(nil)
@@ -132,13 +123,20 @@ struct DesktopOverlayView: View {
         .opacity(overlayController.overlayOpacity)
     }
 
+    // Static formatters — DateFormatter allocation is expensive; reusing them
+    // avoids rebuilding on every SwiftUI render of the clock.
+    private static let timeFormatter: DateFormatter = {
+        let f = DateFormatter(); f.dateFormat = "HH:mm"; return f
+    }()
+    private static let dateFormatter: DateFormatter = {
+        let f = DateFormatter(); f.dateFormat = "d MMMM EEEE"; f.locale = Locale.current; return f
+    }()
+
     private var timeString: String {
-        let f = DateFormatter(); f.dateFormat = "HH:mm"; return f.string(from: Date())
+        Self.timeFormatter.string(from: Date())
     }
 
     private var dateString: String {
-        let f = DateFormatter(); f.dateFormat = "d MMMM EEEE"
-        f.locale = Locale.current
-        return f.string(from: Date())
+        Self.dateFormatter.string(from: Date())
     }
 }

--- a/src/Wallnetic/Engine/DesktopWindowController.swift
+++ b/src/Wallnetic/Engine/DesktopWindowController.swift
@@ -63,12 +63,9 @@ class DesktopWindowController {
 
     /// Creates a single desktop window for a specific screen
     private func createDesktopWindow(for screen: NSScreen) {
-        let window = NSWindow(
-            contentRect: screen.frame,
-            styleMask: .borderless,
-            backing: .buffered,
-            defer: true  // Defer creation for performance
-        )
+        // Defer creation for performance. isReleasedWhenClosed=false is baked
+        // into the factory so ARC alone owns the window. [#206]
+        let window = OverlayWindowFactory.makeBackgroundWindow(contentRect: screen.frame)
 
         // Position window at desktop level (behind icons, above actual desktop)
         let desktopIconLevel = Int(CGWindowLevelForKey(.desktopIconWindow))
@@ -82,13 +79,9 @@ class DesktopWindowController {
             .fullScreenNone          // Never go fullscreen
         ]
 
-        // Visual properties - optimized for performance
-        window.isOpaque = true  // Opaque is faster than transparent
-        window.backgroundColor = .black
-        window.hasShadow = false
+        // Visual properties - optimized for performance (opaque is faster)
         window.ignoresMouseEvents = true
         window.acceptsMouseMovedEvents = false
-        window.isReleasedWhenClosed = false
 
         // Disable window animations
         window.animationBehavior = .none

--- a/src/Wallnetic/Engine/DynamicIslandController.swift
+++ b/src/Wallnetic/Engine/DynamicIslandController.swift
@@ -94,25 +94,12 @@ class DynamicIslandController: ObservableObject {
                 .environmentObject(self)
         )
 
-        let panel = NSPanel(
-            contentRect: frame,
-            styleMask: [.borderless, .nonactivatingPanel],
-            backing: .buffered,
-            defer: true
-        )
-
-        // ARC owns the panel via islandWindows; close() must NOT also release it,
-        // otherwise an in-flight animator().setFrame animation (updateWindowFrames)
-        // over-releases the freed panel during the next CA transaction flush. [#206]
-        panel.isReleasedWhenClosed = false
+        // isReleasedWhenClosed=false (factory) is critical here: an in-flight
+        // animator().setFrame (updateWindowFrames) would otherwise over-release
+        // the freed panel on the next CA transaction flush. [#206]
+        let panel = OverlayWindowFactory.makeOverlayPanel(contentRect: frame)
         panel.level = NSWindow.Level(rawValue: Int(CGWindowLevelForKey(.mainMenuWindow)) + 2)
-        panel.collectionBehavior = [.canJoinAllSpaces, .stationary, .fullScreenNone]
-        panel.isOpaque = false
-        panel.backgroundColor = .clear
-        panel.hasShadow = false
-        panel.isMovableByWindowBackground = false
         panel.contentView = hostingView
-        panel.ignoresMouseEvents = false
 
         panel.orderFront(nil)
         return panel

--- a/src/Wallnetic/Engine/NowPlayingOverlayController.swift
+++ b/src/Wallnetic/Engine/NowPlayingOverlayController.swift
@@ -49,19 +49,12 @@ final class NowPlayingOverlayController: ObservableObject {
             origin = NSPoint(x: 40, y: 40)
         }
 
-        let panel = NSPanel(
+        let panel = OverlayWindowFactory.makeOverlayPanel(
             contentRect: NSRect(origin: origin, size: size),
-            styleMask: [.borderless, .nonactivatingPanel],
-            backing: .buffered,
-            defer: true
+            hasShadow: true,
+            movableByBackground: true
         )
-        panel.isReleasedWhenClosed = false  // ARC owns `window`; avoid over-release on close() [#206]
         panel.level = NSWindow.Level(rawValue: Int(CGWindowLevelForKey(.desktopIconWindow)) + 1)
-        panel.collectionBehavior = [.canJoinAllSpaces, .stationary, .fullScreenNone]
-        panel.isOpaque = false
-        panel.backgroundColor = .clear
-        panel.hasShadow = true
-        panel.isMovableByWindowBackground = true
 
         let view = NowPlayingOverlayView()
             .environmentObject(NowPlayingManager.shared)

--- a/src/Wallnetic/Engine/OverlayWindowFactory.swift
+++ b/src/Wallnetic/Engine/OverlayWindowFactory.swift
@@ -1,0 +1,71 @@
+import Cocoa
+
+/// Centralized factory for the app's programmatically-created windows and
+/// panels. Every overlay/background window in Wallnetic is owned by ARC
+/// (a property or a dictionary on its controller) and torn down with
+/// `close()`. The factory bakes in the safe defaults — most importantly
+/// `isReleasedWhenClosed = false`, whose per-controller omission caused the
+/// #206 unlock crash (a panel freed under an in-flight `_NSWindowTransformAnimation`
+/// over-released on the next CoreAnimation flush).
+///
+/// Keeping the construction in one place means a new overlay can't silently
+/// reintroduce that bug class by forgetting a single property.
+enum OverlayWindowFactory {
+
+    /// A borderless, non-activating `NSPanel` for floating desktop overlays
+    /// (Dynamic Island, Now Playing, controls, audio visualizer).
+    ///
+    /// - Parameters:
+    ///   - contentRect: initial frame.
+    ///   - transparent: `true` for clear/transparent overlays (the common
+    ///     case); `false` for opaque panels.
+    ///   - hasShadow: drop shadow under the panel.
+    ///   - clickThrough: when `true` the panel ignores mouse events entirely.
+    ///   - movableByBackground: drag-to-move by clicking the panel body.
+    static func makeOverlayPanel(
+        contentRect: NSRect,
+        transparent: Bool = true,
+        hasShadow: Bool = false,
+        clickThrough: Bool = false,
+        movableByBackground: Bool = false
+    ) -> NSPanel {
+        let panel = NSPanel(
+            contentRect: contentRect,
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: true
+        )
+        // ARC owns the panel via its controller; close() must NOT also
+        // release it, or an in-flight animation over-releases freed memory. [#206]
+        panel.isReleasedWhenClosed = false
+        panel.collectionBehavior = [.canJoinAllSpaces, .stationary, .fullScreenNone]
+        panel.isOpaque = !transparent
+        panel.backgroundColor = transparent ? .clear : .black
+        panel.hasShadow = hasShadow
+        panel.isMovableByWindowBackground = movableByBackground
+        panel.ignoresMouseEvents = clickThrough
+        return panel
+    }
+
+    /// A borderless `NSWindow` for full-screen background surfaces
+    /// (desktop wallpaper layer, lock-screen wallpaper). Opaque by default.
+    static func makeBackgroundWindow(
+        contentRect: NSRect,
+        deferCreation: Bool = true,
+        opaque: Bool = true,
+        backgroundColor: NSColor = .black
+    ) -> NSWindow {
+        let window = NSWindow(
+            contentRect: contentRect,
+            styleMask: .borderless,
+            backing: .buffered,
+            defer: deferCreation
+        )
+        // ARC owns the window via its controller; avoid over-release on close(). [#206]
+        window.isReleasedWhenClosed = false
+        window.isOpaque = opaque
+        window.backgroundColor = backgroundColor
+        window.hasShadow = false
+        return window
+    }
+}

--- a/src/Wallnetic/Services/DeepLinkHandler.swift
+++ b/src/Wallnetic/Services/DeepLinkHandler.swift
@@ -32,6 +32,9 @@ class DeepLinkHandler {
         Log.deepLink.info("\(safe, privacy: .public) [+\(queryLen) query chars]")
 
         switch host {
+        case "open":
+            NotificationCenter.default.post(name: .openMainWindow, object: nil)
+
         case "playPause":
             WallpaperManager.shared.togglePlayback()
 

--- a/src/Wallnetic/Services/LockScreenManager.swift
+++ b/src/Wallnetic/Services/LockScreenManager.swift
@@ -78,21 +78,14 @@ class LockScreenManager: ObservableObject {
         // Create fullscreen window above lock screen level
         guard let screen = NSScreen.main else { return }
 
-        let window = NSWindow(
+        // isReleasedWhenClosed=false baked into the factory. [#206]
+        let window = OverlayWindowFactory.makeBackgroundWindow(
             contentRect: screen.frame,
-            styleMask: .borderless,
-            backing: .buffered,
-            defer: false
+            deferCreation: false
         )
-
-        // ARC owns lockScreenWindow; close() must not also release it [#206]
-        window.isReleasedWhenClosed = false
         // Position above screen saver but below login window
         window.level = NSWindow.Level(rawValue: Int(CGWindowLevelForKey(.screenSaverWindow)) + 1)
         window.collectionBehavior = [.canJoinAllSpaces, .stationary]
-        window.isOpaque = true
-        window.backgroundColor = .black
-        window.hasShadow = false
         window.ignoresMouseEvents = false
 
         // Create video renderer (must retain — ARC releases it otherwise, stopping playback)

--- a/src/Wallnetic/Services/SupabaseClient.swift
+++ b/src/Wallnetic/Services/SupabaseClient.swift
@@ -5,7 +5,11 @@ import SwiftUI
 class SupabaseClient {
     static let shared = SupabaseClient()
 
-    // Configure these with your Supabase project values
+    // Configure these with your Supabase project values.
+    // NOTE: `supabaseAnonKey` must be the *public anon* key only — it is
+    // designed to be shipped client-side and is protected by Row Level
+    // Security. Never store the `service_role` key here (it bypasses RLS and
+    // would be readable from the App Group container).
     @AppStorage("supabaseURL") private var supabaseURL: String = ""
     @AppStorage("supabaseAnonKey") private var supabaseAnonKey: String = ""
 

--- a/src/Wallnetic/Services/WallpaperManager.swift
+++ b/src/Wallnetic/Services/WallpaperManager.swift
@@ -613,22 +613,6 @@ class WallpaperManager: ObservableObject {
         widgetSync.syncAll(current: currentWallpaper, isPlaying: isPlaying, wallpapers: wallpapers)
     }
 
-    /// Handles URL scheme from widget
-    func handleWidgetURL(_ url: URL) {
-        guard let (action, wallpaperID) = SharedDataManager.parseWidgetURL(url) else { return }
-
-        switch action {
-        case .playPause:
-            togglePlayback()
-        case .setWallpaper:
-            if let id = wallpaperID,
-               let wallpaper = wallpapers.first(where: { $0.id == id }) {
-                setWallpaper(wallpaper)
-            }
-        case .nextWallpaper:
-            cycleToNextWallpaper()
-        }
-    }
 }
 
 // MARK: - Notification Names

--- a/src/Wallnetic/Wallnetic.xcodeproj/project.pbxproj
+++ b/src/Wallnetic/Wallnetic.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		4D244E609DA6FBD637CD7D8F /* WallneticApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D9A31C3562655D7C27A30B1 /* WallneticApp.swift */; };
 		4DC3D57FC37765D6CEABF304 /* ColorCategoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56F59C3C7AB56348DA1D9D45 /* ColorCategoryTests.swift */; };
 		4E139BC5AAC4545984E4B4D3 /* SmartTaggingSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76DFDCB44158B7225C519C63 /* SmartTaggingSettingsView.swift */; };
+		4F8CAD36CA47120561781593 /* OverlayWindowFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66849A711C2A493F21CD7DDB /* OverlayWindowFactory.swift */; };
 		502AEDE09B50668E7154DC6E /* CreateFromPhotosView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC8F63EBF5F78663165C4697 /* CreateFromPhotosView.swift */; };
 		51355B920BE931D2A9A3BE58 /* WallpaperCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8562F59693CF276239AD0905 /* WallpaperCollection.swift */; };
 		53984128C8EBA3CD0BDEB573 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFD329195A86A0398FB6B4D0 /* AppDelegate.swift */; };
@@ -231,6 +232,7 @@
 		6581C17705CF0F9650F91F07 /* DynamicAccent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicAccent.swift; sourceTree = "<group>"; };
 		658D24C439FCC30FFDEBC73C /* DisplaySettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplaySettingsView.swift; sourceTree = "<group>"; };
 		65B960F4D2BFD36368F336A4 /* PexelsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PexelsService.swift; sourceTree = "<group>"; };
+		66849A711C2A493F21CD7DDB /* OverlayWindowFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverlayWindowFactory.swift; sourceTree = "<group>"; };
 		6730B13258B7FB98C75E2BD6 /* WallpaperTimelineProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperTimelineProvider.swift; sourceTree = "<group>"; };
 		689367BF56D29B65CDDB02F2 /* PixabayService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PixabayService.swift; sourceTree = "<group>"; };
 		69A21A2E89BAFCD9A8FE5DA8 /* CloudSyncManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudSyncManager.swift; sourceTree = "<group>"; };
@@ -339,6 +341,7 @@
 				8F02815851C30DCFA0A4ACA3 /* DynamicIslandController.swift */,
 				ED806BD7E0913BCDF1142604 /* MetalVideoRenderer.swift */,
 				22D4CC2AF93849AB8C429D52 /* NowPlayingOverlayController.swift */,
+				66849A711C2A493F21CD7DDB /* OverlayWindowFactory.swift */,
 				9E4C04ED28406292407FFBD0 /* PowerManager.swift */,
 				C36C5B8FAAEBFAB779FBBB39 /* VideoRenderer.swift */,
 			);
@@ -824,6 +827,7 @@
 				8690167783A5141E8CA3EC71 /* OllamaTaggingService.swift in Sources */,
 				61B8431DE4EA724F4E55C7B2 /* OllamaVisionTagger.swift in Sources */,
 				BED9A1AD659C124D26D37355 /* OnboardingView.swift in Sources */,
+				4F8CAD36CA47120561781593 /* OverlayWindowFactory.swift in Sources */,
 				D729B636A0E78713E53C77FD /* PerformanceManager.swift in Sources */,
 				39C032EFB614D68ADAE9403B /* PexelsService.swift in Sources */,
 				1F756590D00246AFD943B61A /* PhotosLibraryService.swift in Sources */,


### PR DESCRIPTION
Addresses the 5 findings from the deep security/perf/architecture review of the v1.3.1 wake-crash work (#211/#212).

## 1 — OverlayWindowFactory (HIGH: bug-class root cause)
The #206 over-release crash was a **duplicated omission**: 5 of 6 controllers forgot `isReleasedWhenClosed = false`. New `OverlayWindowFactory` (`makeOverlayPanel` / `makeBackgroundWindow`) bakes the safe defaults in one place. **All 6** window/panel controllers migrated — `0` raw `NSPanel(`/`NSWindow(` constructors remain in them, so a new overlay can't reintroduce the bug.

## 2 — Deep-link consolidation (MEDIUM)
`DeepLinkHandler` (rich: import/random/effects, with the gated HTTPS-only import) was previously **only reachable from tests**; production used a parallel `WallpaperManager.handleWidgetURL`. Now `AppDelegate.application(open:)` routes **every** `wallnetic://` URL through `DeepLinkHandler` (single validation/routing entry point). Added the `open` host case; removed `handleWidgetURL`.
- ⚠️ This **enables the `import` deep link** in production (per maintainer decision). It is guarded: HTTPS-only + explicit confirmation dialog showing the source URL.
- `SharedDataManager.parseWidgetURL` is now unused; kept as harmless shared infra (removing risks the widget target).

## 3 — Perf (LOW)
`DesktopOverlayView` `DateFormatter`s hoisted to `static let` (were re-allocated on every clock render).

## 4 — Secret hygiene (LOW)
`SupabaseClient` documents that `supabaseAnonKey` must be the **public anon key only** — never `service_role` (App Group container is readable).

*(Finding #3 from the review — intermittent file-read corruption — was a review-tooling glitch, not a code defect; all critical reads were cross-verified via `git show`.)*

## Testing
- `xcodebuild test` (Debug, signing off): **86/86 pass**, `** TEST SUCCEEDED **`.
- Project regenerated via `xcodegen`; `OverlayWindowFactory.swift` included; `DEVELOPMENT_TEAM` stays empty (pre-commit guard clean).

## Risk
Touches the window/overlay creation path of all 6 controllers. Behavior preserved (same level/collectionBehavior/opacity per controller); factory only centralizes construction + lifetime ownership. Full manual sleep/wake + multi-monitor pass recommended before the next archive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)