### PR TITLE
fix: playlist never started (@AppStorage in ObservableObject not reactive)

### DIFF
--- a/src/Wallnetic/Services/PlaylistManager.swift
+++ b/src/Wallnetic/Services/PlaylistManager.swift
@@ -58,13 +58,29 @@ class PlaylistManager: ObservableObject {
     }
 
     // MARK: - Settings (persisted)
+    //
+    // Backed by @Published + UserDefaults (not @AppStorage): @AppStorage inside
+    // an ObservableObject does NOT fire objectWillChange, so SwiftUI never
+    // re-renders the settings view — pickers wouldn't appear and `.onChange`
+    // wouldn't fire (the playlist silently never started). @Published fixes the
+    // reactivity; didSet persists.
 
-    @AppStorage("playlist.enabled") var isEnabled: Bool = false
-    @AppStorage("playlist.intervalSeconds") var intervalSeconds: Int = 1800
+    @Published var isEnabled: Bool = UserDefaults.standard.bool(forKey: "playlist.enabled") {
+        didSet { UserDefaults.standard.set(isEnabled, forKey: "playlist.enabled") }
+    }
+    @Published var intervalSeconds: Int = (UserDefaults.standard.object(forKey: "playlist.intervalSeconds") as? Int) ?? 1800 {
+        didSet { UserDefaults.standard.set(intervalSeconds, forKey: "playlist.intervalSeconds") }
+    }
     /// Raw storage bound directly by the Pickers; logic reads `order`/`source`.
-    @AppStorage("playlist.order") var orderRaw: String = Order.shuffle.rawValue
-    @AppStorage("playlist.source") var sourceRaw: String = Source.library.rawValue
-    @AppStorage("playlist.collectionID") var collectionIDString: String = ""
+    @Published var orderRaw: String = UserDefaults.standard.string(forKey: "playlist.order") ?? Order.shuffle.rawValue {
+        didSet { UserDefaults.standard.set(orderRaw, forKey: "playlist.order") }
+    }
+    @Published var sourceRaw: String = UserDefaults.standard.string(forKey: "playlist.source") ?? Source.library.rawValue {
+        didSet { UserDefaults.standard.set(sourceRaw, forKey: "playlist.source") }
+    }
+    @Published var collectionIDString: String = UserDefaults.standard.string(forKey: "playlist.collectionID") ?? "" {
+        didSet { UserDefaults.standard.set(collectionIDString, forKey: "playlist.collectionID") }
+    }
 
     var order: Order { Order(rawValue: orderRaw) ?? .shuffle }
     var source: Source { Source(rawValue: sourceRaw) ?? .library }
@@ -91,10 +107,12 @@ class PlaylistManager: ObservableObject {
     }
 
     /// User-initiated enable. Turns off time-of-day switching first so the two
-    /// schedulers never fight over the wallpaper.
+    /// schedulers never fight over the wallpaper, then shuffles immediately so
+    /// enabling feels responsive (and the next change follows after `interval`).
     func enableExclusively() {
         TimeOfDayManager.shared.stop()
         start()
+        advance()
     }
 
     func toggle() {


### PR DESCRIPTION
## Bug

The playlist merged in #225 **silently never rotated** — confirmed on-device (the toggle wrote no defaults and nothing switched).

## Root cause

`PlaylistManager` stored its settings as `@AppStorage`, but **`@AppStorage` inside an `ObservableObject` does not fire `objectWillChange`**. So the SwiftUI settings view never re-rendered: the Source/Order/Interval pickers wouldn't appear after enabling, and the toggle's `.onChange` never fired — meaning `start()` was never called and no timer was ever scheduled.

## Fix

- Back the 5 settings with `@Published` + `UserDefaults` (`didSet` persists), so the view is properly reactive and `start()` / `reschedule()` fire on toggle / picker change.
- `enableExclusively()` now advances immediately, so enabling shuffles right away (responsive, and makes it obvious it's working) before the interval kicks in.

## Note
`TimeOfDayManager` uses the same `@AppStorage`-in-`ObservableObject` pattern and is likely affected by the same bug — follow-up fix candidate (not in this PR to keep scope tight on the just-shipped playlist).

## Tests
122/122 green, clean build. Verified live: enabling now shuffles instantly and rotates on the interval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)