### PR TITLE
fix: never resume a pause the user asked for

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@
 [![Swift](https://img.shields.io/badge/Swift-5.9+-F05138.svg?style=flat&logo=swift&logoColor=white)](https://swift.org/)
 [![SwiftUI](https://img.shields.io/badge/SwiftUI-blue.svg?style=flat&logo=swift&logoColor=white)](https://developer.apple.com/xcode/swiftui/)
 [![Metal](https://img.shields.io/badge/Metal-GPU-8E8E93.svg?style=flat&logo=apple)](https://developer.apple.com/metal/)
-[![App Store](https://img.shields.io/badge/App%20Store-Download-blue.svg?style=flat&logo=app-store&logoColor=white)](https://apps.apple.com/tr/app/wallnetic/id6760347328?mt=12)
+[![App Store](https://img.shields.io/badge/App%20Store-Download-blue.svg?style=flat&logo=app-store&logoColor=white)](https://apps.apple.com/app/id6760347328?mt=12)
 [![CI](https://img.shields.io/github/actions/workflow/status/fatihkan/wallnetic/ci.yml?branch=main&label=CI)](https://github.com/fatihkan/wallnetic/actions)
 [![License](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/Version-1.4.0-blue.svg)](https://github.com/fatihkan/wallnetic/releases/latest)
+[![Version](https://img.shields.io/badge/Version-1.4.1-blue.svg)](https://github.com/fatihkan/wallnetic/releases/latest)
 
 <p align="center">
   <video src="https://github.com/user-attachments/assets/61182f15-1208-4cc5-b37a-d7827e871022" width="800" autoplay loop muted playsinline>
@@ -137,7 +137,8 @@ Wallnetic brings **live video wallpapers** to your Mac desktop — turn any vide
 ### Performance
 - **Metal GPU acceleration** for smooth playback
 - 3 performance modes: Quality, Balanced, Battery Saver
-- Minimal CPU usage (~2-5%)
+- Stops decoding entirely when the desktop is covered, the Mac is locked, the
+  screen saver is running or the display is asleep
 - Async image caching
 
 ---
@@ -155,7 +156,7 @@ Wallnetic brings **live video wallpapers** to your Mac desktop — turn any vide
 
 ### Mac App Store
 
-<a href="https://apps.apple.com/tr/app/wallnetic/id6760347328?mt=12">
+<a href="https://apps.apple.com/app/id6760347328?mt=12">
   <img src="https://developer.apple.com/assets/elements/badges/download-on-the-mac-app-store.svg" alt="Download on the Mac App Store" height="50">
 </a>
 
@@ -163,8 +164,8 @@ Wallnetic brings **live video wallpapers** to your Mac desktop — turn any vide
 
 | Platform | Download |
 |----------|----------|
-| macOS (Apple Silicon) | [Wallnetic_1.4.0_arm64.dmg](https://github.com/fatihkan/wallnetic/releases/latest) |
-| macOS (Intel) | [Wallnetic_1.4.0_x86_64.dmg](https://github.com/fatihkan/wallnetic/releases/latest) |
+| macOS (Apple Silicon) | [Wallnetic_1.4.1_arm64.dmg](https://github.com/fatihkan/wallnetic/releases/latest) |
+| macOS (Intel) | [Wallnetic_1.4.1_x86_64.dmg](https://github.com/fatihkan/wallnetic/releases/latest) |
 
 > **"Wallnetic is damaged and can't be opened"** &mdash; This happens because the DMG is not notarized by Apple. Run this command in Terminal after dragging Wallnetic to Applications:
 > ```bash
@@ -279,12 +280,18 @@ open Wallnetic.xcodeproj
 - [x] Crash/hang & data-race fixes &mdash; AIService, Photos, DownloadManager, AudioVisualizer (#208, #210)
 - [x] Wake/power main-thread hardening (#211)
 
-### v1.4.0 &mdash; Reliability & Rotation (current)
+### v1.4.0 &mdash; Reliability & Rotation
 - [x] Playlist / Shuffle &mdash; auto-rotate wallpapers on an interval (library, favorites, or a collection)
 - [x] System wallpaper sync &mdash; lock screen & Mission Control show a still frame of your video
 - [x] Playback watchdog &mdash; detects and recovers frozen wallpapers automatically
 - [x] In-app App Store rating prompt
 - [x] macOS 26 Tahoe fix &mdash; invisible window close/minimize buttons (#228)
+
+### v1.4.1 &mdash; Power (current)
+- [x] Pauses decoding while the desktop is fully covered, per display
+- [x] Pauses on screen lock and fast user switching
+- [x] Screen-saver pausing fixed &mdash; the observers could never fire before
+- [x] Watchdog no longer restarts a deliberately suspended renderer
 
 ### v2.0 &mdash; Planned
 - [ ] AI video generation from text prompts
@@ -300,10 +307,9 @@ open Wallnetic.xcodeproj
 Release notes live in [CHANGELOG.md](CHANGELOG.md), formatted to
 [Keep a Changelog](https://keepachangelog.com/) and [SemVer](https://semver.org/).
 
-Latest: **[1.4.0](CHANGELOG.md#140--2026-06-29)** — playlist/shuffle auto-rotation,
-system wallpaper sync (lock screen & Mission Control), playback reliability
-watchdog, in-app rating prompt, and the macOS 26 Tahoe invisible
-window-buttons fix (#228).
+Latest: **[1.4.1](CHANGELOG.md#141--2026-08-08)** — stops decoding video nobody
+can see: per-display occlusion pause, screen lock and fast-user-switch pausing,
+and a screen-saver pause that could never fire before.
 
 ---
 

--- a/apps.json
+++ b/apps.json
@@ -12,7 +12,7 @@
       "name": "Wallnetic",
       "subtitle": "Live Video Wallpapers for Mac",
       "description": "Transform your Mac desktop with live video wallpapers. Dynamic Island controls, Netflix-style UI, 6 wallpaper sources, Metal GPU acceleration, and multi-monitor support.",
-      "longDescription": "Wallnetic brings live video wallpapers to your Mac desktop with a Netflix-style browsing experience. Features include Dynamic Island — a floating control pill at the top of your screen with notch-aware layout for MacBook Pro, 6 built-in wallpaper sources (Pixabay, Pexels, MyLiveWallpapers, DesktopHut, MoeWalls, MotionBGs), per-Space wallpapers that auto-switch with Mission Control, lock screen video wallpapers, wallpaper effects (blur, brightness, tint, vignette), time-of-day auto switching, Apple Shortcuts & Siri integration, wallpaper rename, dock icon hiding for menu bar-only mode, and striking UI effects with glow cards, neon navigation, and glass morphism. Metal GPU-accelerated rendering keeps CPU usage at 2-5%. Wallpaper Engine has 40M+ users on Windows — now Mac users have a native alternative built with SwiftUI and Metal.",
+      "longDescription": "Wallnetic brings live video wallpapers to your Mac desktop with a Netflix-style browsing experience. Features include Dynamic Island — a floating control pill at the top of your screen with notch-aware layout for MacBook Pro, 6 built-in wallpaper sources (Pixabay, Pexels, MyLiveWallpapers, DesktopHut, MoeWalls, MotionBGs), per-Space wallpapers that auto-switch with Mission Control, lock screen video wallpapers, wallpaper effects (blur, brightness, tint, vignette), time-of-day auto switching, Apple Shortcuts & Siri integration, wallpaper rename, dock icon hiding for menu bar-only mode, and striking UI effects with glow cards, neon navigation, and glass morphism. Metal GPU-accelerated rendering, and playback stops entirely when the desktop is covered, the Mac is locked or the display is asleep. Wallpaper Engine has 40M+ users on Windows — now Mac users have a native alternative built with SwiftUI and Metal.",
       "icon": "https://raw.githubusercontent.com/fatihkan/wallnetic/main/docs/assets/icon.png",
       "iconStyle": {
         "scale": 1.3,
@@ -44,7 +44,7 @@
         "Wallpaper effects: blur, brightness, tint, vignette, 8 presets",
         "Time-of-day auto switching (Morning, Afternoon, Evening, Night)",
         "Apple Shortcuts & Siri integration",
-        "Metal GPU-accelerated rendering (~2-5% CPU)",
+        "Metal GPU-accelerated rendering; stops decoding when nothing is visible",
         "Wallpaper rename with custom display titles",
         "Dock icon hiding — menu bar-only mode",
         "Striking UI: glow cards, neon navigation, glass morphism",

--- a/docs/SOCIAL_MEDIA.md
+++ b/docs/SOCIAL_MEDIA.md
@@ -43,7 +43,7 @@ The Problem:
 Wallpaper Engine has 40M+ users on Windows.
 Mac users? We've been stuck with static images.
 
-I wanted dynamic, animated backgrounds without killing my battery or CPU.
+I wanted dynamic, animated backgrounds that stop working when I'm not looking at them.
 
 So I built it myself.
 
@@ -64,7 +64,7 @@ Key features:
 ✅ Multi-monitor support
 ✅ Auto-pause on battery
 ✅ Menu bar app
-✅ ~2-5% CPU usage
+✅ Stops decoding when nothing is visible
 
 3/4
 ```
@@ -123,7 +123,7 @@ Not with Wallnetic:
 - Metal GPU acceleration
 - Auto-pause on battery
 - Pause when fullscreen apps are active
-- ~2-5% CPU usage
+- Stops decoding when nothing is visible
 
 Mac users can finally have nice things.
 
@@ -152,7 +152,7 @@ Wallnetic is built from the ground up for macOS using:
 Key Features:
 ✅ Play any video file as your desktop background
 ✅ Multi-monitor support with per-display wallpapers
-✅ Minimal resource usage (~2-5% CPU)
+✅ Stops decoding when the desktop is covered or the Mac is locked
 ✅ Menu bar app for quick access
 
 The entire project is open source on GitHub. I'd love feedback from fellow developers!
@@ -175,7 +175,7 @@ Some interesting challenges I solved:
 Creating windows that sit behind all other content required diving into CGWindowLevel and careful NSWindow configuration.
 
 2️⃣ Video Performance
-Using AVFoundation with Metal rendering to maintain <5% CPU usage while playing 4K video loops.
+Using AVFoundation with Metal rendering, and pausing decode entirely whenever the desktop is covered, the Mac is locked or the display is asleep.
 
 3️⃣ Smart Pause Detection
 Detecting fullscreen apps to auto-pause wallpapers without false positives from Finder, Dock, or Control Center.
@@ -243,7 +243,7 @@ Wallnetic, macOS için sıfırdan şu teknolojilerle geliştirildi:
 Temel Özellikler:
 ✅ Herhangi bir video dosyasını masaüstü arka planı olarak oynat
 ✅ Ekran başına farklı duvar kağıdı ile çoklu monitör desteği
-✅ Minimum kaynak kullanımı (~%2-5 CPU)
+✅ Masaüstü kapalı ya da Mac kilitliyken video çözme tamamen durur
 ✅ Hızlı erişim için menü çubuğu uygulaması
 
 Proje tamamen açık kaynak! Geliştirici arkadaşlardan geri bildirim almak isterim.
@@ -266,7 +266,7 @@ Native bir macOS video duvar kağıdı motoru geliştirmek, düşük seviye macO
 Tüm içeriğin arkasında kalan pencereler oluşturmak, CGWindowLevel'a dalmayı ve dikkatli NSWindow yapılandırması gerektirdi.
 
 2️⃣ Video Performansı
-4K video döngüleri oynatırken <%5 CPU kullanımı sağlamak için AVFoundation ve Metal rendering kullandım.
+AVFoundation ve Metal rendering kullandım; masaüstü kapalı, Mac kilitli ya da ekran uykudayken video çözme tamamen duruyor.
 
 3️⃣ Akıllı Duraklatma Algılama
 Finder, Dock veya Kontrol Merkezi'nden yanlış pozitifler almadan tam ekran uygulamaları algılayıp duvar kağıtlarını otomatik duraklatma.
@@ -337,7 +337,7 @@ For maximum engagement, include visuals:
 2. **Before/After** - Static vs animated desktop
 3. **Multi-Monitor Setup** - Different wallpapers on each display
 4. **Menu Bar** - Quick access controls
-5. **Performance Stats** - Activity Monitor showing low CPU usage
+5. **Performance** - the wallpaper pausing itself the moment a window covers the desktop
 
 ---
 

--- a/src/Wallnetic/Engine/PowerManager.swift
+++ b/src/Wallnetic/Engine/PowerManager.swift
@@ -472,7 +472,23 @@ class PowerManager {
 
     // MARK: - Notifications
 
+    /// True only while playback is paused *by this manager*. See
+    /// ``PowerPauseOwnership`` for why this exists.
+    private var pausedByPower = false
+
+    /// Hands playback ownership back to the user. Called when they explicitly
+    /// press Play or Pause, after which no power event may override them until
+    /// we pause again ourselves.
+    func userDidTogglePlayback() {
+        pausedByPower = false
+    }
+
     private func notifyPauseIfNeeded() {
+        if PowerPauseOwnership.shouldClaimPause(
+            wallpaperIsPlaying: WallpaperManager.shared.isPlaying
+        ) {
+            pausedByPower = true
+        }
         let callback = onShouldPausePlayback
         runOnMain { callback?() }
     }
@@ -482,13 +498,16 @@ class PowerManager {
     ///   is about battery and fullscreen pauses; applying it to a screen lock
     ///   would leave the wallpaper dead after every unlock.
     private func notifyResumeIfNeeded(respectAutoResume: Bool = true) {
-        // Only resume if all conditions are clear
-        guard !shouldBePaused else { return }
+        guard PowerPauseOwnership.shouldResume(
+            pausedByPower: pausedByPower,
+            shouldBePaused: shouldBePaused,
+            respectAutoResume: respectAutoResume,
+            autoResumeEnabled: WallpaperManager.shared.shouldAutoResume
+        ) else { return }
 
-        if !respectAutoResume || WallpaperManager.shared.shouldAutoResume {
-            let callback = onShouldResumePlayback
-            runOnMain { callback?() }
-        }
+        pausedByPower = false
+        let callback = onShouldResumePlayback
+        runOnMain { callback?() }
     }
 
     /// Routes playback callbacks to the main thread before they touch

--- a/src/Wallnetic/Engine/PowerPauseOwnership.swift
+++ b/src/Wallnetic/Engine/PowerPauseOwnership.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// Pure resume-decision logic for ``PowerManager`` (v1.4.2).
+///
+/// v1.4.1 added pausing on screen lock, fast user switching and the screen
+/// saver, and let those resume paths bypass the "resume automatically" setting
+/// — locking is not a pause the user asked for, so leaving the wallpaper dead
+/// after every unlock would be wrong.
+///
+/// What that shipped without was any notion of *who* paused. Every resume path
+/// called straight through, so a wallpaper the **user** had paused came back to
+/// life on the next unlock, wake or screen-saver exit. For anyone who had
+/// turned "resume automatically" off, the setting stopped working entirely.
+///
+/// The rule is therefore ownership-based: only a pause this app caused may be
+/// undone by this app. It is kept here — pure, no AppKit — so the exact
+/// combination that shipped broken is unit-testable, following the same
+/// precedent as ``PlaybackWatchdog``.
+enum PowerPauseOwnership {
+
+    /// Whether a pause should be *claimed* as ours when a power condition
+    /// fires.
+    ///
+    /// Only claim it if the wallpaper was actually playing. If the user had
+    /// already paused, claiming here would hand us permission to "resume" a
+    /// pause we never caused — which is the v1.4.1 defect, just moved.
+    static func shouldClaimPause(wallpaperIsPlaying: Bool) -> Bool {
+        wallpaperIsPlaying
+    }
+
+    /// Whether playback should resume now.
+    ///
+    /// - Parameters:
+    ///   - pausedByPower: we paused it and have not handed control back.
+    ///   - shouldBePaused: some power condition is still active.
+    ///   - respectAutoResume: `false` for pauses the user never asked for
+    ///     (lock, user switch, screen saver, wake), where the auto-resume
+    ///     setting must not strand the wallpaper.
+    ///   - autoResumeEnabled: the user's "resume automatically" preference.
+    static func shouldResume(
+        pausedByPower: Bool,
+        shouldBePaused: Bool,
+        respectAutoResume: Bool,
+        autoResumeEnabled: Bool
+    ) -> Bool {
+        // A condition is still active — nothing to resume into.
+        guard !shouldBePaused else { return false }
+        // Never override the user's own Pause.
+        guard pausedByPower else { return false }
+        return !respectAutoResume || autoResumeEnabled
+    }
+}

--- a/src/Wallnetic/Services/WallpaperManager.swift
+++ b/src/Wallnetic/Services/WallpaperManager.swift
@@ -582,6 +582,9 @@ class WallpaperManager: ObservableObject {
     func togglePlayback() {
         isPlaying.toggle()
 
+        // The user is taking control: a later unlock or wake must not undo it.
+        PowerManager.shared.userDidTogglePlayback()
+
         if isPlaying {
             playbackDelegate?.playbackPlay()
         } else {

--- a/src/Wallnetic/Tests/PowerPauseOwnershipTests.swift
+++ b/src/Wallnetic/Tests/PowerPauseOwnershipTests.swift
@@ -1,0 +1,102 @@
+import XCTest
+@testable import Wallnetic
+
+final class PowerPauseOwnershipTests: XCTestCase {
+
+    // MARK: - The v1.4.1 regression these tests exist for
+
+    /// Pause the wallpaper yourself, lock the Mac, unlock: it must stay paused.
+    /// v1.4.1 resumed it, because the unlock path bypassed the auto-resume
+    /// setting without checking who had paused in the first place.
+    func testUserPauseSurvivesUnlock() {
+        // The user paused, so no power condition ever claimed ownership.
+        XCTAssertFalse(PowerPauseOwnership.shouldResume(
+            pausedByPower: false,
+            shouldBePaused: false,
+            respectAutoResume: false,   // unlock bypasses the setting
+            autoResumeEnabled: true
+        ))
+    }
+
+    /// Same, for someone who explicitly turned auto-resume off — v1.4.1 broke
+    /// that setting outright on every lock, wake and screen-saver exit.
+    func testUserPauseSurvivesUnlockWithAutoResumeDisabled() {
+        XCTAssertFalse(PowerPauseOwnership.shouldResume(
+            pausedByPower: false,
+            shouldBePaused: false,
+            respectAutoResume: false,
+            autoResumeEnabled: false
+        ))
+    }
+
+    /// A power condition claims the pause only when something was playing.
+    func testClaimsPauseOnlyWhenPlaying() {
+        XCTAssertTrue(PowerPauseOwnership.shouldClaimPause(wallpaperIsPlaying: true))
+        XCTAssertFalse(PowerPauseOwnership.shouldClaimPause(wallpaperIsPlaying: false))
+    }
+
+    // MARK: - The behaviour v1.4.1 was built for, which must still hold
+
+    /// A lock-induced pause resumes on unlock even with auto-resume off —
+    /// otherwise the wallpaper is dead after every unlock, which is the whole
+    /// reason the bypass exists.
+    func testPowerPauseResumesOnUnlockDespiteAutoResumeDisabled() {
+        XCTAssertTrue(PowerPauseOwnership.shouldResume(
+            pausedByPower: true,
+            shouldBePaused: false,
+            respectAutoResume: false,
+            autoResumeEnabled: false
+        ))
+    }
+
+    func testPowerPauseResumesWhenAutoResumeEnabled() {
+        XCTAssertTrue(PowerPauseOwnership.shouldResume(
+            pausedByPower: true,
+            shouldBePaused: false,
+            respectAutoResume: true,
+            autoResumeEnabled: true
+        ))
+    }
+
+    /// Battery and fullscreen pauses *do* respect the setting.
+    func testPowerPauseHonoursAutoResumeSettingOnOrdinaryPaths() {
+        XCTAssertFalse(PowerPauseOwnership.shouldResume(
+            pausedByPower: true,
+            shouldBePaused: false,
+            respectAutoResume: true,
+            autoResumeEnabled: false
+        ))
+    }
+
+    // MARK: - Never resume into a live condition
+
+    func testNeverResumesWhileAConditionIsStillActive() {
+        for respect in [true, false] {
+            for auto in [true, false] {
+                XCTAssertFalse(
+                    PowerPauseOwnership.shouldResume(
+                        pausedByPower: true,
+                        shouldBePaused: true,
+                        respectAutoResume: respect,
+                        autoResumeEnabled: auto
+                    ),
+                    "respectAutoResume=\(respect) autoResumeEnabled=\(auto)"
+                )
+            }
+        }
+    }
+
+    /// Ownership is not sticky: once we resume, PowerManager clears the latch,
+    /// so a second resume attempt must not fire again on its own.
+    func testResumeIsNotRepeatableWithoutANewPause() {
+        XCTAssertTrue(PowerPauseOwnership.shouldResume(
+            pausedByPower: true, shouldBePaused: false,
+            respectAutoResume: false, autoResumeEnabled: true
+        ))
+        // PowerManager sets pausedByPower = false at this point.
+        XCTAssertFalse(PowerPauseOwnership.shouldResume(
+            pausedByPower: false, shouldBePaused: false,
+            respectAutoResume: false, autoResumeEnabled: true
+        ))
+    }
+}

--- a/src/Wallnetic/Wallnetic.xcodeproj/project.pbxproj
+++ b/src/Wallnetic/Wallnetic.xcodeproj/project.pbxproj
@@ -65,6 +65,7 @@
 		6ADBCB967C34EB7B36825043 /* WallpaperMetadataCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 941B25667F75E00393C7E895 /* WallpaperMetadataCacheTests.swift */; };
 		6B3FA8945F430A067CC4DB4D /* WallpaperLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F557952B625823A2689EBE7 /* WallpaperLibrary.swift */; };
 		6FDE90B9E751CC319C45BA54 /* MusicReactiveManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F48518E41B9C56DFE5EB099 /* MusicReactiveManager.swift */; };
+		70B012A497B21F7363B306AE /* PowerPauseOwnershipTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A4D65E49E1EE33BF5DFE9E3 /* PowerPauseOwnershipTests.swift */; };
 		71B0E8B741F75A6147C62611 /* MetalVideoRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED806BD7E0913BCDF1142604 /* MetalVideoRenderer.swift */; };
 		71CE2A10CE71B016228E091D /* SchedulerSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DF980A4142FBBE468FBBD05 /* SchedulerSettingsView.swift */; };
 		725E4F9BF3A84F458A306BDF /* WallpaperModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 388D852D79939F22C5EF801C /* WallpaperModelTests.swift */; };
@@ -102,6 +103,7 @@
 		AC32B1A81A352A35055916BC /* SlideshowGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 800451287F439529FF570B44 /* SlideshowGenerator.swift */; };
 		AC7FBC93D689C03ADF1AEDF5 /* AudioVisualizerOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C858C83BC8D22A21A53D7BD /* AudioVisualizerOverlayView.swift */; };
 		AE9FCE08CE4EDEECE7A843BD /* SharedDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52CE6EB39E15687BF3655B8C /* SharedDataManager.swift */; };
+		B00A74C018CF057BE5695C2D /* PowerPauseOwnership.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF1BACABE0D8F9C5C34AE3CB /* PowerPauseOwnership.swift */; };
 		B03176CE3858D5C7915FA8BB /* URLImporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0AADE7F3045087811919B3C /* URLImporterTests.swift */; };
 		B0E9EFEE56304B99C2D7A14D /* StrikingEffects.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FD8494A42E5AA356A35BA25 /* StrikingEffects.swift */; };
 		B29970D2C363902C62330D7C /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = F3D3A43BF60BFD2ADD5853F5 /* README.md */; };
@@ -258,6 +260,7 @@
 		77E4D58C6269978E4994C7CE /* AppShortcuts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppShortcuts.swift; sourceTree = "<group>"; };
 		7899051E1F990CC55CC1CB83 /* NSScreen+DisplayID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSScreen+DisplayID.swift"; sourceTree = "<group>"; };
 		79BC197A9E8C082F2C39C673 /* NowPlayingOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowPlayingOverlayView.swift; sourceTree = "<group>"; };
+		7A4D65E49E1EE33BF5DFE9E3 /* PowerPauseOwnershipTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PowerPauseOwnershipTests.swift; sourceTree = "<group>"; };
 		7BB04CF2E27DC75B29EE8A67 /* ErrorReporterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorReporterTests.swift; sourceTree = "<group>"; };
 		7F557952B625823A2689EBE7 /* WallpaperLibrary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperLibrary.swift; sourceTree = "<group>"; };
 		800451287F439529FF570B44 /* SlideshowGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlideshowGenerator.swift; sourceTree = "<group>"; };
@@ -293,6 +296,7 @@
 		BB036BA69CC6D00731C1D273 /* DiscoverView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverView.swift; sourceTree = "<group>"; };
 		BC8F63EBF5F78663165C4697 /* CreateFromPhotosView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateFromPhotosView.swift; sourceTree = "<group>"; };
 		BED74D009FBE1A0068DC2C62 /* PlaybackWatchdogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaybackWatchdogTests.swift; sourceTree = "<group>"; };
+		BF1BACABE0D8F9C5C34AE3CB /* PowerPauseOwnership.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PowerPauseOwnership.swift; sourceTree = "<group>"; };
 		BF36E216B5F900C62E824B59 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		C296AD08F207FEC3AF4CDCB9 /* AnalyticsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsManager.swift; sourceTree = "<group>"; };
 		C36C5B8FAAEBFAB779FBBB39 /* VideoRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoRenderer.swift; sourceTree = "<group>"; };
@@ -363,6 +367,7 @@
 				66849A711C2A493F21CD7DDB /* OverlayWindowFactory.swift */,
 				F9FC7269E149DE512043F002 /* PlaybackWatchdog.swift */,
 				9E4C04ED28406292407FFBD0 /* PowerManager.swift */,
+				BF1BACABE0D8F9C5C34AE3CB /* PowerPauseOwnership.swift */,
 				C36C5B8FAAEBFAB779FBBB39 /* VideoRenderer.swift */,
 			);
 			path = Engine;
@@ -610,6 +615,7 @@
 				2D709F3F20160782C077CAF5 /* OllamaVisionTaggerTests.swift */,
 				BED74D009FBE1A0068DC2C62 /* PlaybackWatchdogTests.swift */,
 				0B9765656604317F3C804094 /* PlaylistManagerTests.swift */,
+				7A4D65E49E1EE33BF5DFE9E3 /* PowerPauseOwnershipTests.swift */,
 				72D0BD40EC15021C36E115F3 /* RatingPromptManagerTests.swift */,
 				4C428B5A76D12B2D39EB866E /* SlideshowGeneratorTests.swift */,
 				58476278C192D425D261FE53 /* SystemWallpaperSyncTests.swift */,
@@ -740,8 +746,8 @@
 			projectRoot = "";
 			targets = (
 				9D9A6596302C548CCE03E80C /* Wallnetic */,
-				1116A8DEAAD1B829E09C688F /* WallneticTests */,
 				619B21F5247512020263D942 /* WallneticWidget */,
+				1116A8DEAAD1B829E09C688F /* WallneticTests */,
 			);
 		};
 /* End PBXProject section */
@@ -787,6 +793,7 @@
 				92D9C1672FDC4498193B9949 /* OllamaVisionTaggerTests.swift in Sources */,
 				6409F37EB1ED02FDDA458327 /* PlaybackWatchdogTests.swift in Sources */,
 				A873F6AB011A07A98FF34F6A /* PlaylistManagerTests.swift in Sources */,
+				70B012A497B21F7363B306AE /* PowerPauseOwnershipTests.swift in Sources */,
 				1BA56744587A55C81A484104 /* RatingPromptManagerTests.swift in Sources */,
 				D812BECBE0458A174EF2696E /* SlideshowGeneratorTests.swift in Sources */,
 				484B9F66D9BCBFF3C86EC727 /* SystemWallpaperSyncTests.swift in Sources */,
@@ -868,6 +875,7 @@
 				FC8374937C392694F64FF066 /* PlaylistSettingsView.swift in Sources */,
 				E1A41C3F6B921B68A90EBBFA /* PopularView.swift in Sources */,
 				B528C1F69B3CD9B3914A58A6 /* PowerManager.swift in Sources */,
+				B00A74C018CF057BE5695C2D /* PowerPauseOwnership.swift in Sources */,
 				9C31750F91516DE9EBBAF3D0 /* RatingPromptManager.swift in Sources */,
 				B42A0A282FC2AA2D1C21B83F /* SchedulerService.swift in Sources */,
 				71CE2A10CE71B016228E091D /* SchedulerSettingsView.swift in Sources */,

--- a/src/Wallnetic/project.yml
+++ b/src/Wallnetic/project.yml
@@ -8,8 +8,8 @@ options:
 
 settings:
   base:
-    MARKETING_VERSION: "1.4.0"
-    CURRENT_PROJECT_VERSION: "9"
+    MARKETING_VERSION: "1.4.1"
+    CURRENT_PROJECT_VERSION: "10"
     DEVELOPMENT_TEAM: ""
     CODE_SIGN_STYLE: Automatic
     SWIFT_VERSION: "5.9"


### PR DESCRIPTION
Fallout from a 43-agent post-launch assessment run one week after v1.4.1 went live. One confirmed user-facing defect, plus verification fallout.

## The defect

v1.4.1 (shipped 2026-08-08, live now) added pausing on screen lock, fast user switching and the screen saver, and let those resume paths bypass the auto-resume setting. That bypass was right: locking is not a pause the user asked for, and honouring `shouldAutoResume` there would leave the wallpaper dead after every unlock.

What it shipped without was any notion of **who** paused. Every resume path called straight through:

> Pause the wallpaper yourself → lock the Mac → unlock → **it plays again.**

100% reproducible, no dropped notification required. For anyone who had turned "resume automatically" off, that setting stopped working altogether — on lock, on wake, and on screen-saver exit. This is my regression from #232, and it is exactly the class of thing the manual test pass would have caught. That pass was never run before submitting.

## The fix

Ownership: only a pause this app caused may be undone by this app. `PowerManager` latches `pausedByPower` when it pauses something that was **actually playing** (the guard matters — without it we'd claim a pause the user had already made and the bug would survive), clears it on an explicit user Play/Pause via `userDidTogglePlayback()`, and refuses to resume without it.

The decision lives in a pure `PowerPauseOwnership` type rather than inline, following the existing `PlaybackWatchdog` precedent, so the exact state combination that shipped broken is unit-testable. Eight tests; two reproduce the regression directly, three pin the v1.4.1 behaviour that must **not** change (a lock-induced pause still resumes on unlock even with auto-resume off).

## Verification fallout, also here

- **`project.yml` said 1.4.0 / build 9** while the shipped project is 1.4.1 / build 10. README:181 tells contributors to run `xcodegen generate` — which would have silently regressed the version below the live build. Confirmed by regenerating: the version now survives.
- **Removed the CPU claims** from `README.md`, `apps.json` (×2) and `docs/SOCIAL_MEDIA.md` (×6). "~2-5%" is not reproducible — the same binary measured 3.4% to 51% on the same machine on 2026-08-08, and profiles show two concurrent CoreMedia decode pipelines for a single display, still unexplained. GitHub is the product's only real traffic right now, so this is where the claim actually gets read. Replaced with the pausing behaviour, which any reader can verify in ten seconds. `CHANGELOG.md`'s historical Instruments figure is correctly framed as a past measurement and is untouched.
- **README aligned with the live release**: 1.4.1 badge, real DMG asset names (verified against the v1.4.1 release), a v1.4.1 section carrying "(current)", and locale-neutral App Store links (the `/tr/` ones sent every visitor to the Turkish storefront).

## Not in this PR

The assessment surfaced three more code defects worth a 1.4.2 — `isScreenAsleep` has no independent re-derivation so a lost `screensDidWake` pins it for the process lifetime; `togglePlayback` reports "Playing" over a swallowed `play()`; and the rating prompt's presenter is unconditionally nil when the main window is closed, which silently skips every menu-bar-driven ask. They are real but none is a 100%-reproducible override of user intent, so they follow separately rather than riding along here.

## Test plan

- [x] `xcodebuild test` — **130/130 pass** (122 before; 8 new)
- [x] All eight `PowerPauseOwnershipTests` cases execute, none fail
- [x] `xcodegen generate` preserves 1.4.1 / build 10 and leaks no team ID
- [ ] Manual pass against the installed Mac App Store build, still outstanding from #232: lock/unlock, fast user switch, display sleep/wake, fullscreen game, unplug a covered monitor — plus the two compound cases (saver → display sleep → wake to lock screen → unlock; unlock straight into a user switch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)