### PR TITLE
perf: stop decoding video nobody can see (occlusion, screen lock, user switch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -323,7 +323,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `.regularMaterial` blur, reducing stacked-material passes per window.
 - **Hero animation** (P2-10, ORTA-1): `withAnimation(repeatForever)` replaced
   with `TimelineView` driven from elapsed-since-appear (no wall-clock jump
-  on sleep/wake), and paused when the window is occluded (ORTA-2).
+  on sleep/wake).
 - **Search routing** (P3-11): libraries > 200 wallpapers route through the
   SQLite cache index instead of fuzzy in-memory scan.
 - **Bulk import** (P3-12, YUKSEK-1, KRITIK-2): `importVideos` now maintains

--- a/src/Wallnetic/App/AppDelegate.swift
+++ b/src/Wallnetic/App/AppDelegate.swift
@@ -210,10 +210,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private func setupPowerManager() {
         powerManager = PowerManager.shared
 
+        // Keep the widget in step with these pauses. It used to be harmless to
+        // skip — power pauses were rare — but screen-lock pausing makes this
+        // the common path, and a widget stuck on "playing" reads as a bug.
         powerManager?.onShouldPausePlayback = { [weak self] in
             self?.desktopWindowController?.pause()
             DispatchQueue.main.async {
                 WallpaperManager.shared.isPlaying = false
+                WidgetSyncService.shared.syncPlaybackState(isPlaying: WallpaperManager.shared.isPlaying)
             }
         }
 
@@ -221,6 +225,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             self?.desktopWindowController?.play()
             DispatchQueue.main.async {
                 WallpaperManager.shared.isPlaying = true
+                WidgetSyncService.shared.syncPlaybackState(isPlaying: WallpaperManager.shared.isPlaying)
             }
         }
     }

--- a/src/Wallnetic/Engine/DesktopWindowController.swift
+++ b/src/Wallnetic/Engine/DesktopWindowController.swift
@@ -130,6 +130,7 @@ class DesktopWindowController {
         // Store references
         desktopWindows[displayID] = window
         renderers[displayID] = renderer
+        observeOcclusion(of: window, displayID: displayID)
 
         // Apply current effects
         applyEffectsToOverlay(effectOverlay)
@@ -218,6 +219,11 @@ class DesktopWindowController {
         for renderer in renderers.values {
             renderer.play()
         }
+        // A play() issued while a desktop is fully covered must not start a
+        // decode nobody can see.
+        for id in desktopWindows.keys {
+            applyOcclusion(for: id)
+        }
         startWatchdog()
     }
 
@@ -229,6 +235,7 @@ class DesktopWindowController {
         for renderer in renderers.values {
             renderer.pause()
         }
+        occlusionSuspended.removeAll()
         stopWatchdog()
     }
 
@@ -255,6 +262,74 @@ class DesktopWindowController {
 
     var isCurrentlyPlaying: Bool {
         return isPlaying
+    }
+
+    // MARK: - Occlusion
+
+    /// Displays whose renderer is paused purely because the desktop window is
+    /// fully covered. Deliberately separate from `isPlaying`, which must keep
+    /// meaning "the user intends the wallpaper to play" for the menu bar,
+    /// widget sync and the resume paths.
+    private var occlusionSuspended: Set<CGDirectDisplayID> = []
+    private var occlusionObservers: [CGDirectDisplayID: NSObjectProtocol] = [:]
+    private var occlusionDebounce: [CGDirectDisplayID: Timer] = [:]
+
+    /// macOS delivers a burst of alternating occlusion notifications across a
+    /// single cover/uncover transition (21 within 360 ms when measured here),
+    /// so state is applied only once it settles.
+    private static let occlusionDebounceInterval: TimeInterval = 0.5
+
+    private func observeOcclusion(of window: NSWindow, displayID: CGDirectDisplayID) {
+        // Scoped to this window: the process also owns overlay panels and two
+        // SwiftUI WindowGroups whose occlusion is none of our business.
+        let observer = NotificationCenter.default.addObserver(
+            forName: NSWindow.didChangeOcclusionStateNotification,
+            object: window,
+            queue: .main
+        ) { [weak self] _ in
+            self?.scheduleOcclusionUpdate(for: displayID)
+        }
+        occlusionObservers[displayID] = observer
+    }
+
+    private func scheduleOcclusionUpdate(for displayID: CGDirectDisplayID) {
+        occlusionDebounce[displayID]?.invalidate()
+        occlusionDebounce[displayID] = Timer.scheduledTimer(
+            withTimeInterval: Self.occlusionDebounceInterval,
+            repeats: false
+        ) { [weak self] _ in
+            self?.occlusionDebounce[displayID] = nil
+            self?.applyOcclusion(for: displayID)
+        }
+    }
+
+    /// Suspends or resumes one display's decoder from *live* window state.
+    /// Reading the state rather than trusting a notification payload is what
+    /// makes a missed notification self-correcting.
+    private func applyOcclusion(for displayID: CGDirectDisplayID) {
+        guard let window = desktopWindows[displayID],
+              let renderer = renderers[displayID] else { return }
+
+        // `.visible` is all-or-nothing — cleared only when the window is
+        // *fully* covered — so partial overlap never pauses the wallpaper.
+        let visible = window.occlusionState.contains(.visible)
+
+        if !visible, isPlaying, !occlusionSuspended.contains(displayID) {
+            occlusionSuspended.insert(displayID)
+            renderer.pause()
+            Log.window.debug("Display \(displayID, privacy: .public) fully occluded — decode suspended")
+        } else if visible, occlusionSuspended.remove(displayID) != nil {
+            if isPlaying { renderer.play() }
+            Log.window.debug("Display \(displayID, privacy: .public) visible again — decode resumed")
+        }
+    }
+
+    private func removeOcclusionTracking(for displayID: CGDirectDisplayID) {
+        if let observer = occlusionObservers.removeValue(forKey: displayID) {
+            NotificationCenter.default.removeObserver(observer)
+        }
+        occlusionDebounce.removeValue(forKey: displayID)?.invalidate()
+        occlusionSuspended.remove(displayID)
     }
 
     // MARK: - Playback Watchdog (v1.4 Wave 1)
@@ -295,6 +370,20 @@ class DesktopWindowController {
         let shouldBePaused = PowerManager.shared.shouldBePaused
 
         for (id, renderer) in renderers {
+            // Re-derive occlusion from live state first. This doubles as a
+            // resync: a dropped notification can strand a display suspended
+            // for at most one watchdog tick.
+            applyOcclusion(for: id)
+            if occlusionSuspended.contains(id) {
+                // A suspended renderer's clock is frozen *on purpose*. Letting
+                // the watchdog see that would restart the decode behind the
+                // cover permanently — the exact waste this pause exists to
+                // avoid — so reset the baseline instead.
+                frozenSampleCounts[id] = 0
+                lastPlaybackTimes[id] = renderer.currentPlaybackTime
+                continue
+            }
+
             let current = renderer.currentPlaybackTime
             let previous = lastPlaybackTimes[id]
             lastPlaybackTimes[id] = current
@@ -333,6 +422,7 @@ class DesktopWindowController {
 
         // Remove windows for disconnected displays
         for id in knownIDs.subtracting(currentIDs) {
+            removeOcclusionTracking(for: id)
             renderers[id]?.stop()
             desktopWindows[id]?.close()
             desktopWindows.removeValue(forKey: id)
@@ -438,6 +528,10 @@ class DesktopWindowController {
 
     func cleanup() {
         stopWatchdog()
+
+        for id in Array(occlusionObservers.keys) {
+            removeOcclusionTracking(for: id)
+        }
 
         for renderer in renderers.values {
             renderer.stop()

--- a/src/Wallnetic/Engine/PowerManager.swift
+++ b/src/Wallnetic/Engine/PowerManager.swift
@@ -18,6 +18,10 @@ class PowerManager {
     private(set) var isFullscreenAppActive = false
     private(set) var isScreenAsleep = false
     private(set) var isScreenSaverActive = false
+    /// True while the login window covers the session (screen locked) or another
+    /// user is switched in. Nothing the user can see is on screen, but without
+    /// this the decoder ran at full rate the whole time.
+    private(set) var isSessionInactive = false
 
     private var fullscreenCheckTimer: Timer?
     private var powerSourceRef: CFRunLoopSource?
@@ -54,6 +58,7 @@ class PowerManager {
         // Remove all notification observers
         NotificationCenter.default.removeObserver(self)
         NSWorkspace.shared.notificationCenter.removeObserver(self)
+        DistributedNotificationCenter.default().removeObserver(self)
 
         // Clear callbacks to break retain cycles
         onShouldPausePlayback = nil
@@ -104,18 +109,62 @@ class PowerManager {
             object: nil
         )
 
-        // Screen saver
-        nc.addObserver(
+        // Screen saver + screen lock. These are cross-process names posted by
+        // loginwindow/screensaver, so they only ever arrive on the *distributed*
+        // center — registering them on NotificationCenter.default (as this did
+        // until v1.4.1) meant they could never fire and the screen-saver branch
+        // of `shouldBePaused` was unreachable.
+        //
+        // `.deliverImmediately` is load-bearing: the convenience overload
+        // defaults to `.coalesce`, and AppKit suspends distributed delivery
+        // while the app is inactive — which it always is when the screen locks
+        // or the saver starts.
+        let dnc = DistributedNotificationCenter.default()
+        dnc.addObserver(
             self,
             selector: #selector(screenSaverDidStart),
             name: NSNotification.Name("com.apple.screensaver.didstart"),
-            object: nil
+            object: nil,
+            suspensionBehavior: .deliverImmediately
         )
 
-        nc.addObserver(
+        dnc.addObserver(
             self,
             selector: #selector(screenSaverDidStop),
             name: NSNotification.Name("com.apple.screensaver.didstop"),
+            object: nil,
+            suspensionBehavior: .deliverImmediately
+        )
+
+        dnc.addObserver(
+            self,
+            selector: #selector(screenDidLock),
+            name: NSNotification.Name("com.apple.screenIsLocked"),
+            object: nil,
+            suspensionBehavior: .deliverImmediately
+        )
+
+        dnc.addObserver(
+            self,
+            selector: #selector(screenDidUnlock),
+            name: NSNotification.Name("com.apple.screenIsUnlocked"),
+            object: nil,
+            suspensionBehavior: .deliverImmediately
+        )
+
+        // Fast user switching — the other user keeps the display awake, so no
+        // sleep or lock notification ever arrives to stop us.
+        wsnc.addObserver(
+            self,
+            selector: #selector(sessionDidResignActive),
+            name: NSWorkspace.sessionDidResignActiveNotification,
+            object: nil
+        )
+
+        wsnc.addObserver(
+            self,
+            selector: #selector(sessionDidBecomeActive),
+            name: NSWorkspace.sessionDidBecomeActiveNotification,
             object: nil
         )
 
@@ -331,7 +380,8 @@ class PowerManager {
     @objc private func screensDidWake() {
         Log.power.info("Screens did wake")
         isScreenAsleep = false
-        notifyResumeIfNeeded()
+        resyncSessionState()
+        notifyResumeIfNeeded(respectAutoResume: false)
     }
 
     @objc private func systemWillSleep() {
@@ -343,7 +393,9 @@ class PowerManager {
         Log.power.info("System did wake")
         // Small delay to let system stabilize
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
-            self?.notifyResumeIfNeeded()
+            guard let self else { return }
+            self.resyncSessionState()
+            self.notifyResumeIfNeeded(respectAutoResume: false)
         }
     }
 
@@ -356,7 +408,54 @@ class PowerManager {
     @objc private func screenSaverDidStop() {
         Log.power.info("Screen saver stopped")
         isScreenSaverActive = false
-        notifyResumeIfNeeded()
+        resyncSessionState()
+        notifyResumeIfNeeded(respectAutoResume: false)
+    }
+
+    @objc private func screenDidLock() {
+        Log.power.info("Screen locked")
+        isSessionInactive = true
+        notifyPauseIfNeeded()
+    }
+
+    @objc private func screenDidUnlock() {
+        Log.power.info("Screen unlocked")
+        isSessionInactive = false
+        resyncSessionState()
+        notifyResumeIfNeeded(respectAutoResume: false)
+    }
+
+    @objc private func sessionDidResignActive() {
+        Log.power.info("Session switched away (fast user switching)")
+        isSessionInactive = true
+        notifyPauseIfNeeded()
+    }
+
+    @objc private func sessionDidBecomeActive() {
+        Log.power.info("Session became active")
+        isSessionInactive = false
+        resyncSessionState()
+        notifyResumeIfNeeded(respectAutoResume: false)
+    }
+
+    /// Re-derives lock / session state from the window server rather than
+    /// trusting a matched pair of notifications to always arrive.
+    ///
+    /// Without this a single missed unlock — screensaver into display sleep
+    /// waking to a lock screen, unlocking straight into a user switch, a
+    /// `distnoted` restart — would leave `shouldBePaused` true forever, and the
+    /// playback watchdog deliberately stands down while paused. The wallpaper
+    /// would simply never come back, which is precisely the "it froze, I had to
+    /// reopen it" complaint the watchdog exists to kill.
+    private func resyncSessionState() {
+        guard let session = CGSessionCopyCurrentDictionary() as? [String: Any] else { return }
+        let onConsole = session["kCGSSessionOnConsoleKey"] as? Bool ?? true
+        let locked = session["CGSSessionScreenIsLocked"] as? Bool ?? false
+        isSessionInactive = !onConsole || locked
+        // A saver that stopped without posting .didstop can't strand us either.
+        if !locked {
+            isScreenSaverActive = false
+        }
     }
 
     @objc private func activeSpaceDidChange() {
@@ -378,11 +477,15 @@ class PowerManager {
         runOnMain { callback?() }
     }
 
-    private func notifyResumeIfNeeded() {
+    /// - Parameter respectAutoResume: pass `false` for pauses the user never
+    ///   asked for (lock, user switch, screen saver, wake). "Don't auto-resume"
+    ///   is about battery and fullscreen pauses; applying it to a screen lock
+    ///   would leave the wallpaper dead after every unlock.
+    private func notifyResumeIfNeeded(respectAutoResume: Bool = true) {
         // Only resume if all conditions are clear
         guard !shouldBePaused else { return }
 
-        if WallpaperManager.shared.shouldAutoResume {
+        if !respectAutoResume || WallpaperManager.shared.shouldAutoResume {
             let callback = onShouldResumePlayback
             runOnMain { callback?() }
         }
@@ -403,7 +506,7 @@ class PowerManager {
 
     /// Returns true if playback should be paused based on current conditions
     var shouldBePaused: Bool {
-        if isScreenAsleep || isScreenSaverActive {
+        if isScreenAsleep || isScreenSaverActive || isSessionInactive {
             return true
         }
 

--- a/src/Wallnetic/Views/Main/HomeView.swift
+++ b/src/Wallnetic/Views/Main/HomeView.swift
@@ -270,8 +270,12 @@ struct HeroBannerCard: View {
         // P2-10 + ORTA-1: phase derived from elapsed-since-appear rather
         // than absolute wall-clock — Mac sleep/wake doesn't cause the
         // Ken Burns to teleport mid-cycle.
-        // ORTA-2: TimelineView paused when window is occluded so we
-        // don't tick the hero off-screen.
+        // The `paused:` gate only covers teardown — `isWindowVisible` goes
+        // false in onDisappear, by which point SwiftUI is already tearing the
+        // TimelineView down. Real occlusion gating needs the hosting NSWindow's
+        // occlusionState plumbed in, and must also carry a paused-duration
+        // offset or `elapsed` (derived from ctx.date) teleports the Ken Burns
+        // on resume. Tracked for v1.4.1.
         TimelineView(.animation(minimumInterval: 1.0 / 30.0, paused: !isWindowVisible)) { ctx in
             let elapsed = ctx.date.timeIntervalSince(startDate)
             let cycle: Double = 14


### PR DESCRIPTION
## Summary

A 6-lens performance audit (15 agents, code-reading + standalone measurement probes) ahead of the App Store submission. This PR ships only the findings I could confirm by reading the shipping code — three states where Wallnetic decoded video at full rate with nothing visible to the user.

**Occlusion pause, per display.** Each desktop window now observes its own `didChangeOcclusionStateNotification` and suspends that display's renderer while it is fully covered — a maximized browser, a fullscreen game, any full-screen window. There was no occlusion handling anywhere in the tree before this (`grep occlusionState` returned zero hits), so this cost was paid in full, permanently. Debounced 500 ms: macOS delivers a burst of alternating notifications across a single transition. Suspension is kept separate from `isPlaying`, which must keep meaning "the user intends the wallpaper to play" for the menu bar, widget sync and resume paths.

The watchdog interaction is the subtle part. A suspended renderer's clock is frozen on purpose; left alone, `PlaybackWatchdog` would read that as a stall after two samples and `recoverPlayback()` would restart the decode behind the cover permanently. `checkPlaybackHealth` now re-derives occlusion from live window state before sampling and skips suspended displays. That re-derivation doubles as a resync — a dropped notification can strand a display for at most one watchdog tick.

**Screen saver pausing was dead code.** The two observers were registered on `NotificationCenter.default` for `com.apple.screensaver.didstart/.didstop`, which are cross-process names — they could never fire, so `isScreenSaverActive` was permanently false and its branch of `shouldBePaused` was unreachable. Moved to `DistributedNotificationCenter` with `.deliverImmediately`; the convenience overload's `.coalesce` default would drop them, because AppKit suspends distributed delivery while the app is inactive, which it always is exactly when a screen saver starts.

**Screen lock and fast user switching were not observed at all** — video decoded at full rate behind the login window, and indefinitely while another user was switched in (nothing else fires there: the other user keeps the display awake). Added `com.apple.screenIsLocked`/`Unlocked` and `NSWorkspace.sessionDid{Resign,Become}ActiveNotification`, gated through a new `isSessionInactive` in `shouldBePaused`.

The freeze risk this creates is mitigated in the same commit. If an unlock is ever missed — saver into display sleep waking to a lock screen, unlock straight into a user switch, a `distnoted` restart — `shouldBePaused` would pin true forever, and the watchdog deliberately stands down while paused, so the wallpaper would simply never come back. `resyncSessionState()` re-derives truth from `CGSessionCopyCurrentDictionary()` on every wake/unlock/saver-stop path instead of trusting notifications to arrive in pairs. Lock/session/saver resumes also bypass the `shouldAutoResume` gate: that setting is about battery and fullscreen pauses, and applying it to a screen lock would leave the wallpaper dead after every unlock.

**Widget sync on the power path.** `onShouldPausePlayback` set `isPlaying = false` without syncing the widget. Harmless while power pauses were rare; lock pausing makes it the common case, and a widget stuck on "playing" reads as a bug.

**Removed a false performance claim.** `HeroBannerCard`'s `paused: !isWindowVisible` is unreachable — `isWindowVisible` only goes false in `onDisappear`, by which point SwiftUI is already tearing the TimelineView down. The comment and the matching CHANGELOG line for 1.3.1 both told users the hero pauses when occluded. Corrected both. Real gating needs the hosting NSWindow's occlusion state plus a paused-duration offset (or the Ken Burns teleports on resume); tracked for v1.4.1.

## What this PR deliberately does not do

The audit's headline claim — that `AmbientStage` costs 8–12% of a core — came from a synthetic probe and **did not reproduce end-to-end**, so no gradient code is touched here. Measured on the real Release build: WindowServer sat at 44.25% with the app running and 46.24% with it quit, i.e. Wallnetic's compositing contribution is within noise. Wave 2/3 items (Metal renderer, shared decode sessions, YUV shader, `PerformanceManager`) are all in a default-off path or need a full test cycle, and none belong in a submission-week build.

## Test plan

- [x] `xcodebuild test` — **122/122 pass**
- [x] Release build clean (only two pre-existing unused-value warnings, untouched)
- [x] A/B attribution: gated `applyOcclusion` behind a temporary flag and measured both ways — 49.74% on / 50.86% off, confirming these changes neither help nor hurt in the measured state and that the machine's high reading has another cause (see below)
- [ ] **Manual pass still required** (cannot be automated): cover/uncover with a maximized window; enter/leave a fullscreen game; lock and unlock; fast-user-switch away and back; sleep/wake the display; hot-unplug a second monitor while covered. In each case the wallpaper must resume, not stay frozen.

## Measurement caveat — read before publishing any CPU number

Idle CPU for the same binary on the same machine ranged from **3.4% to 51%** across launches today, so the "~2% CPU" marketing number is **not yet measurable**. What is solid: closing the main window dropped CPU from ~51% to ~26.6%, so the window's always-on animations are roughly 24 points — the audit was right that the main window, not the wallpaper engine, dominates. Profiles also show two concurrent CoreMedia decode pipelines for a single display and single wallpaper, which is unexplained and worth chasing before any number is published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
