### PR TITLE
docs: README + CHANGELOG for v1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   dokunduğundan `runOnMain` ile main'e alındı (sleep/wake yolları zaten main →
   senkron, timing değişmedi). + 3 non-failable AV force-unwrap temizliği.
 
+### Refactor — Window Layer & Deep Links (PR #214)
+- **OverlayWindowFactory**: tüm programatik pencere/panel oluşturma tek bir
+  factory'ye taşındı (`makeOverlayPanel` / `makeBackgroundWindow`), `isReleasedWhenClosed
+  = false` merkezi olarak bake edildi. 6 controller migrate edildi (Desktop,
+  DynamicIsland, NowPlaying, DesktopOverlay, AudioVisualizer, LockScreen) → 0 ham
+  `NSPanel(`/`NSWindow(` constructor kaldı. #206 over-release bug-class'ı kökten önlenir.
+- **Deep-link konsolidasyonu**: `AppDelegate.application(open:)` artık tüm `wallnetic://`
+  URL'lerini tek giriş noktasından (`DeepLinkHandler`) geçiriyor (scheme doğrulama,
+  routing, HTTPS-only + onay diyaloglu `import`). Paralel `WallpaperManager.handleWidgetURL`
+  kaldırıldı; `open` host case eklendi.
+- **Perf**: `DesktopOverlayView` DateFormatter'ları `static let`'e taşındı (clock
+  render'ında yeniden tahsis yok).
+- **Secret hygiene**: `SupabaseClient` — `supabaseAnonKey` yalnızca public anon key
+  olmalı (asla `service_role`; App Group container okunabilir) notu eklendi.
+
+### Documentation (PR #213)
+- CHANGELOG `[1.3.1]` bölümü wake/unlock crash çalışmasını (#211/#212) kapsayacak
+  şekilde güncellendi.
+
 ### Removed
 - `com.apple.security.device.audio-input` entitlement
 - `NSMicrophoneUsageDescription`, `NSScreenCaptureUsageDescription` (Info.plist + project.yml)
@@ -90,6 +109,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ScreenCaptureKit availability (deployment target 13.0 zaten kapsıyor),
   ZIPReader.swift (hallüsinasyon, dosya yok).
 - 4 PR sequential: #207 → #208 → #209 → #210.
+- Post-review wake/unlock crash fix: #211 (power hardening) → #212 (#206 panel
+  over-release) → #213 (changelog) → #214 (OverlayWindowFactory + deep-link
+  consolidation, 5 review findings). 6 PR toplam, 86/86 test.
 - Post-review wake/unlock crash fix: #211 (power hardening) → #212 (#206 panel over-release).
 
 ## [1.3.0] — 2026-05-17

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![App Store](https://img.shields.io/badge/App%20Store-Download-blue.svg?style=flat&logo=app-store&logoColor=white)](https://apps.apple.com/tr/app/wallnetic/id6760347328?mt=12)
 [![CI](https://img.shields.io/github/actions/workflow/status/fatihkan/wallnetic/ci.yml?branch=main&label=CI)](https://github.com/fatihkan/wallnetic/actions)
 [![License](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/Version-1.2.0-blue.svg)](https://github.com/fatihkan/wallnetic/releases/latest)
+[![Version](https://img.shields.io/badge/Version-1.3.1-blue.svg)](https://github.com/fatihkan/wallnetic/releases/latest)
 
 <p align="center">
   <video src="https://github.com/user-attachments/assets/33a5664a-fc62-400f-9780-006884ff19df" width="800" autoplay loop muted playsinline>
@@ -260,10 +260,17 @@ open Wallnetic.xcodeproj
 - [x] Audio Visualizer customization &mdash; sensitivity slider, 3 styles (Bars/Waveform/Dots), 6 corner positions, S/M/L sizes (#159, #160, #161, #162)
 - [x] Photos slideshow generator &mdash; create wallpapers from your Apple Photos library with Ken Burns and crossfade transitions (#137)
 
+### v1.3.1 &mdash; Hardening (current)
+- [x] Unlock/wake crash fix (#206) &mdash; NSPanel/NSWindow over-release on close under ARC
+- [x] OverlayWindowFactory &mdash; centralized window creation, prevents the over-release bug class (#214)
+- [x] Deep-link consolidation &mdash; single `DeepLinkHandler` entry point, HTTPS-only gated import (#214)
+- [x] Security/privacy sweep &mdash; Spotify SSRF block, Content-Disposition fix, PII → Keychain (#207)
+- [x] Crash/hang & data-race fixes &mdash; AIService, Photos, DownloadManager, AudioVisualizer (#208, #210)
+- [x] Wake/power main-thread hardening (#211)
+
 ### v2.0 &mdash; Planned
 - [ ] AI video generation from text prompts
 - [ ] 3D perspective wallpaper carousel
-- [ ] Now Playing overlay on desktop (currently gated on code signing)
 - [ ] Wallpaper marketplace
 - [ ] Music reactive mode
 - [ ] iCloud library sync
@@ -275,9 +282,10 @@ open Wallnetic.xcodeproj
 Release notes live in [CHANGELOG.md](CHANGELOG.md), formatted to
 [Keep a Changelog](https://keepachangelog.com/) and [SemVer](https://semver.org/).
 
-Latest: **[1.3.0](CHANGELOG.md#130--2026-05-02)** — Photos slideshow generator,
-audio visualizer customization, battery prompt, ViewModel layer, sandbox
-enablement, centralized error surfacing.
+Latest: **[1.3.1](CHANGELOG.md#131--2026-05-30)** — hardening release: unlock/wake
+crash fix (#206), OverlayWindowFactory + deep-link consolidation, and a
+security/perf/correctness sweep on top of the 1.3.0 feature set (Photos slideshow,
+audio visualizer customization, battery prompt, sandbox).
 
 ---
 


### PR DESCRIPTION
Brings the two top-level docs in sync with the shipped state of v1.3.1.

## CHANGELOG.md — `[1.3.1]`
- New **Refactor — Window Layer & Deep Links (PR #214)** subsection: OverlayWindowFactory (6 controllers migrated, 0 raw `NSPanel(`/`NSWindow(`), deep-link consolidation (single `DeepLinkHandler`, HTTPS-only gated import), DateFormatter perf, SupabaseClient anon-key note.
- New **Documentation (PR #213)** subsection.
- Code Review Stats updated to **6 PRs** (#207 → #214).

## README.md
- Version badge **1.2.0 → 1.3.1**.
- New **v1.3.1 — Hardening** roadmap block (#206 unlock crash fix, OverlayWindowFactory #214, security/perf sweep #207–#211).
- Changelog pointer **1.3.0 → 1.3.1**.
- Removed *"Now Playing overlay on desktop (currently gated)"* from **v2.0 Planned** — verified it now ships in v1.3 and is user-reachable via Settings (`nowPlayingOverlay.enabled`), so it no longer belongs in Planned.

Docs-only; no code/build impact. Refs #206.

🤖 Generated with [Claude Code](https://claude.com/claude-code)