### PR TITLE
chore: release v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0] — 2026-06-29
+
 ### Added
 - **System wallpaper sync — lock screen & Mission Control consistency**:
   macOS renders the *system* wallpaper (not Wallnetic's video window) on the

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![App Store](https://img.shields.io/badge/App%20Store-Download-blue.svg?style=flat&logo=app-store&logoColor=white)](https://apps.apple.com/tr/app/wallnetic/id6760347328?mt=12)
 [![CI](https://img.shields.io/github/actions/workflow/status/fatihkan/wallnetic/ci.yml?branch=main&label=CI)](https://github.com/fatihkan/wallnetic/actions)
 [![License](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/Version-1.3.1-blue.svg)](https://github.com/fatihkan/wallnetic/releases/latest)
+[![Version](https://img.shields.io/badge/Version-1.4.0-blue.svg)](https://github.com/fatihkan/wallnetic/releases/latest)
 
 <p align="center">
   <video src="https://github.com/user-attachments/assets/61182f15-1208-4cc5-b37a-d7827e871022" width="800" autoplay loop muted playsinline>

--- a/src/Wallnetic/project.yml
+++ b/src/Wallnetic/project.yml
@@ -8,7 +8,7 @@ options:
 
 settings:
   base:
-    MARKETING_VERSION: "1.3.1"
+    MARKETING_VERSION: "1.4.0"
     CURRENT_PROJECT_VERSION: "8"
     DEVELOPMENT_TEAM: ""
     CODE_SIGN_STYLE: Automatic


### PR DESCRIPTION
Finalize **v1.4.0**: marketing version (project.yml), README badge, CHANGELOG `[Unreleased]` → `[1.4.0]`.

Bundles Wave 1 (playlist/shuffle, time-of-day rotation, playback watchdog, in-app rating prompt, system wallpaper sync) + the #228 window-controls fix. Pushing tag `v1.4.0` after merge triggers the DMG build + GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)