### PR TITLE
fix: Intel Release build — captured-var concurrency errors (release.yml)

### DIFF
--- a/src/Wallnetic/Services/WallpaperManager.swift
+++ b/src/Wallnetic/Services/WallpaperManager.swift
@@ -446,10 +446,17 @@ class WallpaperManager: ObservableObject {
                 var wp = wallpapers[i]
                 if wp.duration == nil {
                     await wp.loadMetadata()
+                    // Immutable copies — capturing the mutated `var wp` in the
+                    // @MainActor closure is a compile error under Release/WMO
+                    // (Xcode 15.2 Intel job: "reference to captured var 'wp'
+                    // in concurrently-executing code").
+                    let id = wp.id
+                    let duration = wp.duration
+                    let resolution = wp.resolution
                     await MainActor.run {
-                        if i < wallpapers.count && wallpapers[i].id == wp.id {
-                            wallpapers[i].duration = wp.duration
-                            wallpapers[i].resolution = wp.resolution
+                        if i < wallpapers.count && wallpapers[i].id == id {
+                            wallpapers[i].duration = duration
+                            wallpapers[i].resolution = resolution
                         }
                     }
                 }
@@ -478,8 +485,10 @@ class WallpaperManager: ObservableObject {
                     updatedColors[target.url.path] = hex
                 }
             }
+            // Immutable copy — same captured-var-in-concurrent-code fix as above.
+            let colors = updatedColors
             await MainActor.run {
-                metadata.savedColors = updatedColors
+                metadata.savedColors = colors
             }
         }
     }


### PR DESCRIPTION
## Summary
The v1.3.1 tag release build failed on the Intel (x86_64) job: Xcode 15.2
Release/WMO rejects capturing mutated local vars in `@MainActor` closures
(`WallpaperManager.swift:450-452,482`). Fixed by capturing immutable copies.
No behavior change.

## Verification
- Local `xcodebuild -configuration Release -arch x86_64` → **BUILD SUCCEEDED**

## Next step (after merge)
Re-tag `v1.3.1` at main and push to re-trigger `release.yml` — current tag
(4150ac0) predates the #211/#212 wake-crash fixes that shipped in build 8,
and no GitHub release exists for it (the original run failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)