### PR TITLE
feat: in-app App Store rating prompt (v1.4 Wave 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `NSWorkspace.setDesktopImageURL` per screen, re-applying on Space and
   display changes. The user's original wallpaper is backed up and restored
   when the toggle is turned off (Settings → Spaces & Lock Screen).
+- **In-app App Store rating prompt**: Wallnetic now asks happy users for a
+  review at a genuinely positive moment — right after a deliberate wallpaper
+  change — gated by app maturity (at least 3 launches and 5 successful
+  applies), never on the automatic launch restore, and at most once per app
+  version, on top of Apple's own annual cap. Uses the modern
+  `AppStore.requestReview(in:)` API. A manual "Rate Wallnetic" link was also
+  added to Settings → About.
 
 ### Removed
 - Non-functional "Show video wallpaper on lock screen" feature

--- a/src/Wallnetic/App/AppDelegate.swift
+++ b/src/Wallnetic/App/AppDelegate.swift
@@ -55,6 +55,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             BatteryPromptService.shared.checkOnLaunch()
         }
 
+        // App-maturity counter feeding the App Store rating prompt (v1.4 Wave 1).
+        RatingPromptManager.shared.recordLaunch()
+
         logger.info("Wallnetic started successfully")
     }
 

--- a/src/Wallnetic/Services/RatingPromptManager.swift
+++ b/src/Wallnetic/Services/RatingPromptManager.swift
@@ -1,0 +1,139 @@
+import Cocoa
+import StoreKit
+import os.log
+
+private let logger = Logger(subsystem: "com.wallnetic.app", category: "RatingPrompt")
+
+/// Decides when to surface the App Store rating prompt (Wave 1, v1.4).
+///
+/// Wallnetic shipped with zero App Store reviews while competitors carry
+/// tens of thousands, so the goal is simply to ask happy users at a good
+/// moment. The heuristic asks only after several positive sessions:
+///
+///   • never on first launch (needs ``minLaunches`` launches),
+///   • never on the automatic launch restore (needs the *second* deliberate
+///     apply of a session — the first apply is `restoreLastWallpaper()`),
+///   • after enough cumulative successful applies (``minApplies``),
+///   • at most once per app version.
+///
+/// `AppStore.requestReview(in:)` layers its own annual cap on top (max three
+/// prompts per 365 days, and it may choose not to show at all), so these
+/// gates only decide *when we are allowed to ask* — the system has the final
+/// say. The call is `@MainActor`-isolated and needs a presenting
+/// `NSViewController`; in this menu-bar/accessory app the prompt fires right
+/// after a deliberate in-app wallpaper change, so a window is normally
+/// available. If none is, we skip without consuming the per-version slot.
+final class RatingPromptManager {
+    static let shared = RatingPromptManager()
+
+    /// App Store listing for the explicit "Rate Wallnetic" action.
+    /// Source: App Store product page id6760347328.
+    static let appStoreID = "6760347328"
+    static let writeReviewURL = URL(
+        string: "https://apps.apple.com/app/id\(appStoreID)?action=write-review"
+    )!
+
+    // MARK: - UserDefaults keys
+
+    private let launchCountKey = "ratingPrompt.launchCount"
+    private let applyCountKey = "ratingPrompt.applyCount"
+    private let lastPromptedVersionKey = "ratingPrompt.lastPromptedVersion"
+
+    private let defaults = UserDefaults.standard
+
+    // MARK: - Thresholds
+
+    static let minLaunches = 3
+    static let minApplies = 5
+
+    // MARK: - Session state (reset on relaunch)
+
+    private var appliesThisSession = 0
+    private var hasPromptedThisSession = false
+
+    private init() {}
+
+    private var currentVersion: String {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?"
+    }
+
+    // MARK: - Event recording
+
+    /// Called once from AppDelegate on launch.
+    func recordLaunch() {
+        defaults.set(defaults.integer(forKey: launchCountKey) + 1, forKey: launchCountKey)
+    }
+
+    /// Called from `WallpaperManager` whenever a wallpaper is successfully
+    /// applied (the meaningful positive moment for a wallpaper app).
+    func recordWallpaperApplied() {
+        appliesThisSession += 1
+        defaults.set(defaults.integer(forKey: applyCountKey) + 1, forKey: applyCountKey)
+        requestReviewIfAppropriate()
+    }
+
+    // MARK: - Manual entry (Settings → About → "Rate Wallnetic")
+
+    /// Explicit, user-initiated rating. Opens the App Store write-review page
+    /// directly — the in-app review sheet is reserved for the automatic prompt
+    /// and is not guaranteed to appear, which is the wrong behaviour for a
+    /// button the user deliberately tapped.
+    func openWriteReviewPage() {
+        NSWorkspace.shared.open(Self.writeReviewURL)
+    }
+
+    // MARK: - Gating (pure, unit-testable)
+
+    /// Whether the maturity gates allow asking for a review right now. Kept
+    /// pure (no UserDefaults / NSApp) so the heuristic can be unit-tested.
+    ///
+    /// - `appliesThisSession >= 2` skips the automatic launch restore (the
+    ///   session's first apply) and waits for a deliberate change.
+    /// - `lastPromptedVersion != currentVersion` asks at most once per app
+    ///   version so updates can re-engage without nagging within a release.
+    static func shouldPrompt(
+        launchCount: Int,
+        cumulativeApplies: Int,
+        appliesThisSession: Int,
+        lastPromptedVersion: String?,
+        currentVersion: String
+    ) -> Bool {
+        guard appliesThisSession >= 2 else { return false }
+        guard launchCount >= minLaunches else { return false }
+        guard cumulativeApplies >= minApplies else { return false }
+        guard lastPromptedVersion != currentVersion else { return false }
+        return true
+    }
+
+    // MARK: - Private
+
+    private func requestReviewIfAppropriate() {
+        guard !hasPromptedThisSession else { return }
+        guard Self.shouldPrompt(
+            launchCount: defaults.integer(forKey: launchCountKey),
+            cumulativeApplies: defaults.integer(forKey: applyCountKey),
+            appliesThisSession: appliesThisSession,
+            lastPromptedVersion: defaults.string(forKey: lastPromptedVersionKey),
+            currentVersion: currentVersion
+        ) else { return }
+
+        Task { @MainActor [weak self] in
+            guard let self, !self.hasPromptedThisSession else { return }
+            guard let controller = self.presentationController else { return }
+            self.hasPromptedThisSession = true
+            self.defaults.set(self.currentVersion, forKey: self.lastPromptedVersionKey)
+            logger.info("Requesting App Store review (version \(self.currentVersion, privacy: .public))")
+            AppStore.requestReview(in: controller)
+        }
+    }
+
+    /// A view controller to present the rating sheet from. Prefers the focused
+    /// window, then the main window, then any visible window.
+    @MainActor
+    private var presentationController: NSViewController? {
+        let window = NSApp.keyWindow
+            ?? NSApp.mainWindow
+            ?? NSApp.windows.first(where: { $0.isVisible })
+        return window?.contentViewController
+    }
+}

--- a/src/Wallnetic/Services/WallpaperManager.swift
+++ b/src/Wallnetic/Services/WallpaperManager.swift
@@ -510,6 +510,8 @@ class WallpaperManager: ObservableObject {
         NotificationCenter.default.post(name: .wallpaperDidChange, object: wallpaper)
         NotificationCenter.default.post(name: .playbackStateDidChange, object: true)
 
+        RatingPromptManager.shared.recordWallpaperApplied()
+
         Task {
             await widgetSync.syncCurrentWallpaper(wallpaper)
             widgetSync.syncPlaybackState(isPlaying: true)
@@ -535,6 +537,7 @@ class WallpaperManager: ObservableObject {
             currentWallpaper = wallpaper
             lastWallpaperURL = wallpaper.url.path
             NotificationCenter.default.post(name: .wallpaperDidChange, object: wallpaper)
+            RatingPromptManager.shared.recordWallpaperApplied()
             Task {
                 await widgetSync.syncCurrentWallpaper(wallpaper)
                 widgetSync.syncPlaybackState(isPlaying: true)

--- a/src/Wallnetic/Tests/RatingPromptManagerTests.swift
+++ b/src/Wallnetic/Tests/RatingPromptManagerTests.swift
@@ -1,0 +1,75 @@
+import XCTest
+@testable import Wallnetic
+
+final class RatingPromptManagerTests: XCTestCase {
+
+    private let version = "1.4"
+
+    // MARK: - Skip the automatic launch restore
+
+    func testDoesNotPromptOnFirstApplyOfSession() {
+        // appliesThisSession == 1 is the launch restore, never a prompt moment,
+        // even when every cumulative threshold is already satisfied.
+        XCTAssertFalse(RatingPromptManager.shouldPrompt(
+            launchCount: 99,
+            cumulativeApplies: 99,
+            appliesThisSession: 1,
+            lastPromptedVersion: nil,
+            currentVersion: version
+        ))
+    }
+
+    // MARK: - Maturity thresholds
+
+    func testDoesNotPromptBeforeMinLaunches() {
+        XCTAssertFalse(RatingPromptManager.shouldPrompt(
+            launchCount: RatingPromptManager.minLaunches - 1,
+            cumulativeApplies: RatingPromptManager.minApplies,
+            appliesThisSession: 2,
+            lastPromptedVersion: nil,
+            currentVersion: version
+        ))
+    }
+
+    func testDoesNotPromptBeforeMinApplies() {
+        XCTAssertFalse(RatingPromptManager.shouldPrompt(
+            launchCount: RatingPromptManager.minLaunches,
+            cumulativeApplies: RatingPromptManager.minApplies - 1,
+            appliesThisSession: 2,
+            lastPromptedVersion: nil,
+            currentVersion: version
+        ))
+    }
+
+    func testPromptsWhenAllGatesAreMet() {
+        XCTAssertTrue(RatingPromptManager.shouldPrompt(
+            launchCount: RatingPromptManager.minLaunches,
+            cumulativeApplies: RatingPromptManager.minApplies,
+            appliesThisSession: 2,
+            lastPromptedVersion: nil,
+            currentVersion: version
+        ))
+    }
+
+    // MARK: - Once per app version
+
+    func testDoesNotPromptTwiceForSameVersion() {
+        XCTAssertFalse(RatingPromptManager.shouldPrompt(
+            launchCount: RatingPromptManager.minLaunches,
+            cumulativeApplies: RatingPromptManager.minApplies,
+            appliesThisSession: 2,
+            lastPromptedVersion: version,
+            currentVersion: version
+        ))
+    }
+
+    func testPromptsAgainAfterVersionBump() {
+        XCTAssertTrue(RatingPromptManager.shouldPrompt(
+            launchCount: RatingPromptManager.minLaunches,
+            cumulativeApplies: RatingPromptManager.minApplies,
+            appliesThisSession: 2,
+            lastPromptedVersion: "1.3.1",
+            currentVersion: version
+        ))
+    }
+}

--- a/src/Wallnetic/Views/Settings/SettingsSubViews.swift
+++ b/src/Wallnetic/Views/Settings/SettingsSubViews.swift
@@ -222,6 +222,7 @@ struct AboutSettingsView: View {
                 Link("Website", destination: URL(string: "https://wallnetic.app")!)
                 Link("GitHub", destination: URL(string: "https://github.com/fatihkan/wallnetic")!)
                 Link("Support", destination: URL(string: "mailto:support@wallnetic.app")!)
+                Link("Rate Wallnetic", destination: RatingPromptManager.writeReviewURL)
             }
             .font(.caption)
             Spacer()

--- a/src/Wallnetic/Wallnetic.xcodeproj/project.pbxproj
+++ b/src/Wallnetic/Wallnetic.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		1ACE67A285A3AC235ECF7904 /* MLWDecryptorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35A70D71A1BFA621DE839CA5 /* MLWDecryptorTests.swift */; };
 		1AEF59FC27860B386A6D7049 /* ErrorReporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BB04CF2E27DC75B29EE8A67 /* ErrorReporterTests.swift */; };
 		1B480E4A92B2E3538B724AE4 /* WallpaperEffectsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B86B489A26E64EF63ED72A8 /* WallpaperEffectsManager.swift */; };
+		1BA56744587A55C81A484104 /* RatingPromptManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72D0BD40EC15021C36E115F3 /* RatingPromptManagerTests.swift */; };
 		1CA1504E421EAE5C547DF122 /* KeychainManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51A337D506233D372B7187D6 /* KeychainManager.swift */; };
 		1F756590D00246AFD943B61A /* PhotosLibraryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4D12B25631A66EDCB10593 /* PhotosLibraryService.swift */; };
 		2082CED0A15F59CAEEDB57F8 /* DownloadManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 543E1B92A4536DE1415BD91E /* DownloadManager.swift */; };
@@ -84,6 +85,7 @@
 		93CA4E731227254F983F6270 /* TimeOfDaySettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E4002911F0B7869F3183DA /* TimeOfDaySettingsView.swift */; };
 		9721B6140E12A2FA558584B8 /* NowPlayingOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79BC197A9E8C082F2C39C673 /* NowPlayingOverlayView.swift */; };
 		975BFD8CBA6DB402B4EFB2A5 /* WallpaperMetadataCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C5D6AF9B7CC270A5CB93E0 /* WallpaperMetadataCache.swift */; };
+		9C31750F91516DE9EBBAF3D0 /* RatingPromptManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 462505FEFED6122E27620E34 /* RatingPromptManager.swift */; };
 		9C7206924D126AE38A11DD51 /* WallpaperStoreManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40A93EE0CF1D353315FEA25D /* WallpaperStoreManager.swift */; };
 		9D898F865EED9BB751EBF7EF /* AIGenerateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91B502C8C68ABF2CD503030E /* AIGenerateView.swift */; };
 		A0A7D57E670326EECB26D581 /* NotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 140AE9B28FFA1BF12B3651C5 /* NotificationManager.swift */; };
@@ -208,6 +210,7 @@
 		3FD3DFBD42A5D9B294784C5F /* OllamaVisionTagger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OllamaVisionTagger.swift; sourceTree = "<group>"; };
 		40A93EE0CF1D353315FEA25D /* WallpaperStoreManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperStoreManager.swift; sourceTree = "<group>"; };
 		43A9F2E051E3DDAA18ACAC9D /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
+		462505FEFED6122E27620E34 /* RatingPromptManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RatingPromptManager.swift; sourceTree = "<group>"; };
 		4662279ADB65DBA3957578B7 /* VideoFormatConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoFormatConverter.swift; sourceTree = "<group>"; };
 		48513382BB8B61A6DD8431DC /* UpdateChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateChecker.swift; sourceTree = "<group>"; };
 		4BD359DF3443AB6E3242CA90 /* LiquidGlass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiquidGlass.swift; sourceTree = "<group>"; };
@@ -241,6 +244,7 @@
 		69A21A2E89BAFCD9A8FE5DA8 /* CloudSyncManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudSyncManager.swift; sourceTree = "<group>"; };
 		69A7F21804AB5D266A239578 /* WallneticWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallneticWidget.swift; sourceTree = "<group>"; };
 		6D0396F7C77849244B424DD5 /* ScreenSaverBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenSaverBridge.swift; sourceTree = "<group>"; };
+		72D0BD40EC15021C36E115F3 /* RatingPromptManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RatingPromptManagerTests.swift; sourceTree = "<group>"; };
 		739D8C6AD1566F8C21F48DFD /* WeatherWallpaperManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherWallpaperManager.swift; sourceTree = "<group>"; };
 		73A3E9458476683E0230677D /* ErrorReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorReporter.swift; sourceTree = "<group>"; };
 		76DFDCB44158B7225C519C63 /* SmartTaggingSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartTaggingSettingsView.swift; sourceTree = "<group>"; };
@@ -398,6 +402,7 @@
 				65B960F4D2BFD36368F336A4 /* PexelsService.swift */,
 				BA4D12B25631A66EDCB10593 /* PhotosLibraryService.swift */,
 				689367BF56D29B65CDDB02F2 /* PixabayService.swift */,
+				462505FEFED6122E27620E34 /* RatingPromptManager.swift */,
 				2A3CC73608BAFA155E615F1B /* SchedulerService.swift */,
 				6D0396F7C77849244B424DD5 /* ScreenSaverBridge.swift */,
 				52CE6EB39E15687BF3655B8C /* SharedDataManager.swift */,
@@ -590,6 +595,7 @@
 				DA18283F2FD8E99F3FFDC805 /* FuzzySearchTests.swift */,
 				35A70D71A1BFA621DE839CA5 /* MLWDecryptorTests.swift */,
 				2D709F3F20160782C077CAF5 /* OllamaVisionTaggerTests.swift */,
+				72D0BD40EC15021C36E115F3 /* RatingPromptManagerTests.swift */,
 				4C428B5A76D12B2D39EB866E /* SlideshowGeneratorTests.swift */,
 				58476278C192D425D261FE53 /* SystemWallpaperSyncTests.swift */,
 				A0AADE7F3045087811919B3C /* URLImporterTests.swift */,
@@ -764,6 +770,7 @@
 				82F024AE9E99C4A77098AD9B /* FuzzySearchTests.swift in Sources */,
 				1ACE67A285A3AC235ECF7904 /* MLWDecryptorTests.swift in Sources */,
 				92D9C1672FDC4498193B9949 /* OllamaVisionTaggerTests.swift in Sources */,
+				1BA56744587A55C81A484104 /* RatingPromptManagerTests.swift in Sources */,
 				D812BECBE0458A174EF2696E /* SlideshowGeneratorTests.swift in Sources */,
 				484B9F66D9BCBFF3C86EC727 /* SystemWallpaperSyncTests.swift in Sources */,
 				B03176CE3858D5C7915FA8BB /* URLImporterTests.swift in Sources */,
@@ -841,6 +848,7 @@
 				3D0DEC82756E9F587DEEA843 /* PixabayService.swift in Sources */,
 				E1A41C3F6B921B68A90EBBFA /* PopularView.swift in Sources */,
 				B528C1F69B3CD9B3914A58A6 /* PowerManager.swift in Sources */,
+				9C31750F91516DE9EBBAF3D0 /* RatingPromptManager.swift in Sources */,
 				B42A0A282FC2AA2D1C21B83F /* SchedulerService.swift in Sources */,
 				71CE2A10CE71B016228E091D /* SchedulerSettingsView.swift in Sources */,
 				DEA965482FC1C3045A26958B /* ScreenSaverBridge.swift in Sources */,


### PR DESCRIPTION
## What

Wallnetic shipped with **zero App Store reviews** while competitors carry tens of thousands. This adds an in-app rating prompt that asks happy users for a review at a genuinely positive moment, without ever nagging.

This is **Wave 1, item 3b** of the v1.4 roadmap (decision: *collect reviews first, then monetize*).

## How

- **`Services/RatingPromptManager.swift`** — decides when to ask via `AppStore.requestReview(in:)`.
- **Gate** (pure, unit-tested `shouldPrompt(...)`):
  - ≥ 3 launches **and** ≥ 5 cumulative successful applies
  - the **2nd+ deliberate apply** of a session — skips the automatic launch restore (which routes through `setWallpaper`, so it would otherwise count)
  - at most **once per app version**
  - Apple's own 3-prompts / 365-days cap sits on top
- **Modern API**: `AppStore.requestReview(in: NSViewController)` — `SKStoreReviewController.requestReview()` is deprecated as of the macOS 15 SDK. Verified `@available(macOS 13.0)` against the SDK interface, matching the deployment target.
- **Accessory-safe**: resolves a presenting `NSViewController` on the main actor (`Task { @MainActor }`, mirroring `SystemWallpaperSync`) — avoids the `@MainActor`-in-Release errors this project hit before. Works whether or not a window is open.

## Hooks

- `WallpaperManager.setWallpaper` (both the uniform and per-screen apply paths) → `recordWallpaperApplied()`
- `AppDelegate.applicationDidFinishLaunching` → `recordLaunch()`
- Settings → About → **"Rate Wallnetic"** link (opens the write-review page directly — the in-app sheet isn't guaranteed to show, wrong for a deliberate tap)

## Tests

- 6 new `RatingPromptManagerTests` covering the restore-skip, both maturity thresholds, and once-per-version (incl. re-prompt after a version bump).
- **Full suite: 107/107 green.** Clean `xcodebuild` Debug build, no warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)