### PR TITLE
fix: three reliability defects, and make CI actually gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,19 @@
 name: CI
 
+# Until v1.4.2 this only ran on `v*` tags, so no pull request was ever checked
+# and the job — despite its name — never ran a single test. A user-facing
+# regression shipped in v1.4.1 partly because of that gap (#234).
 on:
+  pull_request:
+    branches: [main, dev]
   push:
+    branches: [main, dev]
     tags:
       - 'v*'
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   SCHEME: Wallnetic
@@ -16,24 +26,57 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: '15.2'
 
-      - name: Build
+      # project.yml is the XcodeGen source of truth and README tells
+      # contributors to run `xcodegen generate`. When the two drift, that
+      # command silently rewrites the version — in August 2026 project.yml
+      # still said 1.4.0/9 while the shipped build was 1.4.1/10, so
+      # regenerating would have pushed the version *below* the live release.
+      - name: Verify project.yml matches the committed project
         run: |
-          xcodebuild -project ${{ env.PROJECT_PATH }} \
-            -scheme ${{ env.SCHEME }} \
+          set -euo pipefail
+          yml_mv=$(grep -m1 'MARKETING_VERSION:' src/Wallnetic/project.yml | tr -d ' "' | cut -d: -f2)
+          yml_cv=$(grep -m1 'CURRENT_PROJECT_VERSION:' src/Wallnetic/project.yml | tr -d ' "' | cut -d: -f2)
+          pbx_mv=$(grep -m1 -o 'MARKETING_VERSION = [^;]*' "$PROJECT_PATH/project.pbxproj" | awk '{print $3}')
+          pbx_cv=$(grep -m1 -o 'CURRENT_PROJECT_VERSION = [^;]*' "$PROJECT_PATH/project.pbxproj" | awk '{print $3}')
+          echo "project.yml : $yml_mv ($yml_cv)"
+          echo "pbxproj     : $pbx_mv ($pbx_cv)"
+          if [ "$yml_mv" != "$pbx_mv" ] || [ "$yml_cv" != "$pbx_cv" ]; then
+            echo "::error::project.yml and project.pbxproj disagree on the version. Run 'xcodegen generate' in src/Wallnetic and commit the result."
+            exit 1
+          fi
+
+      # The team ID must never be committed; a pre-commit hook enforces this
+      # locally, but nothing enforced it for anything that bypassed the hook.
+      - name: Verify no signing team leaked into the project
+        run: |
+          if grep -q 'DEVELOPMENT_TEAM = [A-Z0-9]\{10\}' "$PROJECT_PATH/project.pbxproj"; then
+            echo "::error::A DEVELOPMENT_TEAM value is committed in project.pbxproj. It must stay empty."
+            exit 1
+          fi
+
+      # Entitlements are cleared and the sandbox disabled because the app-group
+      # entitlement cannot be ad-hoc signed on a runner. This mirrors the
+      # documented local recipe so CI and local runs agree.
+      - name: Build & test
+        run: |
+          xcodebuild test \
+            -project "$PROJECT_PATH" \
+            -scheme "$SCHEME" \
             -configuration Debug \
-            -arch arm64 \
+            -destination 'platform=macOS,arch=arm64' \
             -derivedDataPath build \
-            clean build \
             CODE_SIGN_IDENTITY="-" \
-            CODE_SIGNING_REQUIRED=NO \
-            CODE_SIGNING_ALLOWED=NO
+            CODE_SIGNING_ALLOWED=YES \
+            CODE_SIGN_ENTITLEMENTS="" \
+            ENABLE_APP_SANDBOX=NO \
+            DEBUG_INFORMATION_FORMAT=dwarf
 
       - name: Build Summary
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -83,7 +83,7 @@ jobs:
           echo "DMG_PATH=$DMG_NAME" >> $GITHUB_ENV
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.APP_NAME }}_${{ matrix.arch }}
           path: "*.dmg"
@@ -98,12 +98,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
 

--- a/src/Wallnetic/App/AppDelegate.swift
+++ b/src/Wallnetic/App/AppDelegate.swift
@@ -51,6 +51,18 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             DispatchQueue.main.async { DockIconPolicy.reapply() }
         }
 
+        // Drain a review request that had no window to present from. In a
+        // menu-bar app that is the usual case, so the ask used to be dropped
+        // outright.
+        NotificationCenter.default.addObserver(
+            forName: NSWindow.didBecomeKeyNotification, object: nil, queue: .main
+        ) { note in
+            guard let window = note.object as? NSWindow else { return }
+            MainActor.assumeIsolated {
+                RatingPromptManager.shared.windowDidBecomeKey(window)
+            }
+        }
+
         // Setup global hotkeys
         setupGlobalHotkeys()
 
@@ -266,10 +278,14 @@ extension AppDelegate: PlaybackDelegate {
         }
     }
 
-    func playbackPlay() {
-        if !(powerManager?.shouldBePaused ?? false) {
-            desktopWindowController?.play()
+    @discardableResult
+    func playbackPlay() -> Bool {
+        guard !(powerManager?.shouldBePaused ?? false) else {
+            Log.app.info("Play request swallowed — a power condition is active")
+            return false
         }
+        desktopWindowController?.play()
+        return true
     }
 
     func playbackPause() {

--- a/src/Wallnetic/App/AppDelegate.swift
+++ b/src/Wallnetic/App/AppDelegate.swift
@@ -58,7 +58,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             forName: NSWindow.didBecomeKeyNotification, object: nil, queue: .main
         ) { note in
             guard let window = note.object as? NSWindow else { return }
-            MainActor.assumeIsolated {
+            // Not MainActor.assumeIsolated — that needs macOS 14 and this app
+            // targets 13.0. The observer already runs on .main; the hop just
+            // gives the compiler the isolation it wants.
+            Task { @MainActor in
                 RatingPromptManager.shared.windowDidBecomeKey(window)
             }
         }

--- a/src/Wallnetic/Engine/PowerManager.swift
+++ b/src/Wallnetic/Engine/PowerManager.swift
@@ -35,6 +35,10 @@ class PowerManager {
     private init() {
         setupObservers()
         checkInitialPowerState()
+        // Seed lock/session state up front, so launching into a locked screen
+        // (login items do exactly this) doesn't decode at full rate until the
+        // first notification happens to arrive.
+        resyncSessionState()
         isInitialized = true
         startFullscreenMonitoring()
     }
@@ -238,8 +242,24 @@ class PowerManager {
     private func startFullscreenMonitoring() {
         // Check periodically for fullscreen apps (more reliable than notifications alone)
         fullscreenCheckTimer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: true) { [weak self] _ in
+            self?.recoverIfStrandedAsleep()
             self?.checkFullscreenApps()
         }
+    }
+
+    /// Notification-independent backstop for ``isScreenAsleep``.
+    ///
+    /// Every `resyncSessionState()` call site is a resume handler, so it only
+    /// runs once the notification it exists to back up has already arrived —
+    /// useless for the case where `screensDidWake` is the notification that
+    /// went missing. This rides the existing 2 s poll rather than adding a
+    /// timer, so it costs no extra wakeups in a release whose whole point was
+    /// power, and it acts only on a true -> false edge.
+    private func recoverIfStrandedAsleep() {
+        guard isScreenAsleep, CGDisplayIsAsleep(CGMainDisplayID()) == 0 else { return }
+        Log.power.info("Display is awake but isScreenAsleep was still set — recovering")
+        isScreenAsleep = false
+        notifyResumeIfNeeded(respectAutoResume: false)
     }
 
     private func stopFullscreenMonitoring() {
@@ -455,6 +475,19 @@ class PowerManager {
         // A saver that stopped without posting .didstop can't strand us either.
         if !locked {
             isScreenSaverActive = false
+        }
+        // `isScreenAsleep` was the one `shouldBePaused` input with no
+        // independent re-derivation — battery has the IOPS source, low power
+        // has a notification, fullscreen has the 2 s poll — so a single lost
+        // `screensDidWake` pinned the wallpaper paused for the rest of the
+        // session, and the watchdog stands down while paused.
+        //
+        // Clear-only on purpose. This also runs *from* screensDidWake, where
+        // CGDisplayIsAsleep can still read asleep for an instant; an
+        // unconditional assignment would re-pin the flag on every normal wake.
+        // Failing open (playing) is the right direction for this one.
+        if CGDisplayIsAsleep(CGMainDisplayID()) == 0 {
+            isScreenAsleep = false
         }
     }
 

--- a/src/Wallnetic/Services/BatteryPromptService.swift
+++ b/src/Wallnetic/Services/BatteryPromptService.swift
@@ -156,8 +156,11 @@ final class BatteryPromptService {
         guard choice == "continue" else { return }
         sessionContinueOnBattery = true
 
-        WallpaperManager.shared.isPlaying = true
-        WallpaperManager.shared.playbackDelegate?.playbackPlay()
-        NotificationCenter.default.post(name: .playbackStateDidChange, object: true)
+        // The user just chose "keep playing", so hand playback ownership back
+        // to them before asking — otherwise the power pause still owns it.
+        PowerManager.shared.userDidTogglePlayback()
+        let started = WallpaperManager.shared.playbackDelegate?.playbackPlay() ?? false
+        WallpaperManager.shared.isPlaying = started
+        NotificationCenter.default.post(name: .playbackStateDidChange, object: started)
     }
 }

--- a/src/Wallnetic/Services/RatingPromptManager.swift
+++ b/src/Wallnetic/Services/RatingPromptManager.swift
@@ -119,21 +119,64 @@ final class RatingPromptManager {
 
         Task { @MainActor [weak self] in
             guard let self, !self.hasPromptedThisSession else { return }
-            guard let controller = self.presentationController else { return }
-            self.hasPromptedThisSession = true
-            self.defaults.set(self.currentVersion, forKey: self.lastPromptedVersionKey)
-            logger.info("Requesting App Store review (version \(self.currentVersion, privacy: .public))")
-            AppStore.requestReview(in: controller)
+            guard let controller = self.presentationController else {
+                // No window to present from — the normal state of a menu-bar
+                // app. Arm instead of dropping, and deliberately do NOT write
+                // lastPromptedVersion: a deferred ask must never consume the
+                // per-version slot, nor one of StoreKit's three annual ones.
+                self.pendingPrompt = true
+                logger.info("No presentable window — review request deferred")
+                return
+            }
+            self.present(in: controller)
         }
     }
 
-    /// A view controller to present the rating sheet from. Prefers the focused
-    /// window, then the main window, then any visible window.
+    @MainActor
+    private func present(in controller: NSViewController) {
+        hasPromptedThisSession = true
+        pendingPrompt = false
+        defaults.set(currentVersion, forKey: lastPromptedVersionKey)
+        logger.info("Requesting App Store review (version \(self.currentVersion, privacy: .public))")
+        AppStore.requestReview(in: controller)
+    }
+
+    /// Set when the ask was ready but no window could present it. Drained by
+    /// ``windowDidBecomeKey(_:)`` the next time the user opens the app — which
+    /// is a better moment to ask than mid-wallpaper-switch anyway, and steals
+    /// no focus.
+    private var pendingPrompt = false
+
+    /// Called from `AppDelegate`'s `NSWindow.didBecomeKeyNotification` observer.
+    @MainActor
+    func windowDidBecomeKey(_ window: NSWindow) {
+        guard pendingPrompt, !hasPromptedThisSession else { return }
+        guard Self.isPresentable(window), let controller = window.contentViewController else { return }
+        present(in: controller)
+    }
+
+    /// Whether a window can host the StoreKit review sheet.
+    ///
+    /// The original check accepted any visible window and read
+    /// `contentViewController`. Every window Wallnetic creates itself — the
+    /// desktop wallpaper windows, the Dynamic Island panel, the overlays —
+    /// assigns `contentView` directly and has no view controller, so with the
+    /// main window closed the resolver was unconditionally nil and every
+    /// menu-bar-driven ask was silently dropped. That is the normal state of
+    /// this app, and it is the likeliest reason v1.4.x has no ratings.
+    @MainActor
+    static func isPresentable(_ window: NSWindow) -> Bool {
+        window.isVisible
+            && window.level == .normal
+            && window.styleMask.contains(.titled)
+            && window.contentViewController != nil
+    }
+
+    /// A view controller to present the rating sheet from.
     @MainActor
     private var presentationController: NSViewController? {
-        let window = NSApp.keyWindow
-            ?? NSApp.mainWindow
-            ?? NSApp.windows.first(where: { $0.isVisible })
-        return window?.contentViewController
+        let candidates = [NSApp.keyWindow, NSApp.mainWindow].compactMap { $0 }
+            + NSApp.windows
+        return candidates.first(where: { Self.isPresentable($0) })?.contentViewController
     }
 }

--- a/src/Wallnetic/Services/WallpaperManager.swift
+++ b/src/Wallnetic/Services/WallpaperManager.swift
@@ -45,7 +45,10 @@ actor ImportGate {
 protocol PlaybackDelegate: AnyObject {
     func playbackSetWallpaper(url: URL)
     func playbackSetWallpaper(url: URL, for screen: NSScreen)
-    func playbackPlay()
+    /// - Returns: whether playback actually started. A power condition (screen
+    ///   asleep, locked, on battery, fullscreen app) swallows the request, and
+    ///   callers must not report "Playing" over a desktop that isn't.
+    @discardableResult func playbackPlay() -> Bool
     func playbackPause()
     func playbackApplyScreenWallpapers()
 }
@@ -197,12 +200,17 @@ class WallpaperManager: ObservableObject {
         guard !lastWallpaperURL.isEmpty else { return }
         let url = URL(fileURLWithPath: lastWallpaperURL)
         if let wallpaper = wallpapers.first(where: { $0.url.path == url.path }) {
-            setWallpaper(wallpaper)
+            // Launch restore is not a deliberate apply — it must not count
+            // toward the rating prompt.
+            setWallpaper(wallpaper, userInitiated: false)
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
-                self?.isPlaying = true
-                self?.playbackDelegate?.playbackPlay()
+                // Launch restore: if the Mac wakes into a locked screen or the
+                // saver, the play is swallowed — say so rather than restoring
+                // to a "Playing" menu bar over a still desktop.
+                let started = self?.playbackDelegate?.playbackPlay() ?? false
+                self?.isPlaying = started
                 // Keep notification for broadcast consumers (widget, etc.)
-                NotificationCenter.default.post(name: .playbackStateDidChange, object: true)
+                NotificationCenter.default.post(name: .playbackStateDidChange, object: started)
             }
         }
     }
@@ -506,13 +514,14 @@ class WallpaperManager: ObservableObject {
     func setWallpaper(_ wallpaper: Wallpaper, userInitiated: Bool = true) {
         currentWallpaper = wallpaper
         lastWallpaperURL = wallpaper.url.path
-        isPlaying = true
 
         playbackDelegate?.playbackSetWallpaper(url: wallpaper.url)
-        playbackDelegate?.playbackPlay()
+        // A power condition can swallow this; don't claim it played.
+        isPlaying = playbackDelegate?.playbackPlay() ?? false
+        let started = isPlaying
 
         NotificationCenter.default.post(name: .wallpaperDidChange, object: wallpaper)
-        NotificationCenter.default.post(name: .playbackStateDidChange, object: true)
+        NotificationCenter.default.post(name: .playbackStateDidChange, object: started)
 
         if userInitiated {
             RatingPromptManager.shared.recordWallpaperApplied()
@@ -520,7 +529,7 @@ class WallpaperManager: ObservableObject {
 
         Task {
             await widgetSync.syncCurrentWallpaper(wallpaper)
-            widgetSync.syncPlaybackState(isPlaying: true)
+            widgetSync.syncPlaybackState(isPlaying: started)
         }
     }
 
@@ -529,10 +538,10 @@ class WallpaperManager: ObservableObject {
         let screenName = screen.localizedName
         screenWallpapers[screenName] = wallpaper.id
         saveScreenWallpapers()
-        isPlaying = true
 
         playbackDelegate?.playbackSetWallpaper(url: wallpaper.url, for: screen)
-        playbackDelegate?.playbackPlay()
+        // A power condition can swallow this; don't claim it played.
+        isPlaying = playbackDelegate?.playbackPlay() ?? false
 
         // The active screen's wallpaper is what DynamicAccent, DynamicIsland,
         // ThemeManager, and the widget should reflect. Without updating
@@ -580,18 +589,23 @@ class WallpaperManager: ObservableObject {
     }
 
     func togglePlayback() {
-        isPlaying.toggle()
+        let wantsToPlay = !isPlaying
 
         // The user is taking control: a later unlock or wake must not undo it.
         PowerManager.shared.userDidTogglePlayback()
 
-        if isPlaying {
-            playbackDelegate?.playbackPlay()
+        // Report what actually happened, not what was asked for. A power
+        // condition can swallow the play request, and a menu bar reading
+        // "Playing" over a still desktop is a far more damaging bug report
+        // than one that honestly says "Paused".
+        if wantsToPlay {
+            isPlaying = playbackDelegate?.playbackPlay() ?? false
         } else {
             playbackDelegate?.playbackPause()
+            isPlaying = false
         }
-        NotificationCenter.default.post(name: .playbackStateDidChange, object: isPlaying)
 
+        NotificationCenter.default.post(name: .playbackStateDidChange, object: isPlaying)
         widgetSync.syncPlaybackState(isPlaying: isPlaying)
     }
 

--- a/src/Wallnetic/Services/WeatherWallpaperManager.swift
+++ b/src/Wallnetic/Services/WeatherWallpaperManager.swift
@@ -135,7 +135,8 @@ class WeatherWallpaperManager: NSObject, ObservableObject, CLLocationManagerDele
 
         if let wallpaper = WallpaperManager.shared.wallpapers.first(where: { $0.url.path == path }) {
             Log.weather.info("Condition: \(condition.rawValue, privacy: .public) -> wallpaper: \(wallpaper.name, privacy: .public)")
-            WallpaperManager.shared.setWallpaper(wallpaper)
+            // Automatic weather rotation is not a "ask for a review" moment.
+            WallpaperManager.shared.setWallpaper(wallpaper, userInitiated: false)
         }
     }
 

--- a/src/Wallnetic/Views/Main/MenuBarView.swift
+++ b/src/Wallnetic/Views/Main/MenuBarView.swift
@@ -149,7 +149,18 @@ struct MenuBarView: View {
 
             Divider()
 
-            // About & Quit
+            // Rate, About & Quit.
+            //
+            // The automatic StoreKit prompt needs a presentable window, which a
+            // menu-bar-only user never has, so without this entry they have no
+            // route to the App Store at all — the likeliest reason the app sits
+            // at zero ratings.
+            Button {
+                NSWorkspace.shared.open(RatingPromptManager.writeReviewURL)
+            } label: {
+                Label("Rate Wallnetic", systemImage: "star")
+            }
+
             Button {
                 NSApp.orderFrontStandardAboutPanel()
             } label: {


### PR DESCRIPTION
Follow-up to #234 from the same post-launch assessment. All three defects are live in v1.4.1 and reach users only through a 1.4.2 build.

## 1. `isScreenAsleep` could strand the wallpaper for the whole session

It was the one `shouldBePaused` input with no independent re-derivation — battery has the IOPS source, low power a notification, fullscreen the 2 s poll — and `resyncSessionState()` never touched it, despite that function existing precisely because notification pairs cannot be trusted. Worse, all five of its call sites are resume handlers, so the backstop only ran once the notification it exists to back up had already arrived. A single lost `screensDidWake` pinned the flag for the process lifetime, and the watchdog stands down while paused — so the wallpaper simply never came back.

Fixed with a **clear-only** `CGDisplayIsAsleep` check. Clear-only matters: resync runs *from* `screensDidWake`, where the display can still read asleep for an instant, so an unconditional assignment would re-pin the flag on every normal wake. Added a true→false edge recovery riding the **existing** 2 s timer rather than a new one — no extra wakeups in a release whose whole point was power. `PowerManager` also resyncs once at init, so launching into a locked screen (login items do exactly this) no longer decodes at full rate.

## 2. The UI reported playback that never started

`togglePlayback` set `isPlaying = true` and synced the widget **before** AppDelegate's power gate silently swallowed `play()`. The menu bar and widget read "Playing" over a frozen desktop. `playbackPlay()` now returns whether playback actually started, and every caller — toggle, both `setWallpaper` paths, launch restore, the battery prompt — writes state from that return value. A user who sees "Paused" and a still frame files a far less damaging report than one who sees "Playing".

## 3. The rating prompt was dead whenever the main window was closed

Which is the normal state of a menu-bar wallpaper app, and the likeliest reason v1.4.x sits at **zero ratings** after a week live. `presentationController` resolved a window then read `contentViewController`, but every window Wallnetic creates itself — the desktop wallpaper windows, the Dynamic Island panel, the overlays — assigns `contentView` directly and has no view controller. So the resolver was unconditionally nil and every menu-bar-driven ask was dropped.

Now it requires a genuinely presentable window (visible, `.normal` level, titled, has a view controller), and when there is none it **arms a pending flag drained on `didBecomeKey`** instead of dropping — showing the ask the next time the user actually opens the app, which is a better moment than mid-wallpaper-switch and steals no focus. Crucially it still does not write `lastPromptedVersion` on the deferred path, so a deferred ask consumes neither the per-version slot nor one of StoreKit's three annual ones.

Menu-bar-only users also get a direct **"Rate Wallnetic"** item, since the automatic prompt can never reach them. And launch restore plus automatic weather rotation now pass `userInitiated: false` — previously a launch and one weather switch could fire a review sheet with no deliberate user action at all.

## CI now actually gates

The workflow ran only on `v*` tags, so **no pull request was ever checked** — including #232, which shipped the regression #234 just fixed. And despite being named "Build & Test" it ran no tests. It now runs on PRs and pushes to main/dev, runs the suite, and guards the two things that bit us this week:

- **project.yml drift** — it said 1.4.0/build 9 while the shipped project was 1.4.1/build 10, so the `xcodegen generate` README:181 tells contributors to run would have regressed the version below the live build.
- **a signing team leaking into the pbxproj** — enforced locally by a pre-commit hook, but nothing enforced it for anything bypassing that hook.

Actions bumped to current majors in both workflows, which supersedes **#222** — that PR can be closed once this lands. (Note `actions/checkout` is now on v7; this uses v6 as #222 proposed, so a follow-up bump is cheap.)

## Test plan

- [x] `xcodebuild test` — **130/130 pass**
- [x] Both workflow files parse as valid YAML
- [x] Verified every bumped action tag exists (checkout@v6, upload-artifact@v7, download-artifact@v8)
- [ ] **This PR is the first ever to get CI** — its own `pull_request` trigger applies to itself, so the run on this PR is also the proof the fix works
- [ ] Manual pass still outstanding from #232, and items 1–2 above are exactly what it would exercise

Also consolidated `.claude/memory.md` from 136 to 96 lines, under the project's 100-line ceiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)