### PR TITLE
feat: playback reliability watchdog (v1.4 Wave 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `NSWorkspace.setDesktopImageURL` per screen, re-applying on Space and
   display changes. The user's original wallpaper is backed up and restored
   when the toggle is turned off (Settings → Spaces & Lock Screen).
+- **Playback reliability watchdog**: addresses the category's #1 complaint
+  ("the wallpaper freezes and I have to reopen the app"). While playback is
+  intended and not deliberately paused, `DesktopWindowController` samples each
+  display's playback clock and, if it stops advancing, nudges the renderer
+  back to life (`playImmediately`). Release builds previously had no stall
+  detection at all — a wedged `AVPlayer` just looked frozen. Respects
+  `PowerManager` (never resumes a battery/fullscreen/sleep pause).
 
 ### Removed
 - Non-functional "Show video wallpaper on lock screen" feature

--- a/src/Wallnetic/Engine/DesktopWindowController.swift
+++ b/src/Wallnetic/Engine/DesktopWindowController.swift
@@ -8,6 +8,11 @@ protocol WallpaperRenderer {
     func play()
     func pause()
     func stop()
+    /// Current playback position in seconds, or `nil` when no player is loaded.
+    /// The watchdog samples this to detect a frozen player (time not advancing).
+    var currentPlaybackTime: TimeInterval? { get }
+    /// Force playback to resume immediately after a detected stall.
+    func recoverPlayback()
 }
 
 // Conform VideoRenderer to the protocol
@@ -213,6 +218,7 @@ class DesktopWindowController {
         for renderer in renderers.values {
             renderer.play()
         }
+        startWatchdog()
     }
 
     /// Pauses playback on all screens
@@ -223,6 +229,7 @@ class DesktopWindowController {
         for renderer in renderers.values {
             renderer.pause()
         }
+        stopWatchdog()
     }
 
     /// Pauses playback (used by power management)
@@ -250,6 +257,73 @@ class DesktopWindowController {
         return isPlaying
     }
 
+    // MARK: - Playback Watchdog (v1.4 Wave 1)
+
+    /// Samples each renderer's playback clock while playback is intended and,
+    /// when the clock stops advancing, nudges the renderer back to life — the
+    /// honest fix for the category's #1 complaint ("freezes, I have to reopen
+    /// it"). Lives here because this controller owns the renderers and the
+    /// recovery path; the stall decision is the pure ``PlaybackWatchdog``.
+    private var watchdogTimer: Timer?
+    private var lastPlaybackTimes: [CGDirectDisplayID: TimeInterval] = [:]
+    private var frozenSampleCounts: [CGDirectDisplayID: Int] = [:]
+
+    private func startWatchdog() {
+        guard watchdogTimer == nil else { return }
+        lastPlaybackTimes.removeAll()
+        frozenSampleCounts.removeAll()
+        let timer = Timer(timeInterval: PlaybackWatchdog.interval, repeats: true) { [weak self] _ in
+            self?.checkPlaybackHealth()
+        }
+        // .common keeps it firing while a tracking run-loop is active (menu
+        // open, live resize) rather than silently suspending.
+        RunLoop.main.add(timer, forMode: .common)
+        watchdogTimer = timer
+    }
+
+    private func stopWatchdog() {
+        watchdogTimer?.invalidate()
+        watchdogTimer = nil
+        lastPlaybackTimes.removeAll()
+        frozenSampleCounts.removeAll()
+    }
+
+    private func checkPlaybackHealth() {
+        // Don't fight an intentional pause (battery, fullscreen, sleep, screen
+        // saver). When PowerManager pauses us it calls pause(), which already
+        // stops the timer; this is belt-and-braces for an in-flight tick.
+        let shouldBePaused = PowerManager.shared.shouldBePaused
+
+        for (id, renderer) in renderers {
+            let current = renderer.currentPlaybackTime
+            let previous = lastPlaybackTimes[id]
+            lastPlaybackTimes[id] = current
+
+            let frozen = PlaybackWatchdog.isFrozen(
+                previous: previous,
+                current: current,
+                intendedToPlay: isPlaying,
+                shouldBePaused: shouldBePaused
+            )
+
+            guard frozen else {
+                frozenSampleCounts[id] = 0
+                continue
+            }
+
+            let count = (frozenSampleCounts[id] ?? 0) + 1
+            frozenSampleCounts[id] = count
+            if count >= PlaybackWatchdog.frozenSamplesBeforeRecovery {
+                Log.video.error("Playback stalled on display \(id, privacy: .public) — auto-recovering")
+                renderer.recoverPlayback()
+                // Reset the baseline so the post-recovery position isn't
+                // mistaken for a fresh stall on the next sample.
+                frozenSampleCounts[id] = 0
+                lastPlaybackTimes[id] = renderer.currentPlaybackTime
+            }
+        }
+    }
+
     // MARK: - Display Changes
 
     /// Handles display configuration changes (connect/disconnect monitors)
@@ -265,6 +339,8 @@ class DesktopWindowController {
             renderers.removeValue(forKey: id)
             effectOverlays.removeValue(forKey: id)
             screenWallpaperURLs.removeValue(forKey: id)
+            lastPlaybackTimes.removeValue(forKey: id)
+            frozenSampleCounts.removeValue(forKey: id)
         }
 
         // Add windows for newly connected displays
@@ -361,6 +437,8 @@ class DesktopWindowController {
     // MARK: - Cleanup
 
     func cleanup() {
+        stopWatchdog()
+
         for renderer in renderers.values {
             renderer.stop()
         }

--- a/src/Wallnetic/Engine/MetalVideoRenderer.swift
+++ b/src/Wallnetic/Engine/MetalVideoRenderer.swift
@@ -245,6 +245,23 @@ final class MetalVideoRenderer: NSObject {
         cleanup()
     }
 
+    // MARK: - Watchdog
+
+    /// Playback clock in seconds for the watchdog. `nil` when no player is
+    /// loaded or the time is not yet numeric (item not ready).
+    var currentPlaybackTime: TimeInterval? {
+        guard let time = player?.currentItem?.currentTime(), time.isNumeric else { return nil }
+        return time.seconds
+    }
+
+    /// Force playback to resume immediately after a detected stall, also
+    /// un-pausing the Metal view in case its draw loop was the thing wedged.
+    func recoverPlayback() {
+        isPlaying = true
+        metalView.isPaused = false
+        player?.playImmediately(atRate: 1.0)
+    }
+
     // MARK: - Cleanup
 
     private func cleanup() {

--- a/src/Wallnetic/Engine/PlaybackWatchdog.swift
+++ b/src/Wallnetic/Engine/PlaybackWatchdog.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// Pure stall-detection logic for the desktop playback watchdog (v1.4 Wave 1).
+///
+/// The category's #1 complaint is "the wallpaper freezes and I have to reopen
+/// the app." In Release there is no stall detection at all, and the renderers
+/// keep presenting the last decoded frame, so a wedged `AVPlayer` simply looks
+/// frozen. `DesktopWindowController` samples each renderer's playback clock on
+/// a timer and, when the clock stops advancing while playback is *intended*
+/// (and not deliberately paused by `PowerManager`), nudges it back to life.
+///
+/// The decision is kept here — pure, no AVFoundation or AppKit — so it can be
+/// unit-tested in isolation from the timer and the renderers.
+enum PlaybackWatchdog {
+
+    /// How often the controller samples playback progress.
+    static let interval: TimeInterval = 5
+
+    /// Consecutive frozen samples before we treat it as a real stall and
+    /// recover. Two samples (~`interval` × 2 seconds) avoids acting on a
+    /// single unlucky read while still self-healing well within the window a
+    /// frustrated user would otherwise reach for the app.
+    static let frozenSamplesBeforeRecovery = 2
+
+    /// Whether a renderer looks frozen *this sample*: it is meant to be
+    /// playing, the system isn't deliberately paused, and the playback clock
+    /// has not advanced since the previous sample.
+    ///
+    /// A `nil` time — no player loaded (e.g. a still image) or an item that is
+    /// not ready yet — is never considered frozen.
+    static func isFrozen(
+        previous: TimeInterval?,
+        current: TimeInterval?,
+        intendedToPlay: Bool,
+        shouldBePaused: Bool
+    ) -> Bool {
+        guard intendedToPlay, !shouldBePaused else { return false }
+        guard let previous, let current else { return false }
+        return current == previous
+    }
+}

--- a/src/Wallnetic/Engine/VideoRenderer.swift
+++ b/src/Wallnetic/Engine/VideoRenderer.swift
@@ -198,6 +198,18 @@ class VideoRenderer: NSObject {
         return player?.currentTime()
     }
 
+    /// Playback clock in seconds for the watchdog. `nil` when no player is
+    /// loaded or the time is not yet numeric (item not ready).
+    var currentPlaybackTime: TimeInterval? {
+        guard let time = player?.currentTime(), time.isNumeric else { return nil }
+        return time.seconds
+    }
+
+    /// Force the player to resume immediately after a detected stall.
+    func recoverPlayback() {
+        player?.playImmediately(atRate: 1.0)
+    }
+
     var duration: CMTime? {
         return player?.currentItem?.duration
     }

--- a/src/Wallnetic/Tests/PlaybackWatchdogTests.swift
+++ b/src/Wallnetic/Tests/PlaybackWatchdogTests.swift
@@ -1,0 +1,69 @@
+import XCTest
+@testable import Wallnetic
+
+final class PlaybackWatchdogTests: XCTestCase {
+
+    // MARK: - Real stall
+
+    func testFrozenWhenClockDoesNotAdvanceWhilePlaying() {
+        XCTAssertTrue(PlaybackWatchdog.isFrozen(
+            previous: 12.5,
+            current: 12.5,
+            intendedToPlay: true,
+            shouldBePaused: false
+        ))
+    }
+
+    func testNotFrozenWhenClockAdvances() {
+        XCTAssertFalse(PlaybackWatchdog.isFrozen(
+            previous: 12.5,
+            current: 13.6,
+            intendedToPlay: true,
+            shouldBePaused: false
+        ))
+    }
+
+    // MARK: - Never fight an intentional pause
+
+    func testNotFrozenWhenNotIntendedToPlay() {
+        // Same clock, but the controller isn't trying to play — not a stall.
+        XCTAssertFalse(PlaybackWatchdog.isFrozen(
+            previous: 12.5,
+            current: 12.5,
+            intendedToPlay: false,
+            shouldBePaused: false
+        ))
+    }
+
+    func testNotFrozenWhenSystemShouldBePaused() {
+        // PowerManager deliberately paused (battery / fullscreen / sleep);
+        // a non-advancing clock is expected, not a stall.
+        XCTAssertFalse(PlaybackWatchdog.isFrozen(
+            previous: 12.5,
+            current: 12.5,
+            intendedToPlay: true,
+            shouldBePaused: true
+        ))
+    }
+
+    // MARK: - Unknown clock is never a stall
+
+    func testNotFrozenWhenNoPreviousSample() {
+        XCTAssertFalse(PlaybackWatchdog.isFrozen(
+            previous: nil,
+            current: 12.5,
+            intendedToPlay: true,
+            shouldBePaused: false
+        ))
+    }
+
+    func testNotFrozenWhenNoCurrentSample() {
+        // No player loaded (e.g. a still image) — never a stall.
+        XCTAssertFalse(PlaybackWatchdog.isFrozen(
+            previous: 12.5,
+            current: nil,
+            intendedToPlay: true,
+            shouldBePaused: false
+        ))
+    }
+}

--- a/src/Wallnetic/Wallnetic.xcodeproj/project.pbxproj
+++ b/src/Wallnetic/Wallnetic.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		2B0D5970F968D01CC1E3B8B8 /* GrainOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10E68AD45A1FAF11457CDB94 /* GrainOverlay.swift */; };
 		2C5619331688457B6A844B93 /* CollectionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31C51D17BDBBADCDF4D5CB43 /* CollectionsView.swift */; };
 		2D30EDC8BD2E940365F05AB0 /* WallneticWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69A7F21804AB5D266A239578 /* WallneticWidget.swift */; };
+		348AFDCB0D785973A998B8D6 /* PlaybackWatchdog.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9FC7269E149DE512043F002 /* PlaybackWatchdog.swift */; };
 		38BD342CB024693C99DB8B35 /* AudioVisualizerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 082027791B67C0B2DBD43F97 /* AudioVisualizerManager.swift */; };
 		39C032EFB614D68ADAE9403B /* PexelsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65B960F4D2BFD36368F336A4 /* PexelsService.swift */; };
 		3ACABD266118F70AA54B934B /* ThemeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60D80208B9C31066D6C112FB /* ThemeManager.swift */; };
@@ -56,6 +57,7 @@
 		61773D343F4EBEEB12FF8AFB /* BatteryPromptService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0187521E8CC2C0BB29CE90D /* BatteryPromptService.swift */; };
 		61B1EC0DBC85801311FA1F2F /* MenuBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B106464A071BF6E736C3272 /* MenuBarView.swift */; };
 		61B8431DE4EA724F4E55C7B2 /* OllamaVisionTagger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FD3DFBD42A5D9B294784C5F /* OllamaVisionTagger.swift */; };
+		6409F37EB1ED02FDDA458327 /* PlaybackWatchdogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BED74D009FBE1A0068DC2C62 /* PlaybackWatchdogTests.swift */; };
 		64369FBB9497637963EC2B4C /* DynamicAccent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6581C17705CF0F9650F91F07 /* DynamicAccent.swift */; };
 		6A650CD75C4B32AB9889A6A7 /* SharedWidgetModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDFCAB2A636011BB543DD1B5 /* SharedWidgetModels.swift */; };
 		6ACA2AC7AD0702CFEFA50E1B /* DesignTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFF460340111975F4DA40C32 /* DesignTokens.swift */; };
@@ -280,6 +282,7 @@
 		BA4D12B25631A66EDCB10593 /* PhotosLibraryService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotosLibraryService.swift; sourceTree = "<group>"; };
 		BB036BA69CC6D00731C1D273 /* DiscoverView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverView.swift; sourceTree = "<group>"; };
 		BC8F63EBF5F78663165C4697 /* CreateFromPhotosView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateFromPhotosView.swift; sourceTree = "<group>"; };
+		BED74D009FBE1A0068DC2C62 /* PlaybackWatchdogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaybackWatchdogTests.swift; sourceTree = "<group>"; };
 		BF36E216B5F900C62E824B59 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		C296AD08F207FEC3AF4CDCB9 /* AnalyticsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsManager.swift; sourceTree = "<group>"; };
 		C36C5B8FAAEBFAB779FBBB39 /* VideoRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoRenderer.swift; sourceTree = "<group>"; };
@@ -307,6 +310,7 @@
 		F6E13A8C8EF384BF16EDF962 /* FocusHalo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusHalo.swift; sourceTree = "<group>"; };
 		F9534BF578FB9EFE92050C52 /* TimeOfDayManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeOfDayManager.swift; sourceTree = "<group>"; };
 		F9960B917192178D2217E668 /* iCloudSyncManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iCloudSyncManager.swift; sourceTree = "<group>"; };
+		F9FC7269E149DE512043F002 /* PlaybackWatchdog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaybackWatchdog.swift; sourceTree = "<group>"; };
 		FA624026F461BCF47C3E39D5 /* UsageTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageTracker.swift; sourceTree = "<group>"; };
 		FA8E25061D17472552507DF7 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
 		FE3320FF526E744247F3B5BE /* SpaceWallpaperManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceWallpaperManager.swift; sourceTree = "<group>"; };
@@ -347,6 +351,7 @@
 				ED806BD7E0913BCDF1142604 /* MetalVideoRenderer.swift */,
 				22D4CC2AF93849AB8C429D52 /* NowPlayingOverlayController.swift */,
 				66849A711C2A493F21CD7DDB /* OverlayWindowFactory.swift */,
+				F9FC7269E149DE512043F002 /* PlaybackWatchdog.swift */,
 				9E4C04ED28406292407FFBD0 /* PowerManager.swift */,
 				C36C5B8FAAEBFAB779FBBB39 /* VideoRenderer.swift */,
 			);
@@ -590,6 +595,7 @@
 				DA18283F2FD8E99F3FFDC805 /* FuzzySearchTests.swift */,
 				35A70D71A1BFA621DE839CA5 /* MLWDecryptorTests.swift */,
 				2D709F3F20160782C077CAF5 /* OllamaVisionTaggerTests.swift */,
+				BED74D009FBE1A0068DC2C62 /* PlaybackWatchdogTests.swift */,
 				4C428B5A76D12B2D39EB866E /* SlideshowGeneratorTests.swift */,
 				58476278C192D425D261FE53 /* SystemWallpaperSyncTests.swift */,
 				A0AADE7F3045087811919B3C /* URLImporterTests.swift */,
@@ -764,6 +770,7 @@
 				82F024AE9E99C4A77098AD9B /* FuzzySearchTests.swift in Sources */,
 				1ACE67A285A3AC235ECF7904 /* MLWDecryptorTests.swift in Sources */,
 				92D9C1672FDC4498193B9949 /* OllamaVisionTaggerTests.swift in Sources */,
+				6409F37EB1ED02FDDA458327 /* PlaybackWatchdogTests.swift in Sources */,
 				D812BECBE0458A174EF2696E /* SlideshowGeneratorTests.swift in Sources */,
 				484B9F66D9BCBFF3C86EC727 /* SystemWallpaperSyncTests.swift in Sources */,
 				B03176CE3858D5C7915FA8BB /* URLImporterTests.swift in Sources */,
@@ -839,6 +846,7 @@
 				39C032EFB614D68ADAE9403B /* PexelsService.swift in Sources */,
 				1F756590D00246AFD943B61A /* PhotosLibraryService.swift in Sources */,
 				3D0DEC82756E9F587DEEA843 /* PixabayService.swift in Sources */,
+				348AFDCB0D785973A998B8D6 /* PlaybackWatchdog.swift in Sources */,
 				E1A41C3F6B921B68A90EBBFA /* PopularView.swift in Sources */,
 				B528C1F69B3CD9B3914A58A6 /* PowerManager.swift in Sources */,
 				B42A0A282FC2AA2D1C21B83F /* SchedulerService.swift in Sources */,


### PR DESCRIPTION
## What

Addresses the category's **#1 review-killer**: *"the wallpaper freezes and I have to reopen the app."*

In Release builds there was **zero stall detection** — `VideoRenderer`'s status observer is `#if DEBUG` only and `MetalVideoRenderer` has none. The renderers keep presenting the last decoded frame, so a wedged `AVPlayer` (typically after sleep/wake or a buffer stall) just looks frozen to the user.

This is **Wave 1, item 3c** of the v1.4 roadmap.

## How

- **`Engine/PlaybackWatchdog.swift`** — pure, unit-tested `isFrozen(previous:current:intendedToPlay:shouldBePaused:)` decision (no AVFoundation/AppKit).
- **`DesktopWindowController`** drives it: while playback is intended, a 5s timer samples each display's playback clock. Two consecutive non-advancing samples → stall → `recoverPlayback()`.
- **`WallpaperRenderer` protocol** gains `currentPlaybackTime` (liveness probe; `nil` for still images / not-ready items) and `recoverPlayback()` (`playImmediately(atRate: 1.0)`; the Metal renderer also un-pauses its `MTKView`).

## Safety / non-regressions

- **Never fights `PowerManager`**: an intentional pause (battery / fullscreen / sleep / screen saver) calls `pause()`, which stops the timer; a defensive `shouldBePaused` check guards any in-flight tick.
- **Doesn't reintroduce the #206 wake/unlock crash**: no window lifecycle changes; recovery only nudges the existing player.
- **Threading**: timer on the main run loop in `.common` mode (keeps firing during menu tracking / live resize); all renderer access on main. No `@MainActor` annotations (avoids the Release/WMO issues this project hit before).
- Per-display watchdog state is torn down on disconnect, `pause()`, and `cleanup()`.

## Tests

- 6 new `PlaybackWatchdogTests` (real stall, clock-advancing, not-intended, system-paused, nil-time cases).
- **Full suite: 107/107 green.** Clean `xcodebuild` Debug build, no warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)