### PR TITLE
fix: remaining Xcode 15.2 Release concurrency errors (release.yml arm64)

### DIFF
--- a/src/Wallnetic/Services/DynamicAccent.swift
+++ b/src/Wallnetic/Services/DynamicAccent.swift
@@ -30,7 +30,10 @@ final class DynamicAccent: ObservableObject {
             queue: .main
         ) { [weak self] note in
             guard let wp = note.object as? Wallpaper else { return }
-            Task { @MainActor in
+            // Explicit capture list — Xcode 15.2 (Swift 5.9) rejects the
+            // implicit capture of the outer weak `self` inside the Task
+            // ("reference to captured var 'self'").
+            Task { @MainActor [weak self] in
                 self?.applyFrom(wallpaper: wp)
             }
         }

--- a/src/Wallnetic/Views/Photos/CreateFromPhotosView.swift
+++ b/src/Wallnetic/Views/Photos/CreateFromPhotosView.swift
@@ -380,8 +380,13 @@ private struct PhotoThumbnail: View {
     }
 
     private func loadThumbnail() {
-        PhotosLibraryService.shared.requestThumbnail(for: asset, targetSize: CGSize(width: 220, height: 220)) { img in
-            image = img
+        // Hop onto the main actor explicitly — under Xcode 15.2 (Swift 5.9)
+        // this method is nonisolated, so a direct call to the @MainActor
+        // PhotosLibraryService is a Release-build compile error.
+        Task { @MainActor in
+            PhotosLibraryService.shared.requestThumbnail(for: asset, targetSize: CGSize(width: 220, height: 220)) { img in
+                image = img
+            }
         }
     }
 }


### PR DESCRIPTION
Round 2 of release.yml compile fixes (after #218 fixed the Intel job's errors,
the arm64 job surfaced two more — newer code from the #211-#214 era):

- `CreateFromPhotosView.swift:383` — main-actor service call from nonisolated sync context
- `DynamicAccent.swift:34` — captured var 'self' in concurrently-executing code

Verified: local Release build **BUILD SUCCEEDED**; repo-wide grep shows no other
instances of either pattern. After merge: re-tag v1.3.1 → re-run release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)