### PR TITLE
docs: README hero video + gallery, CHANGELOG store-submission entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+- Store media refresh: 8× branded 2560×1600 ASO screenshots + framed
+  1920×1080 demo video; `apps.json` (wvw.dev) updated (#216).
+- README: new hero video, branded screenshot gallery, honest-messaging
+  intro (user-owned videos + free-site search — no bundled library claim),
+  App Store build note for Lock Screen Video (#217).
+- App Store metadata (ASO revision): title "Wallnetic: Live Wallpaper 4K",
+  new subtitle/keywords, Turkish localization, revised description.
+
+### Release
+- **v1.3.1 (build 8) submitted to App Store Review — 2026-06-05.**
+
 ## [1.3.1] — 2026-05-30
 
 > Hardening release. /code-review xhigh-effort tarama 15 bulgu yakaladı; 4 PR

--- a/README.md
+++ b/README.md
@@ -18,9 +18,18 @@
 
 ## What is Wallnetic?
 
-Wallnetic brings **live video wallpapers** to your Mac desktop. Transform your workspace with dynamic, animated backgrounds that run efficiently in the background.
+Wallnetic brings **live video wallpapers** to your Mac desktop — turn any video you own into a living 4K desktop, or find free ones on community sites. Private by design: no accounts, no tracking.
 
 **Wallpaper Engine** has 40M+ users on Windows &mdash; now Mac users finally have a native alternative built with SwiftUI and Metal.
+
+<p align="center">
+  <img src="docs/assets/1.png" width="49%" alt="Your videos, alive on your desktop">
+  <img src="docs/assets/3.png" width="49%" alt="Every display, its own mood">
+</p>
+<p align="center">
+  <img src="docs/assets/4.png" width="49%" alt="Search free wallpaper sites">
+  <img src="docs/assets/6.png" width="49%" alt="Liquid Glass design">
+</p>
 
 <a href="https://buymeacoffee.com/fatihkan" target="_blank">
   <img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me A Coffee" height="50">
@@ -57,6 +66,8 @@ Wallnetic brings **live video wallpapers** to your Mac desktop. Transform your w
 - Video wallpaper on lock screen with clock overlay
 - Uses current wallpaper or a specific selection
 - Auto-detects screen lock/unlock
+- > **Note:** not available in the Mac App Store build — macOS sandboxing
+  > prevents drawing over the system lock screen (`loginwindow`).
 
 ### Multi-Monitor Support
 - Set different wallpapers for each display

--- a/README.md
+++ b/README.md
@@ -163,8 +163,8 @@ Wallnetic brings **live video wallpapers** to your Mac desktop — turn any vide
 
 | Platform | Download |
 |----------|----------|
-| macOS (Apple Silicon) | [Wallnetic_1.1.0_arm64.dmg](https://github.com/fatihkan/wallnetic/releases/latest) |
-| macOS (Intel) | [Wallnetic_1.1.0_x86_64.dmg](https://github.com/fatihkan/wallnetic/releases/latest) |
+| macOS (Apple Silicon) | [Wallnetic_1.3.1_arm64.dmg](https://github.com/fatihkan/wallnetic/releases/latest) |
+| macOS (Intel) | [Wallnetic_1.3.1_x86_64.dmg](https://github.com/fatihkan/wallnetic/releases/latest) |
 
 > **"Wallnetic is damaged and can't be opened"** &mdash; This happens because the DMG is not notarized by Apple. Run this command in Terminal after dragging Wallnetic to Applications:
 > ```bash

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![Version](https://img.shields.io/badge/Version-1.3.1-blue.svg)](https://github.com/fatihkan/wallnetic/releases/latest)
 
 <p align="center">
-  <video src="https://github.com/user-attachments/assets/33a5664a-fc62-400f-9780-006884ff19df" width="800" autoplay loop muted playsinline>
+  <video src="https://github.com/user-attachments/assets/61182f15-1208-4cc5-b37a-d7827e871022" width="800" autoplay loop muted playsinline>
   </video>
 </p>
 

--- a/apps.json
+++ b/apps.json
@@ -29,7 +29,7 @@
       "platform": "macOS",
       "price": "Free",
       "github": "https://github.com/fatihkan/wallnetic",
-      "homepage": "https://github.com/fatihkan/wallnetic",
+      "homepage": "https://apps.apple.com/tr/app/wallnetic/id6760347328?mt=12",
       "language": "Swift",
       "downloadUrl": "https://github.com/fatihkan/wallnetic/releases/latest",
       "requirements": "macOS 13.0 (Ventura) or later",
@@ -49,7 +49,11 @@
         "Dock icon hiding — menu bar-only mode",
         "Striking UI: glow cards, neon navigation, glass morphism",
         "Smart power management (pause on battery/fullscreen)",
-        "Notification Center widget with quick controls"
+        "Notification Center widget with quick controls",
+        "Photo slideshow generator — build live wallpapers from your Apple Photos library (Ken Burns + crossfade)",
+        "Liquid Glass 2026 design language with dynamic accent colors",
+        "Battery-aware playback with remember-my-choice prompt",
+        "Global hotkeys: next / previous / play-pause / random"
       ],
       "screenshots": [
         "https://raw.githubusercontent.com/fatihkan/wallnetic/main/docs/assets/1.png",
@@ -60,7 +64,8 @@
         "https://raw.githubusercontent.com/fatihkan/wallnetic/main/docs/assets/6.png",
         "https://raw.githubusercontent.com/fatihkan/wallnetic/main/docs/assets/7.png",
         "https://raw.githubusercontent.com/fatihkan/wallnetic/main/docs/assets/8.png"
-      ]
+      ],
+      "iconEmoji": "🌊"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- README hero video → new framed demo (user-attachments 61182f15)
- README: branded screenshot gallery, honest-messaging intro, Lock Screen
  Video App Store limitation note
- CHANGELOG [Unreleased]: #216 media refresh + ASO metadata revision +
  v1.3.1 submission record (2026-06-05)

Pairs with #216.

🤖 Generated with [Claude Code](https://claude.com/claude-code)