### PR TITLE
chore: gitignore daily-notes/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,6 @@ coverage/
 # Claude Code (local agent config, memory, logs)
 .claude/
 CLAUDE.md
+
+# Gunluk calisma notlari (kisisel, repo disi)
+daily-notes/


### PR DESCRIPTION
Adds `daily-notes/` to .gitignore — personal session notes, same treatment as `.claude/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)