### PR TITLE
chore: bump GitHub Actions to current majors (checkout v6, upload-artifact v7, download-artifact v8)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -83,7 +83,7 @@ jobs:
           echo "DMG_PATH=$DMG_NAME" >> $GITHUB_ENV
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.APP_NAME }}_${{ matrix.arch }}
           path: "*.dmg"
@@ -98,12 +98,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
 


### PR DESCRIPTION
## Ozet
GitHub Actions surumlerini guncel major'lara cekiyor. `actions/*@v4` artik eski; bu PR `ci.yml` ve `release.yml`'i guncelliyor.

| Action | Onceki | Yeni |
|--------|--------|------|
| `actions/checkout` | v4 | **v6** (3 kullanim) |
| `actions/upload-artifact` | v4 | **v7** |
| `actions/download-artifact` | v4 | **v8** |

3rd-party action'lar (`softprops/action-gh-release@v1`, `maxim-lobanov/setup-xcode@v1`) dokunulmadi.

## Dogrulama
- Saf surum bump — her action'in changelog'una karsi dogrulandi, bu kullanim icin `with:` degisikligi gerekmiyor.
- `upload-artifact@v7` + `download-artifact@v8` ayni v4+ immutable-artifact backend'ini paylasiyor (uyumlu).
- `download-artifact@v8` `artifacts/<name>/` yerlesimini koruyor → release adimindaki `artifacts/**/*.dmg` glob'u iki DMG'yi de hala eslestiriyor.

## Test notu
Workflow'lar yalnizca tag push (`v*`) ile tetikleniyor, PR'da CI kosmaz. Degisiklik bir sonraki gercek release'te (tag) dogrulanacak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)